### PR TITLE
Track more asset metadata

### DIFF
--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -18,7 +18,7 @@ internal class CommandLineManager
     private class Options
     {
         [Option('i', "import_assets", Required = false, 
-            HelpText = "Re-import all assets from the datastore into the database. This is a destructive action, only use when upgrading to <=v1.5.0")]
+            HelpText = "Re-import all assets from the datastore into the database.")]
         public bool ImportAssets { get; set; }
         
         [Option('I', "import_images", Required = false, HelpText = "Convert all images in the database to .PNGs. Otherwise, images will be converted as they are used")]

--- a/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
@@ -18,15 +18,9 @@ public partial class GameDatabaseContext // AssetConfiguration
             this._realm.Add(asset);
         });
 
-    public void AddAssetsToDatabase(IEnumerable<GameAsset> assets) =>
+    public void AddOrUpdateAssetsInDatabase(IEnumerable<GameAsset> assets) =>
         this._realm.Write(() =>
         {
-            this._realm.Add(assets);
-        });
-
-    public void DeleteAllAssetMetadata() =>
-        this._realm.Write(() =>
-        {
-            this._realm.RemoveAll<GameAsset>();
+            this._realm.Add(assets, true);
         });
 }

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -32,7 +32,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 97;
+    protected override ulong SchemaVersion => 98;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -32,7 +32,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 98;
+    protected override ulong SchemaVersion => 99;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameAssetResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameAssetResponse.cs
@@ -9,6 +9,7 @@ public class ApiGameAssetResponse : IApiResponse, IDataConvertableFrom<ApiGameAs
     public required ApiGameUserResponse? OriginalUploader { get; set; }
     public required DateTimeOffset UploadDate { get; set; }
     public required GameAssetType AssetType { get; set; }
+    public required IEnumerable<string> Dependencies { get; set; }
     
     public static ApiGameAssetResponse? FromOld(GameAsset? old)
     {
@@ -20,6 +21,7 @@ public class ApiGameAssetResponse : IApiResponse, IDataConvertableFrom<ApiGameAs
             OriginalUploader = ApiGameUserResponse.FromOld(old.OriginalUploader),
             UploadDate = old.UploadDate,
             AssetType = old.AssetType,
+            Dependencies = old.Dependencies,
         };
     }
 

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -69,7 +69,7 @@ public class LevelEndpoints : EndpointGroup
         return this.GetLevels(context, database, categories, matchService, overrideService, user, token, route);
     }
 
-    [GameEndpoint("s/user/{id}", ContentType.Xml), Authentication(false)]
+    [GameEndpoint("s/user/{id}", ContentType.Xml)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
     public GameLevelResponse? LevelById(RequestContext context, GameDatabaseContext database, MatchService matchService, GameUser user, int id)

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -69,7 +69,7 @@ public class LevelEndpoints : EndpointGroup
         return this.GetLevels(context, database, categories, matchService, overrideService, user, token, route);
     }
 
-    [GameEndpoint("s/user/{id}", ContentType.Xml)]
+    [GameEndpoint("s/user/{id}", ContentType.Xml), Authentication(false)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
     public GameLevelResponse? LevelById(RequestContext context, GameDatabaseContext database, MatchService matchService, GameUser user, int id)

--- a/Refresh.GameServer/Extensions/GameAssetExtensions.cs
+++ b/Refresh.GameServer/Extensions/GameAssetExtensions.cs
@@ -1,0 +1,19 @@
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Assets;
+
+namespace Refresh.GameServer.Extensions;
+
+public static class GameAssetExtensions
+{
+    public static void TraverseDependenciesRecursively(this GameAsset asset, GameDatabaseContext database, Action<string, GameAsset?> callback)
+    {
+        callback(asset.AssetHash, asset);
+        foreach (string internalAssetHash in asset.Dependencies)
+        {
+            GameAsset? internalAsset = database.GetAssetFromHash(internalAssetHash);
+            callback(internalAssetHash, internalAsset);
+
+            internalAsset?.TraverseDependenciesRecursively(database, callback);
+        }
+    }
+}

--- a/Refresh.GameServer/Importing/AssetImporter.cs
+++ b/Refresh.GameServer/Importing/AssetImporter.cs
@@ -19,54 +19,48 @@ public class AssetImporter : Importer
         this._timeProvider = timeProvider;
     }
 
-    public void ImportFromDataStoreCli(GameDatabaseContext context, IDataStore dataStore)
+    public void ImportFromDataStore(GameDatabaseContext database, IDataStore dataStore)
     {
-        Console.WriteLine("This tool will scan and manually import existing assets into Refresh's database.");
-        Console.WriteLine("This will wipe all existing asset metadata in the database. Are you sure you want to follow through with this operation?");
-        Console.WriteLine();
-        Console.Write("Are you sure? [y/N] ");
-        
-        char key = char.ToLower(Console.ReadKey().KeyChar);
-        Console.WriteLine();
-        if(key != 'y')
-        {
-            if(key != 'n') Console.WriteLine("Unsure what you mean, assuming no.");
-            Environment.Exit(0);
-            return;
-        }
-        
-        this.ImportFromDataStore(context, dataStore);
-    }
-
-    public void ImportFromDataStore(GameDatabaseContext context, IDataStore dataStore)
-    {
+        int updatedAssets = 0;
+        int newAssets = 0;
         this.Stopwatch.Start();
         
-        context.DeleteAllAssetMetadata();
-        this.Info("Deleted all asset metadata");
-        
-        List<string> assetHashes = dataStore.GetKeysFromStore()
-            .Where(key => !key.Contains('/'))
-            .ToList();
+        IEnumerable<string> assetHashes = dataStore.GetKeysFromStore()
+            .Where(key => !key.Contains('/'));
 
         List<GameAsset> assets = new();
         foreach (string hash in assetHashes)
         {
             byte[] data = dataStore.GetDataFromStore(hash);
             
-            GameAsset? asset = this.ReadAndVerifyAsset(hash, data, null);
-            if (asset == null) continue;
+            GameAsset? newAsset = this.ReadAndVerifyAsset(hash, data, null);
+            if (newAsset == null) continue;
 
-            assets.Add(asset);
-            this.Info($"Processed {asset.AssetType} asset {hash} ({AssetSafetyLevelExtensions.FromAssetType(asset.AssetType)})");
+            GameAsset? oldAsset = database.GetAssetFromHash(hash);
+
+            if (oldAsset != null)
+            {
+                newAsset.OriginalUploader = oldAsset.OriginalUploader;
+                newAsset.UploadDate = oldAsset.UploadDate;
+                updatedAssets++;
+            }
+            else
+            {
+                newAssets++;
+            }
+
+            assets.Add(newAsset);
+            this.Info($"Processed {newAsset.AssetType} asset {hash} ({AssetSafetyLevelExtensions.FromAssetType(newAsset.AssetType)})");
         }
         
-        context.AddAssetsToDatabase(assets);
+        database.AddOrUpdateAssetsInDatabase(assets);
+
+        int hashCount = assetHashes.Count();
         
-        this.Info($"Successfully imported {assets.Count}/{assetHashes.Count} assets into database");
-        if (assets.Count < assetHashes.Count)
+        this.Info($"Successfully imported {assets.Count}/{hashCount} assets ({newAssets} new, {updatedAssets} updated) into database");
+        if (assets.Count < hashCount)
         {
-            this.Warn($"{assetHashes.Count - assets.Count} assets were not imported");
+            this.Warn($"{hashCount - assets.Count} assets were not imported");
         }
     }
 
@@ -90,6 +84,7 @@ public class AssetImporter : Importer
             AssetHash = hash,
             AssetType = this.DetermineAssetType(data, platform),
             IsPSP = platform == TokenPlatform.PSP,
+            SizeInBytes = data.Length,
         };
 
         return asset;

--- a/Refresh.GameServer/Importing/AssetImporter.cs
+++ b/Refresh.GameServer/Importing/AssetImporter.cs
@@ -63,18 +63,31 @@ public class AssetImporter : Importer
             this.Warn($"{hashCount - assets.Count} assets were not imported");
         }
     }
-
-    private static string GetHashOfShaBytes(byte[] data)
+    
+    private static string BytesToHexString(ReadOnlySpan<byte> data)
     {
-        return BitConverter.ToString(data)
-            .Replace("-", "")
-            .ToLower();
+        Span<char> hexChars = stackalloc char[data.Length * 2];
+
+        for (int i = 0; i < data.Length; i++)
+        {
+            byte b = data[i];
+            hexChars[i * 2] = GetHexChar(b >> 4); // High bits
+            hexChars[i * 2 + 1] = GetHexChar(b & 0x0F); // Low bits
+        }
+
+        return new string(hexChars);
+
+        static char GetHexChar(int value)
+        {
+            return (char)(value < 10 ? '0' + value : 'a' + value - 10);
+        }
     }
+
 
     [Pure]
     public GameAsset? ReadAndVerifyAsset(string hash, byte[] data, TokenPlatform? platform)
     {
-        string checkedHash = GetHashOfShaBytes(SHA1.HashData(data));
+        string checkedHash = BytesToHexString(SHA1.HashData(data));
 
         if (checkedHash != hash)
         {
@@ -147,13 +160,15 @@ public class AssetImporter : Importer
         uint dependencyCount = reader.ReadUInt32();
 
         this.Debug($"Dependency count offset: {dependencyTableOffset}, count: {dependencyCount}");
+
+        Span<byte> hashBuffer = stackalloc byte[20];
         for (int i = 0; i < dependencyCount; i++)
         {
             byte flags = reader.ReadByte();
             if ((flags & 0x1) != 0) // UGC/SHA1
             {
-                byte[] hashBytes = reader.ReadBytes(20);
-                dependencies.Add(GetHashOfShaBytes(hashBytes));
+                ms.ReadExactly(hashBuffer);
+                dependencies.Add(BytesToHexString(hashBuffer));
             }
             else if ((flags & 0x2) != 0) reader.ReadUInt32(); // Skip GUID
                 

--- a/Refresh.GameServer/Importing/Importer.cs
+++ b/Refresh.GameServer/Importing/Importer.cs
@@ -36,6 +36,11 @@ public abstract class Importer
     {
         this._logger.LogWarning(BunkumCategory.UserContent, $"[{this.Stopwatch.ElapsedMilliseconds}ms] {message}");
     }
+
+    protected void Debug(string message)
+    {
+        this._logger.LogDebug(BunkumCategory.UserContent, $"[{this.Stopwatch.ElapsedMilliseconds}ms] {message}");
+    }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool MatchesMagic(ReadOnlySpan<byte> data, ReadOnlySpan<byte> magic)

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -216,14 +216,7 @@ public class RefreshGameServer : IDisposable
         using GameDatabaseContext context = this.InitializeDatabase();
         
         AssetImporter importer = new();
-        if (!force)
-        {
-            importer.ImportFromDataStoreCli(context, this._dataStore);
-        }
-        else
-        {
-            importer.ImportFromDataStore(context, this._dataStore);
-        }
+        importer.ImportFromDataStore(context, this._dataStore);
     }
 
     public void ImportImages()

--- a/Refresh.GameServer/Types/Assets/GameAsset.cs
+++ b/Refresh.GameServer/Types/Assets/GameAsset.cs
@@ -3,14 +3,14 @@ using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Assets;
 
-[JsonObject(MemberSerialization.OptIn)]
 public partial class GameAsset : IRealmObject
 {
-    [PrimaryKey] [JsonProperty] public string AssetHash { get; set; } = string.Empty;
-    [JsonProperty] public GameUser? OriginalUploader { get; set; }
-    [JsonProperty] public DateTimeOffset UploadDate { get; set; }
-    [JsonProperty] public bool IsPSP { get; set; }
-    [JsonProperty] [Ignored] public GameAssetType AssetType
+    [PrimaryKey] public string AssetHash { get; set; } = string.Empty;
+    public GameUser? OriginalUploader { get; set; }
+    public DateTimeOffset UploadDate { get; set; }
+    public bool IsPSP { get; set; }
+    public int SizeInBytes { get; set; }
+    [Ignored] public GameAssetType AssetType
     {
         get => (GameAssetType)this._AssetType;
         set => this._AssetType = (int)value;
@@ -19,7 +19,7 @@ public partial class GameAsset : IRealmObject
     // ReSharper disable once InconsistentNaming
     internal int _AssetType { get; set; }
 
-    [JsonProperty] public IList<GameAsset> Dependencies { get; } = null!;
+    public IList<GameAsset> Dependencies { get; } = null!;
 
-    [JsonProperty] [Ignored] public AssetSafetyLevel SafetyLevel => AssetSafetyLevelExtensions.FromAssetType(this.AssetType);
+    [Ignored] public AssetSafetyLevel SafetyLevel => AssetSafetyLevelExtensions.FromAssetType(this.AssetType);
 }

--- a/Refresh.GameServer/Types/Assets/GameAsset.cs
+++ b/Refresh.GameServer/Types/Assets/GameAsset.cs
@@ -1,4 +1,5 @@
 using Realms;
+using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Assets;

--- a/Refresh.GameServer/Types/Assets/GameAsset.cs
+++ b/Refresh.GameServer/Types/Assets/GameAsset.cs
@@ -19,7 +19,7 @@ public partial class GameAsset : IRealmObject
     // ReSharper disable once InconsistentNaming
     internal int _AssetType { get; set; }
 
-    public IList<GameAsset> Dependencies { get; } = null!;
+    public IList<string> Dependencies { get; } = null!;
 
     [Ignored] public AssetSafetyLevel SafetyLevel => AssetSafetyLevelExtensions.FromAssetType(this.AssetType);
 }


### PR DESCRIPTION
Closes #24 and closes #66

This PR implements support for parsing the dependency tree in binary game assets, and records the size of all assets.

