### PR TITLE
Ability for server to override level pages

### DIFF
--- a/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
@@ -104,4 +104,18 @@ public class LevelApiEndpoints : EndpointGroup
 
         return new ApiOkResponse();
     }
+
+    [ApiV3Endpoint("levels/id/{id}/setAsOverride", HttpMethods.Post)]
+    [DocSummary("Marks the level to show in the next slot list gotten from the game")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
+    public ApiOkResponse SetLevelAsOverrideById(RequestContext context, GameDatabaseContext database, GameUser user, LevelListOverrideService service,
+        [DocSummary("The ID of the level")] int id)
+    {
+        GameLevel? level = database.GetLevelById(id);
+        if (level == null) return ApiNotFoundError.LevelMissingError;
+        
+        service.AddOverridesForUser(user, level);
+        
+        return new ApiOkResponse();
+    }
 }

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -75,12 +75,12 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             Handle = SerializedUserHandle.FromUser(old),
             CommentCount = old.ProfileComments.Count,
             CommentsEnabled = true,
-            FavouriteLevelCount = old.FavouriteLevelRelations.Count(),
-            FavouriteUserCount = old.UsersFavourited.Count(),
-            QueuedLevelCount = old.QueueLevelRelations.Count(),
-            HeartCount = old.UsersFavouritingMe.Count(),
-            PhotosByMeCount = old.PhotosByMe.Count(),
-            PhotosWithMeCount = old.PhotosWithMe.Count(),
+            FavouriteLevelCount = old.IsManaged ? old.FavouriteLevelRelations.Count() : 0,
+            FavouriteUserCount = old.IsManaged ? old.UsersFavourited.Count() : 0,
+            QueuedLevelCount = old.IsManaged ? old.QueueLevelRelations.Count() : 0,
+            HeartCount = old.IsManaged ? old.UsersFavouritingMe.Count() : 0,
+            PhotosByMeCount = old.IsManaged ? old.PhotosByMe.Count() : 0,
+            PhotosWithMeCount = old.IsManaged ? old.PhotosWithMe.Count() : 0,
             
             EntitledSlots = MaximumLevels,
             EntitledSlotsLBP2 = MaximumLevels,
@@ -102,6 +102,14 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
 
     private void FillInExtraData(GameUser old, TokenGame gameVersion, GameDatabaseContext database)
     {
+        if (!old.IsManaged)
+        {
+            this.PlanetsHash = "0";
+            this.IconHash = "0";
+            
+            return;
+        }
+        
         this.PlanetsHash = gameVersion switch
         {
             TokenGame.LittleBigPlanet1 => "0",

--- a/Refresh.GameServer/Endpoints/Game/ModerationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ModerationEndpoints.cs
@@ -43,7 +43,7 @@ public class ModerationEndpoints : EndpointGroup
     /// <returns>The string shown in-game.</returns>
     [GameEndpoint("filter", HttpMethods.Post)]
     [AllowEmptyBody]
-    public string Filter(RequestContext context, CommandService commandService, string body, GameUser user, Token token, GameDatabaseContext database)
+    public string Filter(RequestContext context, CommandService commandService, string body, GameUser user, Token token, GameDatabaseContext database, LevelListOverrideService levelListService)
     {
         // TODO: Add actual filtering/censoring
         
@@ -61,7 +61,8 @@ public class ModerationEndpoints : EndpointGroup
                 
                 context.Logger.LogInfo(BunkumCategory.Commands, $"User used command '{command.Name.ToString()}' with args '{command.Arguments.ToString()}'");
 
-                commandService.HandleCommand(command, database, user, token);
+                commandService.HandleCommand(command, database, levelListService, user, token);
+                return "(Command)";
             }
             catch
             {

--- a/Refresh.GameServer/Endpoints/Game/ModerationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ModerationEndpoints.cs
@@ -43,7 +43,7 @@ public class ModerationEndpoints : EndpointGroup
     /// <returns>The string shown in-game.</returns>
     [GameEndpoint("filter", HttpMethods.Post)]
     [AllowEmptyBody]
-    public string Filter(RequestContext context, CommandService commandService, string body, GameUser user, Token token, GameDatabaseContext database, LevelListOverrideService levelListService)
+    public string Filter(RequestContext context, CommandService commandService, string body, GameUser user, Token token, GameDatabaseContext database)
     {
         // TODO: Add actual filtering/censoring
         
@@ -61,7 +61,7 @@ public class ModerationEndpoints : EndpointGroup
                 
                 context.Logger.LogInfo(BunkumCategory.Commands, $"User used command '{command.Name.ToString()}' with args '{command.Arguments.ToString()}'");
 
-                commandService.HandleCommand(command, database, levelListService, user, token);
+                commandService.HandleCommand(command, database, user, token);
                 return "(Command)";
             }
             catch

--- a/Refresh.GameServer/RefreshContext.cs
+++ b/Refresh.GameServer/RefreshContext.cs
@@ -5,4 +5,5 @@ public enum RefreshContext
     Startup,
     Worker,
     Discord,
+    LevelListOverride,
 }

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -125,7 +125,6 @@ public class RefreshGameServer : IDisposable
         this._server.AddService<CategoryService>();
         this._server.AddService<FriendStorageService>();
         this._server.AddService<MatchService>();
-        this._server.AddService<CommandService>();
         this._server.AddService<ImportService>();
         this._server.AddService<DocumentationService>();
         this._server.AddAutoDiscover(serverBrand: $"{this._config!.InstanceName} (Refresh)",
@@ -146,6 +145,8 @@ public class RefreshGameServer : IDisposable
             this._server.AddService<RequestStatisticTrackingService>();
         
         this._server.AddService<LevelListOverrideService>();
+        
+        this._server.AddService<CommandService>();
         
         #if DEBUG
         this._server.AddService<DebugService>();

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -10,7 +10,6 @@ using Bunkum.Core.Storage;
 using Bunkum.HealthChecks;
 using Bunkum.HealthChecks.RealmDatabase;
 using Bunkum.Protocols.Http;
-using Bunkum.RealmDatabase;
 using NotEnoughLogs;
 using NotEnoughLogs.Behaviour;
 using NotEnoughLogs.Sinks;
@@ -145,6 +144,8 @@ public class RefreshGameServer : IDisposable
 
         if (this._config!.TrackRequestStatistics)
             this._server.AddService<RequestStatisticTrackingService>();
+        
+        this._server.AddService<LevelListOverrideService>();
         
         #if DEBUG
         this._server.AddService<DebugService>();

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -14,9 +14,11 @@ namespace Refresh.GameServer.Services;
 public class CommandService : EndpointService
 {
     private readonly MatchService _match;
+    private readonly LevelListOverrideService _levelListService;
     
-    public CommandService(Logger logger, MatchService match) : base(logger) {
+    public CommandService(Logger logger, MatchService match, LevelListOverrideService levelListService) : base(logger) {
         this._match = match;
+        this._levelListService = levelListService;
     }
 
     private readonly HashSet<ObjectId> _usersPublishing = new();
@@ -77,7 +79,7 @@ public class CommandService : EndpointService
     }
 
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
-    public void HandleCommand(CommandInvocation command, GameDatabaseContext database, LevelListOverrideService levelListService, GameUser user, Token token)
+    public void HandleCommand(CommandInvocation command, GameDatabaseContext database, GameUser user, Token token)
     {
         switch (command.Name)
         {
@@ -117,7 +119,7 @@ public class CommandService : EndpointService
                 GameLevel? level = database.GetLevelById(int.Parse(command.Arguments));
                 if (level != null)
                 {
-                    levelListService.AddOverridesForUser(user, level);
+                    this._levelListService.AddOverridesForUser(user, level);
                 }
                 break;
             }

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -6,6 +6,7 @@ using NotEnoughLogs;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.Commands;
+using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Services;
@@ -76,7 +77,7 @@ public class CommandService : EndpointService
     }
 
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
-    public void HandleCommand(CommandInvocation command, GameDatabaseContext database, GameUser user, Token token)
+    public void HandleCommand(CommandInvocation command, GameDatabaseContext database, LevelListOverrideService levelListService, GameUser user, Token token)
     {
         switch (command.Name)
         {
@@ -109,6 +110,15 @@ public class CommandService : EndpointService
             case "griefphotosoff":
             {
                 user.RedirectGriefReportsToPhotos = false;
+                break;
+            }
+            case "play":
+            {
+                GameLevel? level = database.GetLevelById(int.Parse(command.Arguments));
+                if (level != null)
+                {
+                    levelListService.AddOverridesForUser(user, level);
+                }
                 break;
             }
             #if DEBUG

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -80,7 +80,8 @@ public class CommandService : EndpointService
     {
         switch (command.Name)
         {
-            case "forcematch": {
+            case "forcematch":
+            {
                 if (command.Arguments == null)
                 {
                     throw new Exception("User not provided for force match command");
@@ -95,19 +96,19 @@ public class CommandService : EndpointService
                 
                 break;
             }
-            case "clearforcematch": {
+            case "clearforcematch":
+            {
                 this._match.ClearForceMatch(user.UserId);
-                
                 break;
             }
-            case "griefphotoson": {
+            case "griefphotoson":
+            {
                 user.RedirectGriefReportsToPhotos = true;
-                
                 break;
             }
-            case "griefphotosoff": {
+            case "griefphotosoff":
+            {
                 user.RedirectGriefReportsToPhotos = false;
-                
                 break;
             }
             #if DEBUG

--- a/Refresh.GameServer/Services/LevelListOverrideService.cs
+++ b/Refresh.GameServer/Services/LevelListOverrideService.cs
@@ -19,8 +19,13 @@ public class LevelListOverrideService : EndpointService
     {
         bool result = this._userIdsToLevelList.ContainsKey(user.UserId);
         
-        this.Logger.LogTrace(RefreshContext.LevelListOverride, "{0} has overrides: {1}", user, result);
+        this.Logger.LogTrace(RefreshContext.LevelListOverride, "{0} has overrides: {1}", user.Username, result);
         return result;
+    }
+
+    public void AddOverridesForUser(GameUser user, GameLevel level)
+    {
+        this.AddOverridesForUser(user, new[] { level });
     }
 
     public void AddOverridesForUser(GameUser user, IEnumerable<GameLevel> levels)
@@ -28,7 +33,7 @@ public class LevelListOverrideService : EndpointService
         Debug.Assert(!this.UserHasOverrides(user), "User already has overrides");
         
         List<int> ids = levels.Select(l => l.LevelId).ToList();
-        this.Logger.LogDebug(RefreshContext.LevelListOverride, "Adding level override for {0}: [{1}]", user, string.Join(", ", ids));
+        this.Logger.LogDebug(RefreshContext.LevelListOverride, "Adding level override for {0}: [{1}]", user.Username, string.Join(", ", ids));
         this._userIdsToLevelList.Add(user.UserId, ids);
     }
 
@@ -37,7 +42,7 @@ public class LevelListOverrideService : EndpointService
         Debug.Assert(this.UserHasOverrides(user), "User does not have overrides, should be checked first");
         
         List<int> overrides = this._userIdsToLevelList[user.UserId];
-        this.Logger.LogDebug(RefreshContext.LevelListOverride, "Getting level override for {0}: [{1}]", user, string.Join(", ", overrides));
+        this.Logger.LogDebug(RefreshContext.LevelListOverride, "Getting level override for {0}: [{1}]", user.Username, string.Join(", ", overrides));
         this._userIdsToLevelList.Remove(user.UserId);
 
         return overrides.Select(database.GetLevelById)!;

--- a/Refresh.GameServer/Services/LevelListOverrideService.cs
+++ b/Refresh.GameServer/Services/LevelListOverrideService.cs
@@ -15,13 +15,20 @@ public class LevelListOverrideService : EndpointService
 
     private readonly Dictionary<ObjectId, List<int>> _userIdsToLevelList = new(1);
 
-    public bool UserHasOverrides(GameUser user) => this._userIdsToLevelList.ContainsKey(user.UserId);
+    public bool UserHasOverrides(GameUser user)
+    {
+        bool result = this._userIdsToLevelList.ContainsKey(user.UserId);
+        
+        this.Logger.LogTrace(RefreshContext.LevelListOverride, "{0} has overrides: {1}", user, result);
+        return result;
+    }
 
     public void AddOverridesForUser(GameUser user, IEnumerable<GameLevel> levels)
     {
         Debug.Assert(!this.UserHasOverrides(user), "User already has overrides");
         
         List<int> ids = levels.Select(l => l.LevelId).ToList();
+        this.Logger.LogDebug(RefreshContext.LevelListOverride, "Adding level override for {0}: [{1}]", user, string.Join(", ", ids));
         this._userIdsToLevelList.Add(user.UserId, ids);
     }
 
@@ -30,6 +37,7 @@ public class LevelListOverrideService : EndpointService
         Debug.Assert(this.UserHasOverrides(user), "User does not have overrides, should be checked first");
         
         List<int> overrides = this._userIdsToLevelList[user.UserId];
+        this.Logger.LogDebug(RefreshContext.LevelListOverride, "Getting level override for {0}: [{1}]", user, string.Join(", ", overrides));
         this._userIdsToLevelList.Remove(user.UserId);
 
         return overrides.Select(database.GetLevelById)!;

--- a/Refresh.GameServer/Services/LevelListOverrideService.cs
+++ b/Refresh.GameServer/Services/LevelListOverrideService.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using Bunkum.Core.Services;
+using MongoDB.Bson;
+using NotEnoughLogs;
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.UserData;
+
+namespace Refresh.GameServer.Services;
+
+public class LevelListOverrideService : EndpointService
+{
+    public LevelListOverrideService(Logger logger) : base(logger)
+    {}
+
+    private readonly Dictionary<ObjectId, List<int>> _userIdsToLevelList = new(1);
+
+    public bool UserHasOverrides(GameUser user) => this._userIdsToLevelList.ContainsKey(user.UserId);
+
+    public void AddOverridesForUser(GameUser user, IEnumerable<GameLevel> levels)
+    {
+        Debug.Assert(!this.UserHasOverrides(user), "User already has overrides");
+        
+        List<int> ids = levels.Select(l => l.LevelId).ToList();
+        this._userIdsToLevelList.Add(user.UserId, ids);
+    }
+
+    public IEnumerable<GameLevel> GetOverridesForUser(GameUser user, GameDatabaseContext database)
+    {
+        Debug.Assert(this.UserHasOverrides(user), "User does not have overrides, should be checked first");
+        
+        List<int> overrides = this._userIdsToLevelList[user.UserId];
+        this._userIdsToLevelList.Remove(user.UserId);
+
+        return overrides.Select(database.GetLevelById)!;
+    }
+}

--- a/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
+++ b/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
@@ -1,5 +1,9 @@
+using System.Reflection;
+using Bunkum.Core;
+using Bunkum.Core.Services;
 using Bunkum.Core.Storage;
 using Bunkum.Protocols.Http;
+using JetBrains.Annotations;
 using NotEnoughLogs;
 using NotEnoughLogs.Behaviour;
 using NotEnoughLogs.Sinks;
@@ -67,5 +71,14 @@ public class TestRefreshGameServer : RefreshGameServer
         this._server.AddService<CommandService>();
         this._server.AddService<ImportService>();
         this._server.AddService<LevelListOverrideService>();
+    }
+    
+    [Pure]
+    public TService GetService<TService>() where TService : Service
+    {
+        List<Service> services = (List<Service>)typeof(BunkumServer).GetField("_services", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(this._server)!;
+
+        return (TService)services.First(s => typeof(TService) == s.GetType());
     }
 }

--- a/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
+++ b/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
@@ -66,5 +66,6 @@ public class TestRefreshGameServer : RefreshGameServer
         this._server.AddService<MatchService>();
         this._server.AddService<CommandService>();
         this._server.AddService<ImportService>();
+        this._server.AddService<LevelListOverrideService>();
     }
 }

--- a/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
+++ b/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
@@ -68,9 +68,9 @@ public class TestRefreshGameServer : RefreshGameServer
         this._server.AddService<TimeProviderService>(this.DateTimeProvider);
         this._server.AddService<CategoryService>();
         this._server.AddService<MatchService>();
-        this._server.AddService<CommandService>();
         this._server.AddService<ImportService>();
         this._server.AddService<LevelListOverrideService>();
+        this._server.AddService<CommandService>();
     }
     
     [Pure]

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -1,4 +1,6 @@
+using Bunkum.Core.Services;
 using Bunkum.Protocols.Http.Direct;
+using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Types;
@@ -119,6 +121,9 @@ public class TestContext : IDisposable
 
         return submittedScore;
     }
+
+    [Pure]
+    public TService GetService<TService>() where TService : Service => this.Server.Value.GetService<TService>();
 
     public void Dispose()
     {

--- a/RefreshTests.GameServer/Tests/Commands/CommandParseTests.cs
+++ b/RefreshTests.GameServer/Tests/Commands/CommandParseTests.cs
@@ -20,7 +20,7 @@ public class CommandParseTests : GameServerTest
 	public void ParsingTest()
 	{
 		using Logger logger = new(new []{ new NUnitSink() });
-		CommandService service = new(logger, new MatchService(logger));
+		CommandService service = new(logger, new MatchService(logger), new LevelListOverrideService(logger));
         
 		ParseTest(service, "/parse test", "parse", "test");
 		ParseTest(service, "/noargs", "noargs", "");
@@ -31,7 +31,7 @@ public class CommandParseTests : GameServerTest
 	public void NoSlashThrows()
 	{
 		using Logger logger = new(new []{ new NUnitSink() });
-		CommandService service = new(logger, new MatchService(logger));
+		CommandService service = new(logger, new MatchService(logger), new LevelListOverrideService(logger));
 
 		Assert.That(() => _ = service.ParseCommand("parse test"), Throws.InstanceOf<FormatException>());
 	}
@@ -40,7 +40,7 @@ public class CommandParseTests : GameServerTest
 	public void BlankCommandThrows()
 	{
 		using Logger logger = new(new []{ new NUnitSink() });
-		CommandService service = new(logger, new MatchService(logger));
+		CommandService service = new(logger, new MatchService(logger), new LevelListOverrideService(logger));
 
 		Assert.That(() => _ = service.ParseCommand("/ test"), Throws.InstanceOf<FormatException>());
 	}

--- a/RefreshTests.GameServer/Tests/Levels/LevelListOverrideTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/LevelListOverrideTests.cs
@@ -1,0 +1,53 @@
+using MongoDB.Bson;
+using NotEnoughLogs;
+using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.UserData;
+using RefreshTests.GameServer.Logging;
+
+namespace RefreshTests.GameServer.Tests.Levels;
+
+public class LevelListOverrideUnitTests
+{
+    [Test]
+    public void CanOverrideLevel()
+    {
+        using Logger logger = new(new []{ new NUnitSink() });
+        LevelListOverrideService service = new(logger);
+        GameUser user = new()
+        {
+            UserId = new ObjectId("64ea5a8a7c412d18ab640fd1"),
+            Username = "SuperDingus69",
+        };
+
+        GameLevel level = new()
+        {
+            LevelId = 1,
+        };
+        
+        service.AddOverridesForUser(user, new []{level});
+    }
+}
+
+public class LevelListOverrideIntegrationTests : GameServerTest
+{
+    [Test]
+    public void CanGetOverriddenLevels()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user, "dingus 2B47430C-70F1-4A21-A1D0-EC3011A62239");
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game);
+        
+        // Verify that the endpoint isn't already attempting to return anything
+        // This can be any endpoint that doesnt return all levels but I chose mmpicks
+        HttpResponseMessage message = client.GetAsync("/lbp/slots/mmpicks").Result;
+        Assert.That(message.StatusCode, Is.EqualTo(OK));
+        Assert.That(message.Content.ReadAsStringAsync().Result, Does.Not.Contain(level.Title));
+
+        LevelListOverrideService overrideService = context.GetService<LevelListOverrideService>();
+        Assert.That(overrideService.UserHasOverrides(user), Is.False);
+    }
+}


### PR DESCRIPTION
Will let you easily go to a level from the website (I imagine a button that says 'play now!' ~~that will trigger this) or let you jump into a level by its SHA1/GUID as #200 suggests~~ will come in a separate PR

## TODO
- [x] Define basic API and service for overriding level lists
- [x] Write unit tests
- [x] Expose this system in the website
- [x] Test in-game