### PR TITLE
Website: Ability to host from Refresh, bundle with CI builds

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,6 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,7 +33,7 @@ jobs:
       id: download-artifact
       uses: dawidd6/action-download-artifact@v2
       with:
-        github_token: ${{ inputs.githubToken }}
+        github_token: ${{secrets.GITHUB_TOKEN}}
         workflow: dotnet.yml
         workflow_conclusion: success
         name: refresh-web

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,6 +28,21 @@ jobs:
       
     - name: Publish for Windows x64
       run: dotnet publish -c Release -r win-x64 --self-contained Refresh.GameServer
+
+    - name: Download Refresh Website artifact
+      id: download-artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        github_token: ${{ inputs.githubToken }}
+        workflow: dotnet.yml
+        workflow_conclusion: success
+        name: refresh-web
+        repo: LittleBigRefresh/refresh-web
+        if_no_artifact_found: fail
+        path: "Refresh.GameServer/bin/Release/net7.0/linux-x64/publish/web"
+        
+    - name: Copy artifact to windows build directory
+      run: cp -r "Refresh.GameServer/bin/Release/net7.0/linux-x64/publish/web" "Refresh.GameServer/bin/Release/net7.0/win-x64/publish/"
       
     - name: Upload Linux x64 build
       uses: actions/upload-artifact@v3.1.1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,9 +34,9 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}
-        workflow: dotnet.yml
+        workflow: ng.yml
         workflow_conclusion: success
-        name: refresh-web
+        name: "Refresh Website"
         repo: LittleBigRefresh/refresh-web
         if_no_artifact_found: fail
         path: "Refresh.GameServer/bin/Release/net7.0/linux-x64/publish/web"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,27 +7,27 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  build:
-    name: Build & release
+  release:
+    name: Release Built Artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+      - name: Wait for builds
+        uses: lewagon/wait-on-check-action@v1.3.1
         with:
-          dotnet-version: 7.0.x
-      - name: Restore
-        run: dotnet restore
-      - name: Publish for Linux x64
-        run: dotnet publish -c Release -r linux-x64 --self-contained Refresh.GameServer
-      - name: Publish for Windows x64
-        run: dotnet publish -c Release -r win-x64 --self-contained Refresh.GameServer
-      #      - name: Test
-      #        run: dotnet test -c Release --no-restore --no-build
-      - name: Zip up package for Linux x64
-        run: zip -rj Refresh-Linux-x64.zip Refresh.GameServer/bin/Release/net7.0/linux-x64/publish/
-      - name: Zip up package for Windows x64
-        run: zip -rj Refresh-Windows-x64.zip Refresh.GameServer/bin/Release/net7.0/win-x64/publish/
+          ref: ${{ github.ref }}
+          check-name: 'Build, Test, and Upload Builds'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+      - name: Download artifacts
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          branch: main
+          workflow: dotnet.yml
+          workflow_conclusion: success
+          if_no_artifact_found: fail
+          skip_unpack: true
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/Refresh.GameServer/Middlewares/DigestMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/DigestMiddleware.cs
@@ -68,6 +68,12 @@ public class DigestMiddleware : IMiddleware
 
     public void HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database, Action next)
     {
+        if (!context.Uri.AbsolutePath.StartsWith("/lbp"))
+        {
+            next();
+            return;
+        }
+        
         this.VerifyDigestRequest(context);
         Debug.Assert(context.InputStream.Position == 0); // should be at position 0 before we pass down the pipeline
         

--- a/Refresh.GameServer/Middlewares/WebsiteMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/WebsiteMiddleware.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using Bunkum.CustomHttpListener.Request;
+using Bunkum.HttpServer;
+using Bunkum.HttpServer.Database;
+using Bunkum.HttpServer.Endpoints.Middlewares;
+
+namespace Refresh.GameServer.Middlewares;
+
+public class WebsiteMiddleware : IMiddleware
+{
+    private static readonly string WebPath = Path.Join(BunkumFileSystem.DataDirectory, "web");
+    private static readonly Dictionary<string, string> MimeMapping = new()
+    {
+        {".html", "text/html"},
+        {".css", "text/css"},
+        {".js", "application/javascript"},
+    };
+
+    private static bool HandleWebsiteRequest(ListenerContext context)
+    {
+        if (!Directory.Exists(WebPath)) // If website is not included in this build
+            return false;
+
+        string uri = context.Uri.AbsolutePath;
+
+        if (uri.StartsWith("/lbp") || uri.StartsWith("/api")) return false;
+
+        if (uri == "/" || (context.RequestHeaders["Accept"] ?? "").Contains("text/html"))
+            uri = "/index.html";
+
+        string path = Path.GetFullPath(Path.Join(WebPath, uri));
+        if (!path.StartsWith(WebPath)) return false; // check if path is within WebPath, prevents path traversal
+        
+        if (!File.Exists(path)) return false;
+
+        string ext = Path.GetExtension(uri);
+        string mime = MimeMapping.GetValueOrDefault(ext, "application/octet-stream");
+        
+        context.ResponseStream.Position = 0;
+        context.ResponseCode = HttpStatusCode.OK;
+        context.ResponseHeaders["Content-Type"] = mime;
+        
+        context.Write(File.ReadAllBytes(path));
+        context.FlushResponseAndClose();
+        return true;
+    }
+    
+    public void HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database, Action next)
+    {
+        if (!HandleWebsiteRequest(context)) next();
+    }
+}

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -37,7 +37,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'!='DebugLocalBunkum'">
-        <PackageReference Include="Bunkum" Version="2.2.6" />
+        <PackageReference Include="Bunkum" Version="2.2.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/Startup.cs
+++ b/Refresh.GameServer/Startup.cs
@@ -27,6 +27,7 @@ server.UseAuthenticationProvider(new GameAuthenticationProvider());
 server.UseDataStore(new FileSystemDataStore());
 server.UseJsonConfig<GameServerConfig>("refreshGameServer.json");
 
+server.AddMiddleware<WebsiteMiddleware>();
 server.AddMiddleware<NotFoundLogMiddleware>();
 server.AddMiddleware<DigestMiddleware>();
 server.AddMiddleware<CrossOriginMiddleware>();


### PR DESCRIPTION
CI now automatically downloads the latest artifact from [refresh-web](https://github.com/LittleBigRefresh/refresh-web), and packages it with the artifact it creates when building Refresh.

This also rewrites the Release workflow, ensuring building is only done once to keep changes to building behaviour consistent. For example, I can foresee dotnet.yml being updated without release.yml being updated causing problems when a tag is pushed. This almost happened while making this PR.