### PR TITLE
Implement Cool Levels

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -336,11 +336,14 @@ public partial class GameDatabaseContext // Levels
     public void AddTeamPickToLevel(GameLevel level) => this.SetLevelPickStatus(level, true);
     public void RemoveTeamPickFromLevel(GameLevel level) => this.SetLevelPickStatus(level, false);
 
-    public void SetLevelScore(GameLevel level, float score)
+    public void SetLevelScores(Dictionary<GameLevel, float> scoresToSet)
     {
         this._realm.Write(() =>
         {
-            level.Score = score;
+            foreach ((GameLevel level, float score) in scoresToSet)
+            {
+                level.Score = score;
+            }
         });
     }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -335,4 +335,12 @@ public partial class GameDatabaseContext // Levels
 
     public void AddTeamPickToLevel(GameLevel level) => this.SetLevelPickStatus(level, true);
     public void RemoveTeamPickFromLevel(GameLevel level) => this.SetLevelPickStatus(level, false);
+
+    public void SetLevelScore(GameLevel level, float score)
+    {
+        this._realm.Write(() =>
+        {
+            level.Score = score;
+        });
+    }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -294,6 +294,7 @@ public partial class GameDatabaseContext // Levels
     public DatabaseList<GameLevel> GetCoolLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings) =>
         new(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
             .FilterByLevelFilterSettings(user, levelFilterSettings)
+            .Where(l => l.Score > 0)
             .OrderByDescending(l => l.Score), skip, count);
 
     [Pure]

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -289,6 +289,12 @@ public partial class GameDatabaseContext // Levels
             .FilterByLevelFilterSettings(user, levelFilterSettings)
             .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     }
+    
+    [Pure]
+    public DatabaseList<GameLevel> GetCoolLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings) =>
+        new(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+            .FilterByLevelFilterSettings(user, levelFilterSettings)
+            .OrderByDescending(l => l.Score), skip, count);
 
     [Pure]
     public DatabaseList<GameLevel> SearchForLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings, string query)

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -170,6 +170,10 @@ public partial class GameDatabaseContext // Levels
     }
 
     [Pure]
+    public DatabaseList<GameLevel> GetAllUserLevels() 
+        => new(this._realm.All<GameLevel>().Where(l => l._Source == (int)GameLevelSource.User));
+
+    [Pure]
     public DatabaseList<GameLevel> GetNewestLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings) =>
         new(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
             .FilterByLevelFilterSettings(user, levelFilterSettings)

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -32,7 +32,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 96;
+    protected override ulong SchemaVersion => 97;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameLevelResponse.cs
@@ -38,6 +38,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
     public required bool IsLocked { get; set; }
     public required bool IsSubLevel { get; set; }
     public required bool IsCopyable { get; set; }
+    public required float Score { get; set; }
 
     public static ApiGameLevelResponse? FromOld(GameLevel? level)
     {
@@ -69,6 +70,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
             IsCopyable = level.IsCopyable,
             IsLocked = level.IsLocked,
             IsSubLevel = level.IsSubLevel,
+            Score = level.Score,
         };
     }
 

--- a/Refresh.GameServer/RefreshContext.cs
+++ b/Refresh.GameServer/RefreshContext.cs
@@ -7,4 +7,5 @@ public enum RefreshContext
     Discord,
     PasswordReset,
     LevelListOverride,
+    CoolLevels,
 }

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -202,7 +202,7 @@ public class RefreshGameServer : IDisposable
         {
             Behaviour = new QueueLoggingBehaviour(),
             #if DEBUG
-            MaxLevel = LogLevel.Debug,
+            MaxLevel = LogLevel.Trace,
             #else
             MaxLevel = LogLevel.Info,
             #endif

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -159,6 +159,7 @@ public class RefreshGameServer : IDisposable
         
         this._workerManager.AddWorker<PunishmentExpiryWorker>();
         this._workerManager.AddWorker<ExpiredObjectWorker>();
+        this._workerManager.AddWorker<CoolLevelsWorker>();
         
         if ((this._integrationConfig?.DiscordWebhookEnabled ?? false) && this._config != null)
         {

--- a/Refresh.GameServer/Types/Levels/Categories/CategoryService.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/CategoryService.cs
@@ -10,20 +10,24 @@ public class CategoryService : EndpointService
     // ReSharper disable once InconsistentNaming
     private readonly List<LevelCategory> _categories = new()
     {
-        new NewestLevelsCategory(),
+        new CoolLevelsCategory(),
+        new TeamPickedLevelsCategory(),
+        
+        new CurrentlyPlayingCategory(),
         new RandomLevelsCategory(),
-        new ByUserLevelCategory(),
-        new SearchLevelCategory(),
-        new FavouriteSlotsByUserCategory(),
-        new QueuedLevelsByUserCategory(),
+        new NewestLevelsCategory(),
+        
         new MostHeartedLevelsCategory(),
         new HighestRatedLevelsCategory(),
         new MostUniquelyPlayedLevelsCategory(),
         new MostReplayedLevelsCategory(),
-        new TeamPickedLevelsCategory(),
+        
+        new ByUserLevelCategory(),
+        new FavouriteSlotsByUserCategory(),
+        new QueuedLevelsByUserCategory(),
+        
+        new SearchLevelCategory(),
         new DeveloperLevelsCategory(),
-        new CurrentlyPlayingCategory(),
-        new CoolLevelsCategory(),
     };
 
     internal CategoryService(Logger logger) : base(logger)

--- a/Refresh.GameServer/Types/Levels/Categories/CategoryService.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/CategoryService.cs
@@ -23,6 +23,7 @@ public class CategoryService : EndpointService
         new TeamPickedLevelsCategory(),
         new DeveloperLevelsCategory(),
         new CurrentlyPlayingCategory(),
+        new CoolLevelsCategory(),
     };
 
     internal CategoryService(Logger logger) : base(logger)

--- a/Refresh.GameServer/Types/Levels/Categories/CoolLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/CoolLevelsCategory.cs
@@ -1,0 +1,24 @@
+using Bunkum.Core;
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
+using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.UserData;
+
+namespace Refresh.GameServer.Types.Levels.Categories;
+
+public class CoolLevelsCategory : LevelCategory
+{
+    public CoolLevelsCategory() : base("coolLevels", "cool", false)
+    {
+        this.Name = "Cool Levels";
+        this.Description = "wacha wacha";
+        this.FontAwesomeIcon = "fireAlt";
+        this.IconHash = "g820625";
+    }
+
+    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService,
+        GameDatabaseContext database, GameUser? user, LevelFilterSettings levelFilterSettings)
+    {
+        return database.GetCoolLevels(count, skip, user, levelFilterSettings);
+    }
+}

--- a/Refresh.GameServer/Types/Levels/Categories/CoolLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/CoolLevelsCategory.cs
@@ -8,10 +8,10 @@ namespace Refresh.GameServer.Types.Levels.Categories;
 
 public class CoolLevelsCategory : LevelCategory
 {
-    public CoolLevelsCategory() : base("coolLevels", "cool", false)
+    public CoolLevelsCategory() : base("coolLevels", new []{"lbpcool", "lbp2cool"}, false)
     {
         this.Name = "Cool Levels";
-        this.Description = "wacha wacha";
+        this.Description = "Levels trending with players like you!";
         this.FontAwesomeIcon = "fireAlt";
         this.IconHash = "g820625";
     }

--- a/Refresh.GameServer/Types/Levels/GameLevel.cs
+++ b/Refresh.GameServer/Types/Levels/GameLevel.cs
@@ -8,6 +8,7 @@ using Refresh.GameServer.Types.Levels.SkillRewards;
 using Refresh.GameServer.Types.Relations;
 using Refresh.GameServer.Types.Reviews;
 using Refresh.GameServer.Types.UserData.Leaderboard;
+using Refresh.GameServer.Workers;
 
 namespace Refresh.GameServer.Types.Levels;
 
@@ -75,6 +76,12 @@ public partial class GameLevel : IRealmObject, ISequentialId
     public bool IsLocked { get; set; }
     public bool IsSubLevel { get; set; }
     public bool IsCopyable { get; set; }
+    
+    /// <summary>
+    /// The score, used for Cool Levels.
+    /// </summary>
+    /// <seealso cref="CoolLevelsWorker"/>
+    public float Score { get; set; }
 
 #nullable disable
     public IList<GameComment> LevelComments { get; }

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -81,7 +81,7 @@ public class CoolLevelsWorker : IWorker
         const int negativeRatingPoints = 5;
         const int negativeReviewPoints = 1;
         
-        score += level.Ratings.Count(r => r._RatingType == (int)RatingType.Yay) * negativeRatingPoints;
+        score += level.Ratings.Count(r => r._RatingType == (int)RatingType.Boo) * negativeRatingPoints;
 
         logger.LogTrace(RefreshContext.CoolLevels, "Negative Score is {0}", score);
         return score;

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -13,10 +13,15 @@ public class CoolLevelsWorker : IWorker
     public bool DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database)
     {
         DatabaseList<GameLevel> levels = database.GetAllUserLevels();
+        if (levels.TotalItems <= 0)
+        {
+            logger.LogWarning(RefreshContext.CoolLevels, "No levels to process for cool levels. If you're sure this server has levels, this is a bug.");
+            return false;
+        }
 
         long now = DateTimeOffset.Now.ToUnixTimeSeconds();
-
-        Dictionary<GameLevel, float> scoresToSet = new();
+        // Create a dictionary so we can batch the write to the db
+        Dictionary<GameLevel, float> scoresToSet = new(levels.TotalItems);
 
         Stopwatch stopwatch = new();
         stopwatch.Start();
@@ -24,12 +29,19 @@ public class CoolLevelsWorker : IWorker
         foreach (GameLevel level in levels.Items)
         {
             logger.LogTrace(RefreshContext.CoolLevels, "Calculating score for '{0}' ({1})", level.Title, level.LevelId);
-            float multiplier = CalculateLevelDecayMultiplier(logger, now, level);
+            float decayMultiplier = CalculateLevelDecayMultiplier(logger, now, level);
 
+            // Calculate positive & negative score separately so we don't run into issues with
+            // the multiplier having an opposite effect with the negative score as time passes
             int positiveScore = CalculatePositiveScore(logger, level);
             int negativeScore = CalculateNegativeScore(logger, level);
 
-            float finalScore = (positiveScore * multiplier) - (negativeScore * Math.Min(1.0f, multiplier * 2));
+            // Increase to tweak how little negative score gets affected by decay
+            const int negativeScoreMultiplier = 2;
+            
+            // Weigh everything with the multiplier and set a final score
+            float finalScore = (positiveScore * decayMultiplier) - (negativeScore * Math.Min(1.0f, decayMultiplier * negativeScoreMultiplier));
+            
             logger.LogDebug(RefreshContext.CoolLevels, "Score for '{0}' ({1}) is {2}", level.Title, level.LevelId, finalScore);
             scoresToSet.Add(level, finalScore);
         }
@@ -37,23 +49,25 @@ public class CoolLevelsWorker : IWorker
         stopwatch.Stop();
         logger.LogInfo(RefreshContext.CoolLevels, "Calculated scores for {0} levels in {1}ms", levels.TotalItems, stopwatch.ElapsedMilliseconds);
         
-        // commit scores to database
+        // Commit scores to database. This method lets us use a dictionary so we can batch everything in one write
         database.SetLevelScores(scoresToSet);
-
-        return false;
+        
+        return true; // Tell the worker manager we did work
     }
 
     private static float CalculateLevelDecayMultiplier(Logger logger, long now, GameLevel level)
     {
-        const int decayDays = 30 * 3;
-        const int decaySeconds = decayDays * 24 * 3600;
+        const int decayMonths = 3;
+        const int decaySeconds = decayMonths * 30 * 24 * 3600;
         const float minimumMultiplier = 0.1f;
         
+        // Use seconds. Lets us not worry about float stuff
         long publishDate = level.PublishDate / 1000;
         long elapsed = now - publishDate;
 
+        // Get a scale from 0.0f to 1.0f, the percent of decay
         float multiplier = 1.0f - Math.Min(1.0f, (float)elapsed / decaySeconds);
-        multiplier = Math.Max(minimumMultiplier, multiplier);
+        multiplier = Math.Max(minimumMultiplier, multiplier); // Clamp to minimum multiplier
         
         logger.LogTrace(RefreshContext.CoolLevels, "Decay multiplier is {0}", multiplier);
         return multiplier;
@@ -63,7 +77,7 @@ public class CoolLevelsWorker : IWorker
     {
         int score = 0;
         const int positiveRatingPoints = 5;
-        const int positiveReviewPoints = 5;
+        // const int positiveReviewPoints = 5;
         const int uniquePlayPoints = 1;
         const int heartPoints = 5;
 
@@ -73,7 +87,7 @@ public class CoolLevelsWorker : IWorker
         score += level.UniquePlays.Count() * uniquePlayPoints;
         score += level.FavouriteRelations.Count() * heartPoints;
 
-        logger.LogTrace(RefreshContext.CoolLevels, "Positive Score is {0}", score);
+        logger.LogTrace(RefreshContext.CoolLevels, "positiveScore is {0}", score);
         return score;
     }
 
@@ -81,11 +95,11 @@ public class CoolLevelsWorker : IWorker
     {
         int score = 0;
         const int negativeRatingPoints = 5;
-        const int negativeReviewPoints = 5;
+        // const int negativeReviewPoints = 5;
         
         score += level.Ratings.Count(r => r._RatingType == (int)RatingType.Boo) * negativeRatingPoints;
 
-        logger.LogTrace(RefreshContext.CoolLevels, "Negative Score is {0}", score);
+        logger.LogTrace(RefreshContext.CoolLevels, "negativeScore is {0}", score);
         return score;
     }
 }

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -1,0 +1,42 @@
+using Bunkum.Core.Storage;
+using NotEnoughLogs;
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
+using Refresh.GameServer.Types.Levels;
+
+namespace Refresh.GameServer.Workers;
+
+public class CoolLevelsWorker : IWorker
+{
+    public int WorkInterval => 600_000; // Every 10 minutes
+    public bool DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database)
+    {
+        DatabaseList<GameLevel> levels = database.GetAllUserLevels();
+
+        long now = DateTimeOffset.Now.ToUnixTimeSeconds();
+
+        foreach (GameLevel level in levels.Items)
+        {
+            logger.LogDebug(RefreshContext.CoolLevels, "Calculating score for '{0}' ({1})", level.Title, level.LevelId);
+            float multiplier = CalculateLevelDecayMultiplier(logger, now, level);
+        }
+
+        return false;
+    }
+
+    private static float CalculateLevelDecayMultiplier(Logger logger, long now, GameLevel level)
+    {
+        const int decayDays = 90;
+        const int decaySeconds = decayDays * 24 * 3600;
+        const float minimumMultiplier = 0.1f;
+        
+        long publishDate = level.PublishDate / 1000;
+        long elapsed = now - publishDate;
+
+        float multiplier = 1.0f - Math.Min(1.0f, (float)elapsed / decaySeconds);
+        multiplier = Math.Max(minimumMultiplier, multiplier);
+        
+        logger.LogDebug(RefreshContext.CoolLevels, "Decay multiplier is {0}", multiplier);
+        return multiplier;
+    }
+}

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -45,7 +45,7 @@ public class CoolLevelsWorker : IWorker
 
     private static float CalculateLevelDecayMultiplier(Logger logger, long now, GameLevel level)
     {
-        const int decayDays = 90;
+        const int decayDays = 30 * 3;
         const int decaySeconds = decayDays * 24 * 3600;
         const float minimumMultiplier = 0.1f;
         
@@ -63,10 +63,12 @@ public class CoolLevelsWorker : IWorker
     {
         int score = 0;
         const int positiveRatingPoints = 5;
-        const int positiveReviewPoints = 1;
+        const int positiveReviewPoints = 5;
         const int uniquePlayPoints = 1;
-        const int heartPoints = 2;
+        const int heartPoints = 5;
 
+        if (level.TeamPicked) score += 10;
+        
         score += level.Ratings.Count(r => r._RatingType == (int)RatingType.Yay) * positiveRatingPoints;
         score += level.UniquePlays.Count() * uniquePlayPoints;
         score += level.FavouriteRelations.Count() * heartPoints;
@@ -79,7 +81,7 @@ public class CoolLevelsWorker : IWorker
     {
         int score = 0;
         const int negativeRatingPoints = 5;
-        const int negativeReviewPoints = 1;
+        const int negativeReviewPoints = 5;
         
         score += level.Ratings.Count(r => r._RatingType == (int)RatingType.Boo) * negativeRatingPoints;
 

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -29,7 +29,7 @@ public class CoolLevelsWorker : IWorker
             int positiveScore = CalculatePositiveScore(logger, level);
             int negativeScore = CalculateNegativeScore(logger, level);
 
-            float finalScore = (positiveScore * multiplier) - negativeScore;
+            float finalScore = (positiveScore * multiplier) - (negativeScore * Math.Min(1.0f, multiplier * 2));
             logger.LogDebug(RefreshContext.CoolLevels, "Score for '{0}' ({1}) is {2}", level.Title, level.LevelId, finalScore);
             scoresToSet.Add(level, finalScore);
         }

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -19,7 +19,7 @@ public class CoolLevelsWorker : IWorker
 
         foreach (GameLevel level in levels.Items)
         {
-            logger.LogDebug(RefreshContext.CoolLevels, "Calculating score for '{0}' ({1})", level.Title, level.LevelId);
+            logger.LogTrace(RefreshContext.CoolLevels, "Calculating score for '{0}' ({1})", level.Title, level.LevelId);
             float multiplier = CalculateLevelDecayMultiplier(logger, now, level);
 
             int positiveScore = CalculatePositiveScore(logger, level);
@@ -44,7 +44,7 @@ public class CoolLevelsWorker : IWorker
         float multiplier = 1.0f - Math.Min(1.0f, (float)elapsed / decaySeconds);
         multiplier = Math.Max(minimumMultiplier, multiplier);
         
-        logger.LogDebug(RefreshContext.CoolLevels, "Decay multiplier is {0}", multiplier);
+        logger.LogTrace(RefreshContext.CoolLevels, "Decay multiplier is {0}", multiplier);
         return multiplier;
     }
 
@@ -60,7 +60,7 @@ public class CoolLevelsWorker : IWorker
         score += level.UniquePlays.Count() * uniquePlayPoints;
         score += level.FavouriteRelations.Count() * heartPoints;
 
-        logger.LogDebug(RefreshContext.CoolLevels, "Positive Score is {0}", score);
+        logger.LogTrace(RefreshContext.CoolLevels, "Positive Score is {0}", score);
         return score;
     }
 
@@ -72,7 +72,7 @@ public class CoolLevelsWorker : IWorker
         
         score += level.Ratings.Count(r => r._RatingType == (int)RatingType.Yay) * negativeRatingPoints;
 
-        logger.LogDebug(RefreshContext.CoolLevels, "Negative Score is {0}", score);
+        logger.LogTrace(RefreshContext.CoolLevels, "Negative Score is {0}", score);
         return -score;
     }
 }

--- a/Refresh.sln.DotSettings
+++ b/Refresh.sln.DotSettings
@@ -40,6 +40,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ingame/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inmemory/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=jvyden/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lbpcool/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LITTLEBIGPLANETPS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lolcatftw/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mmpicks/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Closes #250

This PR implements the algorithm described in #250, with the exception of decay factor which now applies to negative score. The multiplier is multiplied by 2 to make decay half as effective towards negative score.

This also introduces the relevant category in `CategoryService`, adds a `float Score` field to `GameLevel`s, and makes the field accessible to the API.

This system is written to be tweakable and expandable later down the line, although I have fiddled with the defaults already to make them reasonable. I haven't properly messed with logarithmic scaling as I wasn't able to get good results, but I think this can be addressed later down the line.