### PR TITLE
Track game and platform when authenticating

### DIFF
--- a/Refresh.GameServer/Authentication/Token.cs
+++ b/Refresh.GameServer/Authentication/Token.cs
@@ -26,6 +26,20 @@ public class Token : RealmObject
         get => (TokenType)this._TokenType;
         set => this._TokenType = (int)value;
     }
+    
+    internal int _TokenPlatform { get; set; }
+    internal int _TokenGame { get; set; }
+    
+    public TokenPlatform TokenPlatform 
+    {
+        get => (TokenPlatform)this._TokenPlatform;
+        set => this._TokenPlatform = (int)value;
+    }
+    public TokenGame TokenGame 
+    {
+        get => (TokenGame)this._TokenGame;
+        set => this._TokenGame = (int)value;
+    }
 
     public DateTimeOffset ExpiresAt { get; set; }
 

--- a/Refresh.GameServer/Authentication/TokenGame.cs
+++ b/Refresh.GameServer/Authentication/TokenGame.cs
@@ -1,0 +1,11 @@
+namespace Refresh.GameServer.Authentication;
+
+public enum TokenGame
+{
+    LittleBigPlanet1 = 0,
+    LittleBigPlanet2 = 1,
+    LittleBigPlanet3 = 2,
+    LittleBigPlanetVita = 3,
+    LittleBigPlanetPSP = 4,
+    Website = 5,
+}

--- a/Refresh.GameServer/Authentication/TokenGameUtility.cs
+++ b/Refresh.GameServer/Authentication/TokenGameUtility.cs
@@ -1,0 +1,107 @@
+namespace Refresh.GameServer.Authentication;
+
+public static class TokenGameUtility
+{
+    // All values taken from SerialStation.
+    // https://serialstation.com
+    
+    private static readonly string[] LittleBigPlanet1Titles =
+    {
+        "BCES00141",
+        "NPEW00047",
+        "UCAS40262",
+        "NPEA00147",
+        "NPHG00035",
+        "BCET70011",
+        "BCUS98199",
+        "BCAS20091",
+        "NPEA00241",
+        "NPUG70064",
+        "BCET70002",
+        "BCJS70009",
+        "NPHA80092",
+        "UCUS98744",
+        "BCJB95003",
+        "BCUS70030",
+        "NPEG90019",
+        "BCUS98148",
+        "NPUA70045",
+        "BCAS20058",
+        "BCJS30018",
+        "NPHG00033",
+        "UCES01264",
+        "BCKS10059",
+        "BCAS20078",
+        "BCUS98208",
+        "BCES00611",
+        "NPJG00073",
+        "UCJS10107",
+        "NPUA80472",
+        "NPJA00052",
+    };
+
+    private static readonly string[] LittleBigPlanet2Titles =
+    {
+        "BCAS20201",
+        "BCUS98245",
+        "BCES01345",
+        "BCJS30058",
+        "BCUS98249",
+        "BCES00850",
+        "BCES01346",
+        "BCUS90260",
+        "BCUS98372",
+    };
+
+    private static readonly string[] LittleBigPlanet3Titles =
+    {
+        "CUSA00738",
+        "CUSA00810",
+        "CUSA00473",
+        "CUSA01072",
+        "CUSA00063",
+        "PCJS50003",
+        "BCES02068",
+        "BCAS20322",
+        "BCJS30095",
+        "BCES01663",
+        "BCUS98362",
+        "PCKS90007",
+        "PCAS00012",
+        "CUSA00601",
+        "NPJA00123",
+        "BCUS81138",
+        "CUSA00762",
+        "PCAS20007",
+        "CUSA01077",
+        "CUSA01304",
+        "CUSA00693",
+    };
+
+    private static readonly string[] LittleBigPlanetVitaTitles =
+    {
+        "PCSC00013",
+        "PCSF00021",
+        "PCSA22106",
+        "PCSF00152",
+        "PCSF00211",
+        "VCAS32010",
+        "PCSA22018",
+        "VCJS10006",
+        "PCSD00006",
+        "PCSA00078",
+        "PCSA00061",
+        "PCSA00017",
+        "PCSA00081", 
+    };
+    
+    public static TokenGame? FromTitleId(string titleId)
+    {
+        if (LittleBigPlanet1Titles.Contains(titleId)) return TokenGame.LittleBigPlanet1;
+        if (LittleBigPlanet2Titles.Contains(titleId)) return TokenGame.LittleBigPlanet2;
+        if (LittleBigPlanet3Titles.Contains(titleId)) return TokenGame.LittleBigPlanet3;
+        if (LittleBigPlanetVitaTitles.Contains(titleId)) return TokenGame.LittleBigPlanetVita;
+        
+        return null;
+    }
+}

--- a/Refresh.GameServer/Authentication/TokenPlatform.cs
+++ b/Refresh.GameServer/Authentication/TokenPlatform.cs
@@ -1,0 +1,9 @@
+namespace Refresh.GameServer.Authentication;
+
+public enum TokenPlatform
+{
+    PS3 = 0,
+    RPCS3 = 1,
+    Vita = 2,
+    Website = 3,
+}

--- a/Refresh.GameServer/Database/RealmDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseContext.Tokens.cs
@@ -31,7 +31,7 @@ public partial class RealmDatabaseContext
         return Convert.ToBase64String(tokenData);
     }
     
-    public Token GenerateTokenForUser(GameUser user, TokenType type, int? tokenExpirySeconds = null)
+    public Token GenerateTokenForUser(GameUser user, TokenType type, TokenGame game, TokenPlatform platform, int? tokenExpirySeconds = null)
     {
         // TODO: JWT (JSON Web Tokens) for TokenType.Api
         
@@ -42,6 +42,8 @@ public partial class RealmDatabaseContext
             User = user,
             TokenData = GetTokenString(cookieLength),
             TokenType = type,
+            TokenGame = game,
+            TokenPlatform = platform,
             ExpiresAt = DateTimeOffset.Now.AddSeconds(tokenExpirySeconds ?? DefaultTokenExpirySeconds),
         };
 

--- a/Refresh.GameServer/Database/RealmDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseProvider.cs
@@ -21,7 +21,7 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
     {
         this._configuration = new RealmConfiguration(Path.Join(Environment.CurrentDirectory, "refreshGameServer.realm"))
         {
-            SchemaVersion = 33,
+            SchemaVersion = 35,
             Schema = new[]
             {
                 typeof(GameUser),
@@ -120,6 +120,9 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
 
                 // In version 22, tokens added expiry and types so just wipe them all
                 if (oldVersion < 22) migration.NewRealm.RemoveAll<Token>();
+                
+                // In version 35, tokens added platforms and games
+                if (oldVersion < 35) migration.NewRealm.RemoveAll<Token>();
                 
                 // IQueryable<dynamic>? oldEvents = migration.OldRealm.DynamicApi.All("Event");
                 IQueryable<Event>? newEvents = migration.NewRealm.All<Event>();

--- a/Refresh.GameServer/Database/RealmDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/RealmDatabaseProvider.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Bunkum.HttpServer;
 using Realms;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Types;
@@ -19,7 +20,7 @@ public class RealmDatabaseProvider : IDatabaseProvider<RealmDatabaseContext>
     [SuppressMessage("ReSharper", "InvertIf")]
     public void Initialize()
     {
-        this._configuration = new RealmConfiguration(Path.Join(Environment.CurrentDirectory, "refreshGameServer.realm"))
+        this._configuration = new RealmConfiguration(Path.Join(BunkumFileSystem.DataDirectory, "refreshGameServer.realm"))
         {
             SchemaVersion = 35,
             Schema = new[]

--- a/Refresh.GameServer/Endpoints/Api/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Api/AuthenticationApiEndpoints.cs
@@ -37,7 +37,7 @@ public partial class AuthenticationApiEndpoints : EndpointGroup
         // if this is a legacy user, have them create a password on login
         if (user.PasswordBcrypt == null)
         {
-            Token resetToken = database.GenerateTokenForUser(user, TokenType.PasswordReset);
+            Token resetToken = database.GenerateTokenForUser(user, TokenType.PasswordReset, TokenGame.Website, TokenPlatform.Website);
 
             ApiResetPasswordResponse resetResp = new()
             {
@@ -58,7 +58,7 @@ public partial class AuthenticationApiEndpoints : EndpointGroup
             return new Response(new ApiErrorResponse("The username or password was incorrect."), ContentType.Json, HttpStatusCode.Forbidden);
         }
 
-        Token token = database.GenerateTokenForUser(user, TokenType.Api);
+        Token token = database.GenerateTokenForUser(user, TokenType.Api, TokenGame.Website, TokenPlatform.Website);
 
         ApiAuthenticationResponse resp = new()
         {

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -42,7 +42,7 @@
 
     <ItemGroup>
       <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-      <PackageReference Include="NPTicket" Version="1.0.0" />
+      <PackageReference Include="NPTicket" Version="2.0.0" />
       <PackageReference Include="Realm" Version="10.21.0" />
     </ItemGroup>
 

--- a/Refresh.GameServer/Types/Activity/Groups/UserActivityGroup.cs
+++ b/Refresh.GameServer/Types/Activity/Groups/UserActivityGroup.cs
@@ -2,6 +2,8 @@ using System.Xml.Serialization;
 
 namespace Refresh.GameServer.Types.Activity.Groups;
 
+#nullable disable
+
 public class UserActivityGroup : ActivityGroup
 {
     [XmlAttribute("type")]

--- a/Refresh.GameServer/Types/Lists/GameFavouriteUserList.cs
+++ b/Refresh.GameServer/Types/Lists/GameFavouriteUserList.cs
@@ -3,6 +3,8 @@ using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Lists;
 
+#nullable disable
+
 [XmlRoot("favouriteUsers")]
 [XmlType("favouriteUsers")]
 public class GameFavouriteUserList : GameList<GameUser>

--- a/Refresh.GameServer/Types/Report/GriefReport.cs
+++ b/Refresh.GameServer/Types/Report/GriefReport.cs
@@ -4,6 +4,8 @@ using Refresh.GameServer.Database;
 
 namespace Refresh.GameServer.Types.Report;
 
+#nullable disable
+
 [XmlRoot("griefReport")]
 public class GriefReport : RealmObject, ISequentialId 
 {

--- a/Refresh.GameServer/Types/Report/InfoBubble.cs
+++ b/Refresh.GameServer/Types/Report/InfoBubble.cs
@@ -3,6 +3,8 @@ using Realms;
 
 namespace Refresh.GameServer.Types.Report;
 
+#nullable disable
+
 [XmlRoot("infoBubble")]
 public class InfoBubble : EmbeddedObject 
 { 

--- a/Refresh.GameServer/Types/Report/Marqee.cs
+++ b/Refresh.GameServer/Types/Report/Marqee.cs
@@ -3,6 +3,8 @@ using Realms;
 
 namespace Refresh.GameServer.Types.Report;
 
+#nullable disable
+
 [XmlRoot("marqee")]
 public class Marqee : EmbeddedObject 
 { 

--- a/Refresh.GameServer/Types/Report/Player.cs
+++ b/Refresh.GameServer/Types/Report/Player.cs
@@ -3,6 +3,8 @@ using Realms;
 
 namespace Refresh.GameServer.Types.Report;
 
+#nullable disable
+
 [XmlRoot("player")]
 public class Player : EmbeddedObject 
 { 

--- a/Refresh.GameServer/Types/Report/ScreenElements.cs
+++ b/Refresh.GameServer/Types/Report/ScreenElements.cs
@@ -3,6 +3,8 @@ using Realms;
 
 namespace Refresh.GameServer.Types.Report;
 
+#nullable disable
+
 [XmlRoot("screenElements")]
 public class ScreenElements : EmbeddedObject 
 { 

--- a/Refresh.GameServer/Types/Report/ScreenRect.cs
+++ b/Refresh.GameServer/Types/Report/ScreenRect.cs
@@ -3,6 +3,8 @@ using Realms;
 
 namespace Refresh.GameServer.Types.Report;
 
+#nullable disable
+
 [XmlRoot("screenRect")]
 public class ScreenRect : EmbeddedObject 
 { 

--- a/Refresh.GameServer/Types/Report/Slot.cs
+++ b/Refresh.GameServer/Types/Report/Slot.cs
@@ -3,6 +3,8 @@ using Realms;
 
 namespace Refresh.GameServer.Types.Report;
 
+#nullable disable
+
 [XmlRoot("slot")]
 public class Slot : EmbeddedObject 
 { 

--- a/Refresh.sln.DotSettings
+++ b/Refresh.sln.DotSettings
@@ -8,10 +8,20 @@
 	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForOtherTypes/@EntryValue">UseExplicitType</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForSimpleTypes/@EntryValue">UseExplicitType</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LBP/@EntryIndexedValue">LBP</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PS/@EntryIndexedValue">PS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PSP/@EntryIndexedValue">PSP</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RPCS/@EntryIndexedValue">RPCS</s:String>
 	<s:Boolean x:Key="/Default/Environment/Editor/UseCamelHumps/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/SolBuilderDuo/UseMsbuildSolutionBuilder/@EntryValue">No</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Asdf/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autodiscover/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCAS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCES/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCET/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCJB/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCJS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCKS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCUS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=canbenull/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Favourited/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Favouriting/@EntryIndexedValue">True</s:Boolean>
@@ -20,6 +30,28 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=jvyden/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LITTLEBIGPLANETPS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lolcatftw/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPEA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPEG/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPEW/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPHA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPHG/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPJA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPJG/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPUA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NPUG/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PCAS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PCJS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PCKS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PCSA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PCSD/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RFSH/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=RPCS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=titleid/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=UCAS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=UCES/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=UCJS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=UCUS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unfavourite/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=unpublish/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unpublish/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=VCAS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=VCJS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
First part of #19 - this allows Refresh to know what platform and game the user is playing on.