### PR TITLE
LevelFilterSettings: LBP3 sometimes sends `dontCare`

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/Levels/FilterSettings/LevelFilterSettings.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/FilterSettings/LevelFilterSettings.cs
@@ -98,6 +98,7 @@ public class LevelFilterSettings
                 "true" => MoveFilterType.True,
                 "false" => MoveFilterType.False,
                 "only" => MoveFilterType.Only,
+                "dontCare" => MoveFilterType.True,
                 _ => throw new ArgumentOutOfRangeException(),
             };
 


### PR DESCRIPTION
Right now we return a 500 InternalServerError, which crashes the game and the console.

Whoops!