### PR TITLE
NotFoundLogMiddleware: Dont try to read unimplemented endpoints file if missing

### DIFF
--- a/Refresh.GameServer/Middlewares/NotFoundLogMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/NotFoundLogMiddleware.cs
@@ -12,7 +12,12 @@ public class NotFoundLogMiddleware : IMiddleware
 
     public NotFoundLogMiddleware()
     {
-         this._unimplementedEndpoints = File.ReadAllLines(EndpointFile).ToList();
+        if (!File.Exists(EndpointFile)) {
+            this._unimplementedEndpoints = new List<string>();
+            return;
+        }
+
+        this._unimplementedEndpoints = File.ReadAllLines(EndpointFile).ToList();
     }
     
     public void HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database, Action next)


### PR DESCRIPTION
This fixes an exception on startup with fresh runs