### PR TITLE
Add test coverage for grief reports

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Reports.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Reports.cs
@@ -7,5 +7,10 @@ public partial class GameDatabaseContext
     public void AddGriefReport(GameReport report) 
     {
         this.AddSequentialObject(report, () => {});
-    }    
+    }
+
+    public DatabaseList<GameReport> GetGriefReports(int count, int skip)
+    {
+        return new DatabaseList<GameReport>(this._realm.All<GameReport>(), skip, count);
+    }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -237,6 +237,14 @@ public partial class GameDatabaseContext // Users
             user.VitaPlanetsHash = "0";
         });
     }
+
+    public void SetUserGriefReportRedirection(GameUser user, bool value)
+    {
+        this._realm.Write(() =>
+        {
+            user.RedirectGriefReportsToPhotos = value;
+        });
+    }
     
     #if DEBUG
     public void ForceUserTokenGame(Token token, TokenGame game)

--- a/Refresh.GameServer/Endpoints/Game/ModerationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ModerationEndpoints.cs
@@ -64,8 +64,9 @@ public class ModerationEndpoints : EndpointGroup
                 commandService.HandleCommand(command, database, user, token);
                 return "(Command)";
             }
-            catch
+            catch(Exception ex)
             {
+                context.Logger.LogWarning(BunkumCategory.Commands, $"Error running command {body}. ex {ex}");
                 //do nothing
             } 
         }

--- a/Refresh.GameServer/Endpoints/Game/ReportingEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ReportingEndpoints.cs
@@ -21,15 +21,26 @@ public class ReportingEndpoints : EndpointGroup
     {
         GameLevel? level = database.GetLevelById(body.LevelId);
 
-        Size imageSize = token.TokenGame switch {
-            TokenGame.LittleBigPlanet1 => new Size(640, 360),
-            TokenGame.LittleBigPlanet2 => new Size(640, 360),
-            TokenGame.LittleBigPlanet3 => new Size(640, 360),
-            TokenGame.LittleBigPlanetVita => new Size(512, 290),
-            TokenGame.LittleBigPlanetPSP => new Size(480, 272),
-            _ => throw new ArgumentOutOfRangeException(nameof(token), $"Token game {token.TokenGame} is not allowed for grief upload!"),
-        };
-        
+        Size imageSize;
+        switch (token.TokenGame)
+        {
+            case TokenGame.LittleBigPlanet1:
+            case TokenGame.LittleBigPlanet2:
+            case TokenGame.LittleBigPlanet3:
+                imageSize = new Size(640, 360);
+                break;
+            case TokenGame.LittleBigPlanetVita:
+                imageSize = new Size(512, 290);
+                break;
+            case TokenGame.LittleBigPlanetPSP:
+                imageSize = new Size(480, 272);
+                break;
+            case TokenGame.Website:
+            default:
+                context.Logger.LogWarning(BunkumCategory.Game, $"User {user} tried to upload grief report with token type {token.TokenGame}!");
+                return BadRequest;
+        }
+
         //If the level is specified but its invalid, return BadRequest
         if (body.LevelId != 0 && level == null)
             return BadRequest;

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -106,12 +106,12 @@ public class CommandService : EndpointService
             }
             case "griefphotoson":
             {
-                user.RedirectGriefReportsToPhotos = true;
+                database.SetUserGriefReportRedirection(user, true);
                 break;
             }
             case "griefphotosoff":
             {
-                user.RedirectGriefReportsToPhotos = false;
+                database.SetUserGriefReportRedirection(user, false);
                 break;
             }
             case "play":

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -37,6 +37,13 @@ public class TestContext : IDisposable
     {
         return this.GetAuthenticatedClient(type, out _, user, tokenExpirySeconds);
     }
+    
+    public HttpClient GetAuthenticatedClient(TokenType type, TokenGame game, TokenPlatform platform,
+        GameUser? user = null,
+        int tokenExpirySeconds = GameDatabaseContext.DefaultTokenExpirySeconds)
+    {
+        return this.GetAuthenticatedClient(type, game, platform, out _, user, tokenExpirySeconds);
+    }
 
     public HttpClient GetAuthenticatedClient(TokenType type, out string tokenData,
         GameUser? user = null,
@@ -55,6 +62,15 @@ public class TestContext : IDisposable
             TokenType.Game => TokenPlatform.PS3,
             _ => TokenPlatform.Website,
         };
+
+        return this.GetAuthenticatedClient(type, game, platform, out tokenData, user, tokenExpirySeconds);
+    }
+    
+    public HttpClient GetAuthenticatedClient(TokenType type, TokenGame game, TokenPlatform platform, out string tokenData,
+        GameUser? user = null,
+        int tokenExpirySeconds = GameDatabaseContext.DefaultTokenExpirySeconds)
+    {
+        user ??= this.CreateUser();
 
         Token token = this.Database.GenerateTokenForUser(user, type, game, platform, tokenExpirySeconds);
         tokenData = token.TokenData;

--- a/RefreshTests.GameServer/Tests/Reporting/ReportingEndpointsTests.cs
+++ b/RefreshTests.GameServer/Tests/Reporting/ReportingEndpointsTests.cs
@@ -1,0 +1,18 @@
+using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.UserData;
+
+namespace RefreshTests.GameServer.Tests.Reporting;
+
+public class ReportingEndpointsTests : GameServerTest
+{
+    [Test]
+    public void UploadReport()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user);
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
+    }
+}

--- a/RefreshTests.GameServer/Tests/Reporting/ReportingEndpointsTests.cs
+++ b/RefreshTests.GameServer/Tests/Reporting/ReportingEndpointsTests.cs
@@ -1,6 +1,9 @@
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.Report;
 using Refresh.GameServer.Types.UserData;
+using RefreshTests.GameServer.Extensions;
 
 namespace RefreshTests.GameServer.Tests.Reporting;
 
@@ -13,6 +16,170 @@ public class ReportingEndpointsTests : GameServerTest
         GameUser user = context.CreateUser();
         GameLevel level = context.CreateLevel(user);
 
-        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, user);
+
+        GameReport report = new()
+        {
+            InfoBubble = new InfoBubble[]
+                {},
+            Type = GriefReportType.Obscene,
+            Marqee = new Marqee
+            {
+                Rect = new Rect
+                {
+                    Top = 10,
+                    Left = 10,
+                    Bottom = 20,
+                    Right = 20,
+                },
+            },
+            LevelOwner = level.Publisher!.Username,
+            InitialStateHash = null,
+            LevelType = "user",
+            LevelId = level.LevelId,
+            Description = "This is a description, sent by LBP3",
+            GriefStateHash = null,
+            JpegHash = null,
+            Players = new Player[]
+            {
+                new()
+                {
+                    Username = user.Username,
+                    Rectangle = new Rect
+                    {
+                        Top = 10,
+                        Left = 10,
+                        Bottom = 20,
+                        Right = 20,
+                    },
+                    Reporter = true,
+                    IngameNow = true,
+                    PlayerNumber = 0,
+                    Text = "Some text",
+                    ScreenRect = new ScreenRect
+                    {
+                        Rect = new Rect
+                        {
+                            Top = 10,
+                            Left = 10,
+                            Bottom = 20,
+                            Right = 20,
+                        },
+                    },
+                },
+            },
+            ScreenElements = new ScreenElements(),
+        };
+        
+        HttpResponseMessage response = client.PostAsync("/lbp/grief", new StringContent(report.AsXML())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(OK));
+
+        context.Database.Refresh();
+
+        DatabaseList<GameReport> griefReports = context.Database.GetGriefReports(10, 0);
+        Assert.That(griefReports.TotalItems, Is.EqualTo(1));
+        List<GameReport> reports = griefReports.Items.ToList();
+        Assert.That(reports[0].Description, Is.EqualTo(report.Description));
+        Assert.That(reports[0].LevelId, Is.EqualTo(report.LevelId));
+    }
+    
+    [Test]
+    public void CantUploadReportWithBadLevel()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, user);
+
+        GameReport report = new()
+        {
+            LevelId = int.MaxValue,
+        };
+        
+        HttpResponseMessage response = client.PostAsync("/lbp/grief", new StringContent(report.AsXML())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(BadRequest));
+    }
+    
+    [Test]
+    public void CantUploadReportWithBadPlayerCount()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, user);
+
+        GameReport report = new()
+        {
+            LevelId = 0,
+            Players = new Player[]
+            {
+                new()
+                {
+                    Username = "hee",
+                },
+                new()
+                {
+                    Username = "haw",
+                },
+                new()
+                {
+                    Username = "ham",
+                },
+                new()
+                {
+                    Username = "burg",
+                },
+                new()
+                {
+                    Username = "er",
+                },
+            },
+        };
+        
+        HttpResponseMessage response = client.PostAsync("/lbp/grief", new StringContent(report.AsXML())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(BadRequest));
+    }
+    
+    [Test]
+    public void CantUploadReportWithBadScreenElementPlayerCount()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, user);
+
+        GameReport report = new()
+        {
+            LevelId = 0,
+            ScreenElements = new ScreenElements
+            {
+                Player = new Player[]
+                {
+                    new()
+                    {
+                        Username = "hee",
+                    },
+                    new()
+                    {
+                        Username = "haw",
+                    },
+                    new()
+                    {
+                        Username = "ham",
+                    },
+                    new()
+                    {
+                        Username = "burg",
+                    },
+                    new()
+                    {
+                        Username = "er",
+                    },
+                },
+            },
+        };
+        
+        HttpResponseMessage response = client.PostAsync("/lbp/grief", new StringContent(report.AsXML())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(BadRequest));
     }
 }

--- a/RefreshTests.GameServer/Tests/Reporting/ReportingEndpointsTests.cs
+++ b/RefreshTests.GameServer/Tests/Reporting/ReportingEndpointsTests.cs
@@ -1,6 +1,7 @@
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.Photos;
 using Refresh.GameServer.Types.Report;
 using Refresh.GameServer.Types.UserData;
 using RefreshTests.GameServer.Extensions;
@@ -180,6 +181,130 @@ public class ReportingEndpointsTests : GameServerTest
         };
         
         HttpResponseMessage response = client.PostAsync("/lbp/grief", new StringContent(report.AsXML())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(BadRequest));
+    }
+
+    [TestCase(TokenGame.LittleBigPlanet1)]
+    [TestCase(TokenGame.LittleBigPlanet2)]
+    [TestCase(TokenGame.LittleBigPlanet3)]
+    [TestCase(TokenGame.LittleBigPlanetVita)]
+    [TestCase(TokenGame.LittleBigPlanetPSP)]
+    public void RedirectGriefReportToPhoto(TokenGame game)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user);
+        
+        //Enable the grief report re-direction
+        context.Database.SetUserGriefReportRedirection(user, true);
+        context.Database.Refresh();
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, game, TokenPlatform.PS3, user);
+
+        HttpResponseMessage response = client.PostAsync("/lbp/grief", new StringContent(new GameReport
+        {
+            Players = new Player[]
+            {
+                new()
+                {
+                    Username = user.Username,
+                    Rectangle = new Rect
+                    {
+                        Top = 10,
+                        Left = 10,
+                        Bottom = 20,
+                        Right = 20,
+                    },
+                },
+            },
+            LevelId = level.LevelId,
+        }.AsXML())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(OK));
+        
+        context.Database.Refresh();
+
+        DatabaseList<GamePhoto> photos = context.Database.GetPhotosByUser(user, 10, 0);
+        Assert.That(photos.TotalItems, Is.EqualTo(1));
+
+        GamePhoto photo = photos.Items.First();
+        Assert.That(photo.Publisher.UserId, Is.EqualTo(user.UserId));
+    }
+    
+    [TestCase(TokenGame.LittleBigPlanet1)]
+    [TestCase(TokenGame.LittleBigPlanet2)]
+    [TestCase(TokenGame.LittleBigPlanet3)]
+    [TestCase(TokenGame.LittleBigPlanetVita)]
+    [TestCase(TokenGame.LittleBigPlanetPSP)]
+    public void RedirectGriefReportToPhotoDeveloperLevel(TokenGame game)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameLevel level = context.Database.GetStoryLevelById(100000);
+        
+        //Enable the grief report re-direction
+        context.Database.SetUserGriefReportRedirection(user, true);
+        context.Database.Refresh();
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, game, TokenPlatform.PS3, user);
+
+        HttpResponseMessage response = client.PostAsync("/lbp/grief", new StringContent(new GameReport
+        {
+            Players = new Player[]
+            {
+                new()
+                {
+                    Username = user.Username,
+                    Rectangle = new Rect
+                    {
+                        Top = 10,
+                        Left = 10,
+                        Bottom = 20,
+                        Right = 20,
+                    },
+                },
+            },
+            LevelId = level.LevelId,
+        }.AsXML())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(OK));
+        
+        context.Database.Refresh();
+
+        DatabaseList<GamePhoto> photos = context.Database.GetPhotosByUser(user, 10, 0);
+        Assert.That(photos.TotalItems, Is.EqualTo(1));
+
+        GamePhoto photo = photos.Items.First();
+        Assert.That(photo.Publisher.UserId, Is.EqualTo(user.UserId));
+    }
+    
+    [Test]
+    public void CantRedirectGriefReportToPhotoWhenWebsiteToken()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        
+        //Enable the grief report re-direction
+        context.Database.SetUserGriefReportRedirection(user, true);
+        context.Database.Refresh();
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.Website, TokenPlatform.PS3, user);
+
+        HttpResponseMessage response = client.PostAsync("/lbp/grief", new StringContent(new GameReport
+        {
+            Players = new Player[]
+            {
+                new()
+                {
+                    Username = user.Username,
+                    Rectangle = new Rect
+                    {
+                        Top = 10,
+                        Left = 10,
+                        Bottom = 20,
+                        Right = 20,
+                    },
+                },
+            },
+        }.AsXML())).Result;
         Assert.That(response.StatusCode, Is.EqualTo(BadRequest));
     }
 }


### PR DESCRIPTION
Not 100% due to unreachable switch cases, disabling those would require adding ugly #pragma lines, so i didnt bother