### PR TITLE
Authentication via API

### DIFF
--- a/Refresh.GameServer/Authentication/GameAuthenticationProvider.cs
+++ b/Refresh.GameServer/Authentication/GameAuthenticationProvider.cs
@@ -14,6 +14,20 @@ public class GameAuthenticationProvider : IAuthenticationProvider<GameUser>
         RealmDatabaseContext database = (RealmDatabaseContext)db;
         Debug.Assert(database != null);
 
-        return database.GetUserFromTokenData(request.Cookies["MM_AUTH"]);
+        // first try to grab token data from MM_AUTH
+        string? tokenData = request.Cookies["MM_AUTH"];
+        TokenType type = TokenType.Game;
+
+        // if this is null, this must be an API request so grab from authorization
+        if (tokenData == null)
+        {
+            type = TokenType.Api;
+            tokenData = request.RequestHeaders["Authorization"];
+        }
+
+        // if still null, then we dont have a token so bail 
+        if (tokenData == null) return null;
+
+        return database.GetUserFromTokenData(tokenData, type);
     }
 }

--- a/Refresh.GameServer/Authentication/ResetToken.cs
+++ b/Refresh.GameServer/Authentication/ResetToken.cs
@@ -1,0 +1,20 @@
+using System.Xml.Serialization;
+using MongoDB.Bson;
+using Realms;
+using Refresh.GameServer.Types.UserData;
+
+namespace Refresh.GameServer.Authentication;
+
+#nullable disable
+
+public class ResetToken : RealmObject
+{
+    [PrimaryKey]
+    public ObjectId TokenId { get; set; } = ObjectId.GenerateNewId();
+    
+    [XmlIgnore] public string TokenData { get; set; }
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    public GameUser User { get; set; }
+}

--- a/Refresh.GameServer/Authentication/Token.cs
+++ b/Refresh.GameServer/Authentication/Token.cs
@@ -19,12 +19,12 @@ public class Token : RealmObject
     
     // Realm can't store enums, use recommended workaround
     // ReSharper disable once InconsistentNaming (can't fix due to conflict with TokenType)
-    private string _tokenType { get; set; }
+    internal string _TokenType { get; set; }
 
     public TokenType TokenType
     {
-        get => Enum.Parse<TokenType>(this._tokenType);
-        set => this._tokenType = value.ToString();
+        get => Enum.Parse<TokenType>(this._TokenType);
+        set => this._TokenType = value.ToString();
     }
 
     public DateTimeOffset ExpiresAt { get; set; }

--- a/Refresh.GameServer/Authentication/Token.cs
+++ b/Refresh.GameServer/Authentication/Token.cs
@@ -8,13 +8,26 @@ namespace Refresh.GameServer.Authentication;
 
 #nullable disable
 
+[JsonObject(MemberSerialization.OptIn)]
 public class Token : RealmObject
 {
     [PrimaryKey]
     public ObjectId TokenId { get; set; } = ObjectId.GenerateNewId();
     
     // this shouldn't ever be serialized, but just in case let's ignore it
-    [JsonIgnore] [XmlIgnore] public string TokenData { get; set; }
+    [XmlIgnore] public string TokenData { get; set; }
     
+    // Realm can't store enums, use recommended workaround
+    // ReSharper disable once InconsistentNaming (can't fix due to conflict with TokenType)
+    private string _tokenType { get; set; }
+
+    public TokenType TokenType
+    {
+        get => Enum.Parse<TokenType>(this._tokenType);
+        set => this._tokenType = value.ToString();
+    }
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
     public GameUser User { get; set; }
 }

--- a/Refresh.GameServer/Authentication/TokenType.cs
+++ b/Refresh.GameServer/Authentication/TokenType.cs
@@ -1,0 +1,7 @@
+namespace Refresh.GameServer.Authentication;
+
+public enum TokenType
+{
+    Game = 0,
+    Api = 1,
+}

--- a/Refresh.GameServer/Database/RealmDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseContext.Tokens.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Types.UserData;
@@ -8,10 +9,15 @@ public partial class RealmDatabaseContext
 {
     public Token GenerateTokenForUser(GameUser user, TokenType type)
     {
+        // TODO: JWT (JSON Web Tokens) for TokenType.Api
+        byte[] tokenData = new byte[128];
+        using (RandomNumberGenerator rng = RandomNumberGenerator.Create()) 
+            rng.GetBytes(tokenData);
+
         Token token = new()
         {
             User = user,
-            TokenData = Guid.NewGuid().ToString(),
+            TokenData = Convert.ToBase64String(tokenData),
             TokenType = type,
         };
 

--- a/Refresh.GameServer/Database/RealmDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseContext.Tokens.cs
@@ -57,8 +57,9 @@ public partial class RealmDatabaseContext
     [ContractAnnotation("=> canbenull")]
     public GameUser? GetUserFromTokenData(string tokenData, TokenType type)
     {
+        string realType = type.ToString();
         return this._realm.All<Token>()
-            .FirstOrDefault(t => t.TokenData == tokenData && t.TokenType == type)?
+            .FirstOrDefault(t => t.TokenData == tokenData && t._TokenType == realType)?
             .User;
     }
     

--- a/Refresh.GameServer/Database/RealmDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseContext.Tokens.cs
@@ -6,12 +6,13 @@ namespace Refresh.GameServer.Database;
 
 public partial class RealmDatabaseContext
 {
-    public Token GenerateTokenForUser(GameUser user)
+    public Token GenerateTokenForUser(GameUser user, TokenType type)
     {
         Token token = new()
         {
             User = user,
             TokenData = Guid.NewGuid().ToString(),
+            TokenType = type,
         };
 
         this._realm.Write(() =>
@@ -23,11 +24,12 @@ public partial class RealmDatabaseContext
     }
 
     [Pure]
-    [ContractAnnotation("null => null; notnull => canbenull")]
-    public GameUser? GetUserFromTokenData(string? tokenData)
+    [ContractAnnotation("=> canbenull")]
+    public GameUser? GetUserFromTokenData(string tokenData, TokenType type)
     {
-        if (tokenData == null) return null;
-        return this._realm.All<Token>().FirstOrDefault(t => t.TokenData == tokenData)?.User;
+        return this._realm.All<Token>()
+            .FirstOrDefault(t => t.TokenData == tokenData && t.TokenType == type)?
+            .User;
     }
 
     public bool RevokeTokenByTokenData(string? tokenData)

--- a/Refresh.GameServer/Database/RealmDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseProvider.cs
@@ -19,7 +19,7 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
     {
         this._configuration = new RealmConfiguration(Path.Join(Environment.CurrentDirectory, "refreshGameServer.realm"))
         {
-            SchemaVersion = 22,
+            SchemaVersion = 23,
             Schema = new[]
             {
                 typeof(GameUser),
@@ -63,6 +63,9 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
                     
                     // In version 13, users were given PlanetsHashes
                     if (oldVersion < 13) newUser.PlanetsHash = "0";
+                    
+                    // In version 23, users were given bcrypt passwords
+                    if (oldVersion < 23) newUser.PasswordBcrypt = null;
                 }
                 
                 IQueryable<dynamic>? oldLevels = migration.OldRealm.DynamicApi.All("GameLevel");

--- a/Refresh.GameServer/Database/RealmDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseProvider.cs
@@ -19,7 +19,7 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
     {
         this._configuration = new RealmConfiguration(Path.Join(Environment.CurrentDirectory, "refreshGameServer.realm"))
         {
-            SchemaVersion = 21,
+            SchemaVersion = 22,
             Schema = new[]
             {
                 typeof(GameUser),
@@ -94,6 +94,9 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
                         newLevel.UpdateDate = oldLevel.UpdateDate * 1000;
                     }
                 }
+
+                // In version 22, tokens added expiry and types so just wipe them all
+                if (oldVersion < 22) migration.NewRealm.RemoveAll<Token>();
             },
         };
     }

--- a/Refresh.GameServer/Database/RealmDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseProvider.cs
@@ -19,7 +19,7 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
     {
         this._configuration = new RealmConfiguration(Path.Join(Environment.CurrentDirectory, "refreshGameServer.realm"))
         {
-            SchemaVersion = 23,
+            SchemaVersion = 24,
             Schema = new[]
             {
                 typeof(GameUser),
@@ -31,6 +31,7 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
                 typeof(FavouriteLevelRelation),
                 typeof(QueueLevelRelation),
                 typeof(FavouriteUserRelation),
+                typeof(ResetToken),
             },
             MigrationCallback = (migration, oldVersion) =>
             {

--- a/Refresh.GameServer/Database/RealmDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseProvider.cs
@@ -19,7 +19,7 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
     {
         this._configuration = new RealmConfiguration(Path.Join(Environment.CurrentDirectory, "refreshGameServer.realm"))
         {
-            SchemaVersion = 24,
+            SchemaVersion = 25,
             Schema = new[]
             {
                 typeof(GameUser),

--- a/Refresh.GameServer/Database/RealmDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseProvider.cs
@@ -19,7 +19,7 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
     {
         this._configuration = new RealmConfiguration(Path.Join(Environment.CurrentDirectory, "refreshGameServer.realm"))
         {
-            SchemaVersion = 25,
+            SchemaVersion = 26,
             Schema = new[]
             {
                 typeof(GameUser),
@@ -67,6 +67,9 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
                     
                     // In version 23, users were given bcrypt passwords
                     if (oldVersion < 23) newUser.PasswordBcrypt = null;
+                    
+                    // In version 26, users were given join dates
+                    if (oldVersion < 26) newUser.JoinDate = 0;
                 }
                 
                 IQueryable<dynamic>? oldLevels = migration.OldRealm.DynamicApi.All("GameLevel");

--- a/Refresh.GameServer/Endpoints/Api/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Api/AuthenticationApiEndpoints.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using Bunkum.CustomHttpListener.Parsing;
+using Bunkum.HttpServer;
+using Bunkum.HttpServer.Endpoints;
+using Bunkum.HttpServer.Responses;
+using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.UserData;
+
+namespace Refresh.GameServer.Endpoints.Api;
+
+public class AuthenticationApiEndpoints : EndpointGroup
+{
+    [ApiEndpoint("auth", Method.Post)]
+    [Authentication(false)]
+    public Response Authenticate(RequestContext context, RealmDatabaseContext database, ApiAuthenticationRequest body)
+    {
+        GameUser? user = database.GetUserByUsername(body.Username);
+        if (user == null) return new Response(HttpStatusCode.NotFound);
+        
+        Token token = database.GenerateTokenForUser(user, TokenType.Api);
+
+        ApiAuthenticationResponse resp = new()
+        {
+            TokenData = token.TokenData,
+            UserId = user.UserId.ToString(),
+            ExpiresAt = token.ExpiresAt,
+        };
+
+        return new Response(resp, ContentType.Json);
+    }
+}
+
+#nullable disable
+
+[Serializable]
+public class ApiAuthenticationRequest
+{
+    public string Username { get; set; }
+    public string PasswordSha512 { get; set; }
+}
+
+[Serializable]
+public class ApiAuthenticationResponse
+{
+    public string TokenData { get; set; }
+    public string UserId { get; set; }
+    public DateTimeOffset ExpiresAt { get; set; }
+}

--- a/Refresh.GameServer/Endpoints/Api/LevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Api/LevelApiEndpoints.cs
@@ -20,6 +20,7 @@ public class LevelApiEndpoints : EndpointGroup
 
     [ApiEndpoint("levels")]
     [Authentication(false)]
+    [ClientCacheResponse(86400 / 2)] // cache for half a day
     public IEnumerable<LevelCategory> GetCategories(RequestContext context) => CategoryHandler.Categories;
 
     [ApiEndpoint("level/id/{idStr}")]

--- a/Refresh.GameServer/Endpoints/Api/UserApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Api/UserApiEndpoints.cs
@@ -16,4 +16,7 @@ public class UserApiEndpoints : EndpointGroup
     [Authentication(false)]
     public GameUser? GetUserByUuid(RequestContext context, RealmDatabaseContext database, string uuid) 
         => database.GetUserByUuid(uuid);
+    
+    [ApiEndpoint("user/me")]
+    public GameUser GetMyUser(RequestContext context, GameUser user) => user;
 }

--- a/Refresh.GameServer/Endpoints/ApiEndpointAttribute.cs
+++ b/Refresh.GameServer/Endpoints/ApiEndpointAttribute.cs
@@ -9,7 +9,7 @@ public class ApiEndpointAttribute : EndpointAttribute
 {
     // v2, since maybe we want to add add v1 for backwards compatibility with project lighthouse?
     // LegacyApiEndpointAttribute for lighthouse api
-    private const string BaseRoute = "/api/v2/";
+    public const string BaseRoute = "/api/v2/";
 
     public ApiEndpointAttribute(string route, Method method = Method.Get, ContentType contentType = ContentType.Json)
         : base(BaseRoute + route, method, contentType)

--- a/Refresh.GameServer/Endpoints/Game/Handshake/AuthenticationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Handshake/AuthenticationEndpoints.cs
@@ -32,7 +32,7 @@ public class AuthenticationEndpoints : EndpointGroup
         GameUser? user = database.GetUserByUsername(ticket.Username);
         user ??= database.CreateUser(ticket.Username);
 
-        Token token = database.GenerateTokenForUser(user, TokenType.Api);
+        Token token = database.GenerateTokenForUser(user, TokenType.Game);
         
         return new LoginResponse
         {

--- a/Refresh.GameServer/Endpoints/Game/Handshake/AuthenticationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Handshake/AuthenticationEndpoints.cs
@@ -32,7 +32,7 @@ public class AuthenticationEndpoints : EndpointGroup
         GameUser? user = database.GetUserByUsername(ticket.Username);
         user ??= database.CreateUser(ticket.Username);
 
-        Token token = database.GenerateTokenForUser(user);
+        Token token = database.GenerateTokenForUser(user, TokenType.Api);
         
         return new LoginResponse
         {

--- a/Refresh.GameServer/Extensions/MemoryStreamExtensions.cs
+++ b/Refresh.GameServer/Extensions/MemoryStreamExtensions.cs
@@ -1,0 +1,8 @@
+using System.Text;
+
+namespace Refresh.GameServer.Extensions;
+
+internal static class MemoryStreamExtensions
+{
+    internal static void WriteString(this MemoryStream ms, string str) => ms.Write(Encoding.Default.GetBytes(str));
+}

--- a/Refresh.GameServer/Middlewares/CrossOriginMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/CrossOriginMiddleware.cs
@@ -9,14 +9,14 @@ namespace Refresh.GameServer.Middlewares;
 
 public class CrossOriginMiddleware : IMiddleware
 {
-    private static readonly List<string> _allowedMethods = new();
+    private static readonly List<string> AllowedMethods = new();
 
     static CrossOriginMiddleware()
     {
         foreach (Method method in Enum.GetValues<Method>())
         {
             if(method is Method.Options or Method.Invalid) continue;
-            _allowedMethods.Add(method.ToString().ToUpperInvariant());
+            AllowedMethods.Add(method.ToString().ToUpperInvariant());
         }
     }
     
@@ -29,8 +29,8 @@ public class CrossOriginMiddleware : IMiddleware
         if (context.Uri.AbsolutePath.StartsWith(ApiEndpointAttribute.BaseRoute))
         {
             context.ResponseHeaders.Add("Access-Control-Allow-Origin", "*");
-            context.ResponseHeaders.Add("Access-Control-Allow-Headers", "Authorization");
-            context.ResponseHeaders.Add("Access-Control-Allow-Methods", string.Join(", ", _allowedMethods));
+            context.ResponseHeaders.Add("Access-Control-Allow-Headers", "Authorization, Content-Type");
+            context.ResponseHeaders.Add("Access-Control-Allow-Methods", string.Join(", ", AllowedMethods));
             
             if (context.Method == Method.Options)
             {

--- a/Refresh.GameServer/Middlewares/CrossOriginMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/CrossOriginMiddleware.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using Bunkum.CustomHttpListener.Parsing;
+using Bunkum.CustomHttpListener.Request;
+using Bunkum.HttpServer.Database;
+using Bunkum.HttpServer.Endpoints.Middlewares;
+using Refresh.GameServer.Endpoints;
+
+namespace Refresh.GameServer.Middlewares;
+
+public class CrossOriginMiddleware : IMiddleware
+{
+    private static readonly List<string> _allowedMethods = new();
+
+    static CrossOriginMiddleware()
+    {
+        foreach (Method method in Enum.GetValues<Method>())
+        {
+            if(method is Method.Options or Method.Invalid) continue;
+            _allowedMethods.Add(method.ToString().ToUpperInvariant());
+        }
+    }
+    
+    public void HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database, Action next)
+    {
+        // Allow any origin for API
+        // Mozilla says this is okay:
+        //   "You can also configure a site to allow any site to access it by using the * wildcard. You should only use this for public APIs."
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowOrigin#what_went_wrong
+        if (context.Uri.AbsolutePath.StartsWith(ApiEndpointAttribute.BaseRoute))
+        {
+            context.ResponseHeaders.Add("Access-Control-Allow-Origin", "*");
+            context.ResponseHeaders.Add("Access-Control-Allow-Headers", "Authorization");
+            context.ResponseHeaders.Add("Access-Control-Allow-Methods", string.Join(", ", _allowedMethods));
+            
+            if (context.Method == Method.Options)
+            {
+                context.ResponseCode = HttpStatusCode.OK;
+                return;
+            }
+        }
+        
+        next();
+    }
+}

--- a/Refresh.GameServer/Middlewares/DigestMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/DigestMiddleware.cs
@@ -1,0 +1,80 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using Bunkum.CustomHttpListener.Request;
+using Bunkum.HttpServer;
+using Bunkum.HttpServer.Database;
+using Bunkum.HttpServer.Endpoints.Middlewares;
+using Refresh.GameServer.Extensions;
+
+namespace Refresh.GameServer.Middlewares;
+
+public class DigestMiddleware : IMiddleware
+{
+    // Should be 19 characters (or less maybe?)
+    // Length was taken from PS3 and PS4 digest keys
+    private const string DigestKey = "CustomServerDigest";
+
+    private string CalculateDigest(string url, Stream body, string auth)
+    {
+        using MemoryStream ms = new();
+
+        // FIXME: Directly referencing LBP in Bunkum
+        if (!url.StartsWith("/lbp/upload/"))
+        {
+            // get request body
+            body.CopyTo(ms);
+            body.Seek(0, SeekOrigin.Begin);
+        }
+
+        ms.WriteString(auth);
+        ms.WriteString(url);
+        ms.WriteString(DigestKey);
+
+        ms.Position = 0;
+        using SHA1 sha = SHA1.Create();
+        string digestResponse = Convert.ToHexString(sha.ComputeHash(ms)).ToLower();
+
+        return digestResponse;
+    }
+    
+    // Referenced from Project Lighthouse
+    // https://github.com/LBPUnion/ProjectLighthouse/blob/d16132f67f82555ef636c0dabab5aabf36f57556/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
+    // https://github.com/LBPUnion/ProjectLighthouse/blob/19ea44e0e2ff5f2ebae8d9dfbaf0f979720bd7d9/ProjectLighthouse/Helpers/CryptoHelper.cs#L35
+    // TODO: make this non-lbp specific, or implement middlewares and move to game server
+    private bool VerifyDigestRequest(ListenerContext context)
+    {
+        string url = context.Uri.AbsolutePath;
+        string auth = $"{context.Cookies["MM_AUTH"] ?? string.Empty}";
+    
+        string digestResponse = this.CalculateDigest(url, context.InputStream, auth);
+    
+        string digestHeader = !url.StartsWith("/lbp/upload/") ? "X-Digest-A" : "X-Digest-B";
+        string clientDigest = context.RequestHeaders[digestHeader] ?? string.Empty;
+        
+        context.ResponseHeaders["X-Digest-B"] = digestResponse;
+        if (clientDigest == digestResponse) return true;
+        
+        // this._logger.LogWarning(BunkumContext.Digest, $"Digest failed: {clientDigest} != {digestResponse}");
+        return false;
+    }
+    
+    private void SetDigestResponse(ListenerContext context)
+    {
+        string url = context.Uri.AbsolutePath;
+        string auth = $"{context.Cookies["MM_AUTH"] ?? string.Empty}";
+    
+        string digestResponse = this.CalculateDigest(url, context.ResponseStream, auth);
+        
+        context.ResponseHeaders["X-Digest-A"] = digestResponse;
+    }
+
+    public void HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database, Action next)
+    {
+        this.VerifyDigestRequest(context);
+        Debug.Assert(context.InputStream.Position == 0); // should be at position 0 before we pass down the pipeline
+        
+        next();
+        
+        this.SetDigestResponse(context);
+    }
+}

--- a/Refresh.GameServer/Middlewares/NotFoundLogMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/NotFoundLogMiddleware.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using Bunkum.CustomHttpListener.Request;
+using Bunkum.HttpServer.Database;
+using Bunkum.HttpServer.Endpoints.Middlewares;
+
+namespace Refresh.GameServer.Middlewares;
+
+public class NotFoundLogMiddleware : IMiddleware
+{
+    private const string EndpointFile = "unimplementedEndpoints.txt";
+    private readonly List<string> _unimplementedEndpoints;
+
+    public NotFoundLogMiddleware()
+    {
+         this._unimplementedEndpoints = File.ReadAllLines(EndpointFile).ToList();
+    }
+    
+    public void HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database, Action next)
+    {
+        next(); // Handle the request so we can get the ResponseCode
+
+        if (context.ResponseCode != HttpStatusCode.NotFound) return;
+        
+        if(!File.Exists(EndpointFile)) File.WriteAllText(EndpointFile, string.Empty);
+        if (this._unimplementedEndpoints.Any(e => e.Split('?')[0] == context.Uri.AbsolutePath)) return;
+
+        this._unimplementedEndpoints.Add(context.Uri.PathAndQuery);
+        File.WriteAllLines(EndpointFile, this._unimplementedEndpoints);
+    }
+}

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -37,6 +37,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
       <PackageReference Include="NPTicket" Version="1.0.0" />
       <PackageReference Include="Realm" Version="10.20.0" />
     </ItemGroup>

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Using Include="BCrypt.Net.BCrypt" Alias="BC"/>
+        <Using Include="BCrypt.Net.BCrypt" Alias="BC" />
     </ItemGroup>
     
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -37,7 +37,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'!='DebugLocalBunkum'">
-        <PackageReference Include="Bunkum" Version="2.2.0" />
+        <PackageReference Include="Bunkum" Version="2.2.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'!='DebugLocalBunkum'">
-        <PackageReference Include="Bunkum" Version="2.1.5" />
+        <PackageReference Include="Bunkum" Version="2.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'!='DebugLocalBunkum'">
-        <PackageReference Include="Bunkum" Version="2.1.3" />
+        <PackageReference Include="Bunkum" Version="2.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'!='DebugLocalBunkum'">
-        <PackageReference Include="Bunkum" Version="2.1.2" />
+        <PackageReference Include="Bunkum" Version="2.1.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -13,6 +13,10 @@
       <DefineConstants>TRACE;DEBUG</DefineConstants>
       <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
+
+    <ItemGroup>
+        <Using Include="BCrypt.Net.BCrypt" Alias="BC"/>
+    </ItemGroup>
     
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <PublishSingleFile>true</PublishSingleFile>

--- a/Refresh.GameServer/Startup.cs
+++ b/Refresh.GameServer/Startup.cs
@@ -5,6 +5,7 @@ using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Bunkum.HttpServer;
 using Bunkum.HttpServer.Storage;
+using Refresh.GameServer.Middlewares;
 
 #if DEBUGLOCALBUNKUM
 Console.WriteLine("Starting Refresh with LOCAL Bunkum!");
@@ -17,7 +18,7 @@ BunkumConsole.AllocateConsole();
 BunkumHttpServer server = new()
 {
     AssumeAuthenticationRequired = true,
-    UseDigestSystem = true,
+    // UseDigestSystem = true,
 };
 
 using RealmDatabaseProvider databaseProvider = new();
@@ -27,24 +28,9 @@ server.UseAuthenticationProvider(new GameAuthenticationProvider());
 server.UseDataStore(new FileSystemDataStore());
 server.UseJsonConfig<GameServerConfig>("refreshGameServer.json");
 
+server.AddMiddleware<NotFoundLogMiddleware>();
+server.AddMiddleware<DigestMiddleware>();
+
 server.DiscoverEndpointsFromAssembly(Assembly.GetExecutingAssembly());
-
-#region Log unimplemented endpoints
-#if DEBUG
-
-const string endpointFile = "unimplementedEndpoints.txt";
-if(!File.Exists(endpointFile)) File.WriteAllText(endpointFile, string.Empty);
-List<string> unimplementedEndpoints = File.ReadAllLines(endpointFile).ToList();
-
-server.NotFound += (_, context) =>
-{
-    if (unimplementedEndpoints.Any(e => e.Split('?')[0] == context.Uri.AbsolutePath)) return;
-
-    unimplementedEndpoints.Add(context.Uri.PathAndQuery);
-    File.WriteAllLines(endpointFile, unimplementedEndpoints);
-};
-
-#endif
-#endregion
 
 await server.StartAndBlockAsync();

--- a/Refresh.GameServer/Startup.cs
+++ b/Refresh.GameServer/Startup.cs
@@ -30,6 +30,7 @@ server.UseJsonConfig<GameServerConfig>("refreshGameServer.json");
 
 server.AddMiddleware<NotFoundLogMiddleware>();
 server.AddMiddleware<DigestMiddleware>();
+server.AddMiddleware<CrossOriginMiddleware>();
 
 server.DiscoverEndpointsFromAssembly(Assembly.GetExecutingAssembly());
 

--- a/Refresh.GameServer/Startup.cs
+++ b/Refresh.GameServer/Startup.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics;
+using System.Reflection;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -22,6 +22,8 @@ public partial class GameUser : RealmObject, IUser, INeedsPreparationBeforeSeria
     [XmlElement("biography")] [JsonProperty] public string Description { get; set; } = "";
     [XmlElement("location")] [JsonProperty] public GameLocation Location { get; set; } = GameLocation.Zero;
     
+    [XmlIgnore] [JsonProperty] public long JoinDate { get; set; } // unix seconds
+    
     [XmlIgnore] public UserPins Pins { get; set; } = new();
     
     #nullable disable

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -16,6 +16,7 @@ public partial class GameUser : RealmObject, IUser, INeedsPreparationBeforeSeria
 {
     [PrimaryKey] [Indexed] [XmlIgnore] [JsonProperty] public ObjectId UserId { get; set; } = ObjectId.GenerateNewId();
     [Indexed] [Required] [XmlIgnore] [JsonProperty] public string Username { get; set; } = string.Empty;
+    [Indexed] [XmlIgnore] [JsonIgnore] public string? PasswordBcrypt { get; set; } = null;
     [XmlIgnore] [JsonProperty] public string IconHash { get; set; } = "0";
 
     [XmlElement("biography")] [JsonProperty] public string Description { get; set; } = "";


### PR DESCRIPTION
This is the next big step towards building out the layer that lets Refresh and `refresh-web` communicate.

# What is this?

This PR adds support for users to authenticate to the API. It also introduces a couple endpoints (`/api/v2/me`) and features (caching) that help the website side of things operate.

It also introduces a couple changes as I was working on Bunkum alongside this. Most importantly are the introduction of Middlewares.

# What is this *not*?

- This PR does not introduce authentication for game clients. Accounts will still be generated when a client logs in. This leads into the next point.
- This also isn't a way for users to sign up via the API. It is pure login.
- A full implementation of the API. There's definitely more work to be done!

These points above will absolutely be handled at a later date, but I want to get this merged as this PR is already getting quite large.

# Feedback

In particular, I'm looking for feedback with the password reset system and whether or not `Token`s should be separate for Game and API or joined as they are in this PR.

I'm also looking for feedback on how the API communicates back and forth with the client.

# Client

A reference client written in TypeScript can be found [here](https://github.com/LittleBigRefresh/refresh-web/tree/master/src/app/api), in `refresh-web`'s source code.