### PR TITLE
ReportingEndpoints: Dont error on invalid level + dont return error on PSP

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/ReportingEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ReportingEndpoints.cs
@@ -83,13 +83,15 @@ public class ReportingEndpoints : EndpointGroup
             return OK;
         }
         
-        //If the level is specified but its invalid, return BadRequest
+        //If the level is specified but its invalid, set it to 0, to indicate the level is unknown
+        //This case is hit when someone makes a grief report from a non-existent level, which we allow
         if (body.LevelId != 0 && level == null)
-            return BadRequest;
+            body.LevelId = 0;
         
         //Basic validation
         if (body.Players is { Length: > 4 } || body.ScreenElements is { Player.Length: > 4 })
-            return BadRequest;
+            //Return OK on PSP, since if we dont, it will error when trying to access the community moon and soft-lock the save file
+            return context.IsPSP() ? OK : BadRequest;
 
         database.AddGriefReport(body);
         


### PR DESCRIPTION
More PSP weirdness + allow grief reports on missing levels, just incase some weirdness happens, like a level is deleted after creation, and someone happened to start playing it, and you want to grief report a player in your game or something, unlikely, but we probably should allow it anyway