### PR TITLE
Return 200 OK on PSP when a user tries to do an invalid favourite action

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
@@ -48,7 +48,7 @@ public class RelationEndpoints : EndpointGroup
         if (database.FavouriteUser(userToFavourite, user))
             return OK;
         
-        return Unauthorized;
+        return context.IsPSP() ? OK : Unauthorized;
     }
     
     [GameEndpoint("unfavourite/user/{username}", Method.Post)]
@@ -60,7 +60,7 @@ public class RelationEndpoints : EndpointGroup
         if (database.UnfavouriteUser(userToFavourite, user))
             return OK;
         
-        return Unauthorized;
+        return context.IsPSP() ? OK : Unauthorized;
     }
 
     [GameEndpoint("favouriteUsers/{username}", ContentType.Xml)]

--- a/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
@@ -47,7 +47,9 @@ public class RelationEndpoints : EndpointGroup
 
         if (database.FavouriteUser(userToFavourite, user))
             return OK;
-        
+
+        // On PSP, we have to lie or else the client will begin spamming the server
+        // https://discord.com/channels/1049223665243389953/1049225857350254632/1153468991675838474
         return context.IsPSP() ? OK : Unauthorized;
     }
     
@@ -59,7 +61,9 @@ public class RelationEndpoints : EndpointGroup
 
         if (database.UnfavouriteUser(userToFavourite, user))
             return OK;
-        
+
+        // On PSP, we have to lie or else the client will begin spamming the server
+        // https://discord.com/channels/1049223665243389953/1049225857350254632/1153468991675838474
         return context.IsPSP() ? OK : Unauthorized;
     }
 


### PR DESCRIPTION
If we return Unauthorized, the client spams the server until it gets a 200 OK, which it never will, leading to an infinite loading loop.