### PR TITLE
Simple validation for ScoreType when submitting scores

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
@@ -117,8 +117,15 @@ public class LeaderboardEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return NotFound;
 
-        //Validate the score is a non-negative amount
+        // Validate the score is a non-negative amount
         if (body.Score < 0)
+        {
+            return BadRequest;
+        }
+        
+        // Ensure score type is valid
+        // Only valid values are 1-4 players and 7 for versus
+        if (body.ScoreType is (> 4 or < 1) and not 7)
         {
             return BadRequest;
         }


### PR DESCRIPTION
Closes #142

# Why
Currently, Refresh does not validate the ScoreType (aka the game mode or player count) when submitting scores. This isn't too big of a deal since the game only checks certain score types, but it's quite trivial to protect against so we might as well.

# How
To do this, we simply validate whether the score type is either between 1-4 players in co-op mode or 7 for versus mode.

# Remarks
We *could* do some further validation, checking the level's version and type but I think this is enough to stop most abuse.