### PR TITLE
Implement LBP3 Categories

### DIFF
--- a/Refresh.GameServer/Endpoints/Api/LevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Api/LevelApiEndpoints.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Bunkum.HttpServer;
 using Bunkum.HttpServer.Endpoints;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Levels.Categories;
 using Refresh.GameServer.Types.UserData;
@@ -13,10 +14,14 @@ public class LevelApiEndpoints : EndpointGroup
     [ApiEndpoint("levels/{route}")]
     [Authentication(false)]
     [NullStatusCode(HttpStatusCode.NotFound)]
-    public IEnumerable<GameLevel>? GetLevels(RequestContext context, RealmDatabaseContext database, GameUser? user, string route) 
-        => CategoryHandler.Categories
+    public IEnumerable<GameLevel>? GetLevels(RequestContext context, RealmDatabaseContext database, GameUser? user, string route)
+    {
+        (int skip, int count) = context.GetPageData(true);
+        
+        return CategoryHandler.Categories
             .FirstOrDefault(c => c.ApiRoute.StartsWith(route))?
-            .Fetch(context, database, user);
+            .Fetch(context, skip, count, database, user);
+    }
 
     [ApiEndpoint("levels")]
     [Authentication(false)]

--- a/Refresh.GameServer/Endpoints/Game/ActivityEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ActivityEndpoints.cs
@@ -13,7 +13,6 @@ public class ActivityEndpoints : EndpointGroup
 {
     [GameEndpoint("stream", ContentType.Xml)]
     [NullStatusCode(HttpStatusCode.BadRequest)]
-    [Authentication(false)]
     public ActivityPage? GetRecentActivity(RequestContext context, RealmDatabaseContext database)
     {
         long timestamp = 0;

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -14,11 +14,16 @@ namespace Refresh.GameServer.Endpoints.Game.Levels;
 public class LevelEndpoints : EndpointGroup
 {
     [GameEndpoint("slots/{route}", ContentType.Xml)]
-    public GameMinimalLevelList GetLevels(RequestContext context, RealmDatabaseContext database, GameUser? user, string route) =>
-        new(CategoryHandler.Categories
+    public GameMinimalLevelList GetLevels(RequestContext context, RealmDatabaseContext database, GameUser? user, string route)
+    {
+        (int skip, int count) = context.GetPageData();
+        
+        return new GameMinimalLevelList(CategoryHandler.Categories
             .FirstOrDefault(c => c.GameRoute.StartsWith(route))?
-            .Fetch(context, database, user)?
-            .Select(GameMinimalLevel.FromGameLevel), database.GetTotalLevelCount()); // TODO: proper level count
+            .Fetch(context, skip, count, database, user)?
+            .Select(GameMinimalLevel.FromGameLevel), database.GetTotalLevelCount());
+        // TODO: proper level count
+    }
 
     [GameEndpoint("slots/{route}/{username}", ContentType.Xml)]
     public GameMinimalLevelList GetLevelsWithPlayer(RequestContext context, RealmDatabaseContext database, string route, string username)
@@ -63,13 +68,25 @@ public class LevelEndpoints : EndpointGroup
     }
 
     [GameEndpoint("searches", ContentType.Xml)]
-    public GameCategoryList GetModernCategories(RequestContext context, RealmDatabaseContext database)
+    public GameCategoryList GetModernCategories(RequestContext context, RealmDatabaseContext database, GameUser user)
     {
         IEnumerable<GameCategory> categories = CategoryHandler.Categories
+            .Where(c => c is not SearchLevelCategory)
             .Take(5)
-            .Select(c => GameCategory.FromLevelCategory(c, context, database, 0, 1));
+            .Select(c => GameCategory.FromLevelCategory(c, context, database, user, 0, 1));
         
         return new GameCategoryList(categories);
+    }
+
+    [GameEndpoint("searches/{apiRoute}", ContentType.Xml)]
+    public GameMinimalLevelList GetLevelsFromCategory(RequestContext context, RealmDatabaseContext database, GameUser? user, string apiRoute)
+    {
+        (int skip, int count) = context.GetPageData();
+        
+        return new GameMinimalLevelResultsList(CategoryHandler.Categories
+            .FirstOrDefault(c => c.ApiRoute.StartsWith(apiRoute))?
+            .Fetch(context, skip, count, database, user)?
+            .Select(GameMinimalLevel.FromGameLevel), database.GetTotalLevelCount());
     }
 
     #region Quirk workarounds

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -3,6 +3,7 @@ using Bunkum.CustomHttpListener.Parsing;
 using Bunkum.HttpServer;
 using Bunkum.HttpServer.Endpoints;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Levels.Categories;
 using Refresh.GameServer.Types.Lists;
@@ -59,6 +60,16 @@ public class LevelEndpoints : EndpointGroup
             Total = levels.Count,
             NextPageStart = 0,
         };
+    }
+
+    [GameEndpoint("searches", ContentType.Xml)]
+    public GameCategoryList GetModernCategories(RequestContext context, RealmDatabaseContext database)
+    {
+        IEnumerable<GameCategory> categories = CategoryHandler.Categories
+            .Take(5)
+            .Select(c => GameCategory.FromLevelCategory(c, context, database, 0, 1));
+        
+        return new GameCategoryList(categories);
     }
 
     #region Quirk workarounds

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -68,6 +68,7 @@ public class LevelEndpoints : EndpointGroup
     }
 
     [GameEndpoint("searches", ContentType.Xml)]
+    [GameEndpoint("genres", ContentType.Xml)]
     public GameCategoryList GetModernCategories(RequestContext context, RealmDatabaseContext database, GameUser user)
     {
         IEnumerable<GameCategory> categories = CategoryHandler.Categories

--- a/Refresh.GameServer/Types/Levels/Categories/ByUserLevelCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/ByUserLevelCategory.cs
@@ -15,7 +15,7 @@ public class ByUserLevelCategory : LevelCategory
         this.FontAwesomeIcon = "user";
     }
 
-    public override IEnumerable<GameLevel>? Fetch(RequestContext context, RealmDatabaseContext database, GameUser? user, object[]? extraArgs = null)
+    public override IEnumerable<GameLevel>? Fetch(RequestContext context, int skip, int count, RealmDatabaseContext database, GameUser? user, object[]? extraArgs)
     {
         // Prefer username from query, but fallback to user passed into this category if it's missing
         string? username = context.QueryString["u"];
@@ -23,6 +23,6 @@ public class ByUserLevelCategory : LevelCategory
 
         if (user == null) return null;
         
-        return base.Fetch(context, database, user, extraArgs);
+        return base.Fetch(context, skip, count, database, user, extraArgs);
     }
 }

--- a/Refresh.GameServer/Types/Levels/Categories/GameCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/GameCategory.cs
@@ -1,0 +1,45 @@
+using System.Xml.Serialization;
+using Bunkum.HttpServer;
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Lists;
+
+namespace Refresh.GameServer.Types.Levels.Categories;
+
+#nullable disable
+
+[XmlType("category")]
+public class GameCategory
+{
+    [XmlElement("name")]
+    public string Name { get; set; }
+    [XmlElement("description")]
+    public string Description { get; set; }
+    [XmlElement("url")]
+    public string Url { get; set; }
+    [XmlElement("tag")]
+    public string Tag { get; set; }
+    [XmlElement("icon")]
+    public string IconHash { get; set; }
+    
+    [XmlElement("results")]
+    public GameMinimalLevelList Levels { get; set; }
+
+    public static GameCategory FromLevelCategory(LevelCategory levelCategory, RequestContext context, RealmDatabaseContext database, int skip = 0, int count = 20)
+    {
+        GameCategory category = new()
+        {
+            Name = levelCategory.Name,
+            Description = levelCategory.Description,
+            Url = "/searches/" + levelCategory.ApiRoute,
+            Tag = "",
+            IconHash = levelCategory.IconHash,
+        };
+        
+        IEnumerable<GameMinimalLevel> levels = levelCategory.Fetch(context, database, null)?
+            .Select(GameMinimalLevel.FromGameLevel) ?? Array.Empty<GameMinimalLevel>();
+
+        category.Levels = new GameMinimalLevelList(levels, 10);
+
+        return category;
+    }
+}

--- a/Refresh.GameServer/Types/Levels/Categories/GameCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/GameCategory.cs
@@ -2,6 +2,7 @@ using System.Xml.Serialization;
 using Bunkum.HttpServer;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.Lists;
+using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Levels.Categories;
 
@@ -24,7 +25,7 @@ public class GameCategory
     [XmlElement("results")]
     public GameMinimalLevelList Levels { get; set; }
 
-    public static GameCategory FromLevelCategory(LevelCategory levelCategory, RequestContext context, RealmDatabaseContext database, int skip = 0, int count = 20)
+    public static GameCategory FromLevelCategory(LevelCategory levelCategory, RequestContext context, RealmDatabaseContext database, GameUser user, int skip = 0, int count = 20)
     {
         GameCategory category = new()
         {
@@ -35,7 +36,7 @@ public class GameCategory
             IconHash = levelCategory.IconHash,
         };
         
-        IEnumerable<GameMinimalLevel> levels = levelCategory.Fetch(context, database, null)?
+        IEnumerable<GameMinimalLevel> levels = levelCategory.Fetch(context, skip, count, database, user)?
             .Select(GameMinimalLevel.FromGameLevel) ?? Array.Empty<GameMinimalLevel>();
 
         category.Levels = new GameMinimalLevelList(levels, 10);

--- a/Refresh.GameServer/Types/Levels/Categories/LevelCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/LevelCategory.cs
@@ -39,12 +39,10 @@ public class LevelCategory
     private readonly MethodInfo _method;
 
     [Pure]
-    public virtual IEnumerable<GameLevel>? Fetch(RequestContext context, RealmDatabaseContext database, GameUser? user, object[]? extraArgs = null)
+    public virtual IEnumerable<GameLevel>? Fetch(RequestContext context, int skip, int count, RealmDatabaseContext database, GameUser? user, object[]? extraArgs = null)
     {
         if (this._requiresUser && user == null) return null;
-        
-        (int skip, int count) = context.GetPageData(context.Url.AbsolutePath.StartsWith("/api"));
-        
+
         IEnumerable<object> args;
 
         // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression

--- a/Refresh.GameServer/Types/Levels/Categories/LevelCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/LevelCategory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Contracts;
 using System.Reflection;
 using Bunkum.HttpServer;
 using Newtonsoft.Json;
@@ -37,6 +38,7 @@ public class LevelCategory
     [JsonProperty("RequiresUser")] private readonly bool _requiresUser;
     private readonly MethodInfo _method;
 
+    [Pure]
     public virtual IEnumerable<GameLevel>? Fetch(RequestContext context, RealmDatabaseContext database, GameUser? user, object[]? extraArgs = null)
     {
         if (this._requiresUser && user == null) return null;

--- a/Refresh.GameServer/Types/Levels/Categories/SearchLevelCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/SearchLevelCategory.cs
@@ -14,13 +14,13 @@ public class SearchLevelCategory : LevelCategory
         // no icon for now, too lazy to find
     }
 
-    public override IEnumerable<GameLevel>? Fetch(RequestContext context, RealmDatabaseContext database, GameUser? user, object[]? extraArgs = null)
+    public override IEnumerable<GameLevel>? Fetch(RequestContext context, int skip, int count, RealmDatabaseContext database, GameUser? user, object[]? extraArgs)
     {
         string? query = context.QueryString["query"];
         if (query == null) return null;
 
         extraArgs = new object[] { query };
         
-        return base.Fetch(context, database, user, extraArgs);
+        return base.Fetch(context, skip, count, database, user, extraArgs);
     }
 }

--- a/Refresh.GameServer/Types/Lists/GameCategoryList.cs
+++ b/Refresh.GameServer/Types/Lists/GameCategoryList.cs
@@ -1,0 +1,23 @@
+using System.Xml.Serialization;
+using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.Levels.Categories;
+
+namespace Refresh.GameServer.Types.Lists;
+[XmlRoot("categories")]
+[XmlType("categories")]
+public class GameCategoryList : GameList<GameCategory>
+{
+    public GameCategoryList(IEnumerable<GameCategory> items)
+    {
+        this.Items = items.ToList();
+        this.Total = CategoryHandler.Categories.Count();
+    }
+
+    public GameCategoryList() {}
+
+    [XmlElement("category")]
+    public sealed override List<GameCategory> Items { get; set; } = null!;
+
+    [XmlAttribute("hint")]
+    public string Hint { get; set; } = string.Empty;
+}

--- a/Refresh.GameServer/Types/Lists/GameMinimalLevelResultsList.cs
+++ b/Refresh.GameServer/Types/Lists/GameMinimalLevelResultsList.cs
@@ -1,0 +1,17 @@
+using System.Xml.Serialization;
+using Refresh.GameServer.Types.Levels;
+
+namespace Refresh.GameServer.Types.Lists;
+
+[XmlRoot("results")]
+[XmlType("results")]
+public class GameMinimalLevelResultsList : GameMinimalLevelList
+{
+    public GameMinimalLevelResultsList() {}
+    
+    public GameMinimalLevelResultsList(IEnumerable<GameMinimalLevel>? list, int total)
+    {
+        this.Total = total;
+        this.Items = list?.ToList() ?? new List<GameMinimalLevel>();
+    }
+}


### PR DESCRIPTION
Closes #32

This required a small refactor of the categories system, passing skip & count into the system instead of it being acquired from the request's context.

Search is not implemented.

![image](https://user-images.githubusercontent.com/40577357/228660996-909e8b1e-d3d6-4bdb-bea2-20a49b39ceb1.png)
