### PR TITLE
Modernize dockerfile, add CI job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['main']
+    tags: ["*"]
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step below will fill in things like name, description, etc. from the repository.
+      # It's helpful for us because it also fills in the version information automatically depending on how the job was invoked.
+      # See https://github.com/docker/metadata-action#basic
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ghcr.io/refresh
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM mcr.microsoft.com/dotnet/sdk:7.0.400-bookworm-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.100-1-bookworm-slim AS build
 WORKDIR /build
 
 COPY *.sln ./
@@ -11,7 +11,8 @@ RUN dotnet sln list | grep ".csproj" \
     mv $(basename $line) $(dirname $line); \
     done;
 
-RUN dotnet restore --use-current-runtime
+# FIXME: .NET 8 started being dumb and requiring a runtime identifier for restores. This breaks non-amd64 caching. 
+RUN dotnet restore --use-current-runtime -r linux-x64
 
 COPY . .
 
@@ -19,7 +20,7 @@ RUN dotnet publish Refresh.GameServer -c Release --property:OutputPath=/build/pu
 
 # Final running container
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0.10-bookworm-slim AS final
+FROM mcr.microsoft.com/dotnet/runtime:8.0.0-bookworm-slim AS final
 
 # Add non-root user
 RUN set -eux && \


### PR DESCRIPTION
CI job is untested, also portability is broken at the moment due to changes in `dotnet restore`.