### PR TITLE
Make RandomLevelsCategory use seed from game

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -192,12 +192,16 @@ public partial class GameDatabaseContext // Levels
             .OrderByDescending(l => l.PublishDate), skip, count);
     
     [Pure]
-    public DatabaseList<GameLevel> GetRandomLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings) =>
-        new(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+    public DatabaseList<GameLevel> GetRandomLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings)
+    {
+        Random random = new(levelFilterSettings.Seed ?? 0);
+        
+        return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
             .FilterByLevelFilterSettings(user, levelFilterSettings)
             .AsEnumerable()
-            .OrderBy(_ => Random.Shared.Next()), skip, count);
-    
+            .OrderBy(_ => random.Next()), skip, count);
+    }
+
     // TODO: reduce code duplication for getting most of x
     [Pure]
     public DatabaseList<GameLevel> GetMostHeartedLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings)

--- a/Refresh.GameServer/Endpoints/Game/Levels/FilterSettings/LevelFilterSettings.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/FilterSettings/LevelFilterSettings.cs
@@ -2,6 +2,7 @@ using Bunkum.Core;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Levels.Categories;
 
 namespace Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 
@@ -44,6 +45,12 @@ public class LevelFilterSettings
     /// The game of the request, eg. to prevent LBP3 levels from appearing on LBP2 or LBP1
     /// </summary>
     public TokenGame GameVersion;
+
+    /// <summary>
+    /// The seed used for lucky dip/random levels.
+    /// </summary>
+    /// <seealso cref="RandomLevelsCategory"/>
+    public int? Seed;
 
     public LevelFilterSettings(TokenGame game)
     {
@@ -125,6 +132,12 @@ public class LevelFilterSettings
         {
             this.Labels ??= new string[1];
             this.Labels[0] = labelFilter0;
+        }
+
+        string? seedStr = context.QueryString.Get("seed");
+        if (seedStr != null && int.TryParse(seedStr, out int seed))
+        {
+            this.Seed = seed;
         }
     }
 }


### PR DESCRIPTION
Closes #122

# Why
Previously, we were using a globally shared instance of `Random` when calculating the random order of levels. This caused levels to appear multiple times in the list and caused others to get potentially missed entirely.

By using a consistent seed we can negate both of those problems and ensure the full list gets hit consistently.

# How
To fix, introduce the client's `seed` parameter as an available parameter to use in the filter settings. We can then use this to create a new `Random` object on each call of `GetRandomLevel()` with the new seed.

# Remarks
This will require a change in `refresh-web` to make the website generate a random seed, since if we do not find a seed value server-side we simply use `0`.