### PR TITLE
GameDatabaseContext: Dont check whether user has played level during rate on PSP

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -181,7 +181,7 @@ public partial class GameDatabaseContext // Relations
     public bool RateLevel(GameLevel level, GameUser user, RatingType type)
     {
         if (level.Publisher?.UserId == user.UserId) return false;
-        if (!this.HasUserPlayedLevel(level, user)) return false;
+        if (level.GameVersion != TokenGame.LittleBigPlanetPSP && !this.HasUserPlayedLevel(level, user)) return false;
         
         RateLevelRelation? rating = this.GetRateRelationByUser(level, user);
         


### PR DESCRIPTION
LBP PSP sends the rate level request before the play level request, making this check fail.