### PR TITLE
Track the platform scores were achieved on

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
@@ -1,3 +1,4 @@
+using IronCompress;
 using JetBrains.Annotations;
 using MongoDB.Bson;
 using Refresh.GameServer.Authentication;
@@ -9,7 +10,10 @@ namespace Refresh.GameServer.Database;
 
 public partial class GameDatabaseContext // Leaderboard
 {
-    public GameSubmittedScore SubmitScore(SerializedScore score, GameUser user, GameLevel level, TokenGame game)
+    public GameSubmittedScore SubmitScore(SerializedScore score, Token token, GameLevel level)
+        => this.SubmitScore(score, token.User, level, token.TokenGame, token.TokenPlatform);
+
+    public GameSubmittedScore SubmitScore(SerializedScore score, GameUser user, GameLevel level, TokenGame game, TokenPlatform platform)
     {
         GameSubmittedScore newScore = new()
         {
@@ -19,6 +23,7 @@ public partial class GameDatabaseContext // Leaderboard
             Players = { user },
             ScoreSubmitted = this._time.Now,
             Game = game,
+            Platform = platform,
         };
 
         this._realm.Write(() =>

--- a/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
@@ -1,4 +1,3 @@
-using IronCompress;
 using JetBrains.Annotations;
 using MongoDB.Bson;
 using Refresh.GameServer.Authentication;

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -32,7 +32,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 103;
+    protected override ulong SchemaVersion => 104;
 
     protected override string Filename => "refreshGameServer.realm";
     
@@ -343,6 +343,24 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
             if (oldVersion < 92)
             {
                 newScore.Game = newScore.Level.GameVersion;
+            }
+
+            // In version 104 we started tracking the platform
+            if (oldVersion < 104)
+            {
+                // Determine the most reasonable platform for the score's game
+                TokenPlatform platform = newScore.Game switch
+                {
+                    TokenGame.LittleBigPlanet1 => TokenPlatform.PS3,
+                    TokenGame.LittleBigPlanet2 => TokenPlatform.PS3,
+                    TokenGame.LittleBigPlanet3 => TokenPlatform.PS3,
+                    TokenGame.LittleBigPlanetVita => TokenPlatform.Vita,
+                    TokenGame.LittleBigPlanetPSP => TokenPlatform.PSP,
+                    TokenGame.Website => throw new InvalidOperationException($"what? score id {newScore.ScoreId} by {newScore.Players[0].Username} is fucked"),
+                    _ => throw new ArgumentOutOfRangeException(),
+                };
+
+                newScore.Platform = platform;
             }
         }
         

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameScoreResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameScoreResponse.cs
@@ -1,3 +1,4 @@
+using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Types.UserData.Leaderboard;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -12,6 +13,9 @@ public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameSc
     public required int Score { get; set; }
     public required byte ScoreType { get; set; }
     
+    public required TokenGame Game { get; set; }
+    public required TokenPlatform Platform { get; set; }
+    
     public static ApiGameScoreResponse? FromOld(GameSubmittedScore? old)
     {
         if (old == null) return null;
@@ -24,6 +28,8 @@ public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameSc
             ScoreSubmitted = old.ScoreSubmitted,
             Score = old.Score,
             ScoreType = old.ScoreType,
+            Game = old.Game,
+            Platform = old.Platform,
         };
     }
 

--- a/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
@@ -89,7 +89,7 @@ public class LeaderboardEndpoints : EndpointGroup
             return BadRequest;
         }
 
-        GameSubmittedScore score = database.SubmitScore(body, user, level, token.TokenGame);
+        GameSubmittedScore score = database.SubmitScore(body, token, level);
 
         IEnumerable<ScoreWithRank>? scores = database.GetRankedScoresAroundScore(score, 5);
         Debug.Assert(scores != null);
@@ -130,7 +130,7 @@ public class LeaderboardEndpoints : EndpointGroup
             return BadRequest;
         }
 
-        GameSubmittedScore score = database.SubmitScore(body, user, level, token.TokenGame);
+        GameSubmittedScore score = database.SubmitScore(body, token, level);
 
         IEnumerable<ScoreWithRank>? scores = database.GetRankedScoresAroundScore(score, 5);
         Debug.Assert(scores != null);

--- a/Refresh.GameServer/Types/UserData/Leaderboard/GameSubmittedScore.cs
+++ b/Refresh.GameServer/Types/UserData/Leaderboard/GameSubmittedScore.cs
@@ -20,6 +20,14 @@ public partial class GameSubmittedScore : IRealmObject // TODO: Rename to GameSc
         get => (TokenGame)this._Game;
         set => this._Game = (int)value;
     }
+    
+    // ReSharper disable once InconsistentNaming
+    public int _Platform { get; set; }
+    [Ignored] public TokenPlatform Platform
+    {
+        get => (TokenPlatform)this._Platform;
+        set => this._Platform = (int)value;
+    }
 
     public GameLevel Level { get; set; }
     public IList<GameUser> Players { get; }

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -127,11 +127,11 @@ public class TestContext : IDisposable
         for (byte i = 0; i < count; i++)
         {
             GameUser scoreUser = this.CreateUser("score" + i);
-            this.SubmitScore(i, type, level, scoreUser, TokenGame.LittleBigPlanet2);
+            this.SubmitScore(i, type, level, scoreUser, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         }
     }
 
-    public GameSubmittedScore SubmitScore(int score, byte type, GameLevel level, GameUser user, TokenGame game)
+    public GameSubmittedScore SubmitScore(int score, byte type, GameLevel level, GameUser user, TokenGame game, TokenPlatform platform)
     {
         SerializedScore scoreObject = new()
         {
@@ -140,7 +140,7 @@ public class TestContext : IDisposable
             ScoreType = type,
         };
         
-        GameSubmittedScore submittedScore = this.Database.SubmitScore(scoreObject, user, level, game);
+        GameSubmittedScore submittedScore = this.Database.SubmitScore(scoreObject, user, level, game, platform);
         Assert.That(submittedScore, Is.Not.Null);
 
         return submittedScore;

--- a/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
@@ -258,7 +258,7 @@ public class ScoreLeaderboardTests : GameServerTest
         GameLevel level = context.CreateLevel(user);
 
         context.FillLeaderboard(level, leaderboardCount, 1);
-        GameSubmittedScore score = context.SubmitScore(submittedScore, 1, level, user, TokenGame.LittleBigPlanet2);
+        GameSubmittedScore score = context.SubmitScore(submittedScore, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
 
         List<ObjectId> scores = context.Database.GetRankedScoresAroundScore(score, count)!
             .Select(s => s.score.ScoreId)
@@ -298,8 +298,8 @@ public class ScoreLeaderboardTests : GameServerTest
         
         GameLevel level = context.CreateLevel(user1);
         
-        GameSubmittedScore score1 = context.SubmitScore(0, 1, level, user1, TokenGame.LittleBigPlanet2);
-        GameSubmittedScore score2 = context.SubmitScore(0, 2, level, user2, TokenGame.LittleBigPlanet2);
+        GameSubmittedScore score1 = context.SubmitScore(0, 1, level, user1, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameSubmittedScore score2 = context.SubmitScore(0, 2, level, user2, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         
         Assert.Multiple(() =>
         {
@@ -313,7 +313,7 @@ public class ScoreLeaderboardTests : GameServerTest
     {
         using TestContext context = this.GetServer(false);
         GameUser user = context.CreateUser();
-        GameSubmittedScore score = context.SubmitScore(0, 1, context.CreateLevel(user), user, TokenGame.LittleBigPlanet2);
+        GameSubmittedScore score = context.SubmitScore(0, 1, context.CreateLevel(user), user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         
         Assert.That(() => context.Database.GetRankedScoresAroundScore(score, 2), Throws.ArgumentException);
     }


### PR DESCRIPTION
Closes #241 

# Why
The main reason we'd want to do this is not only is it a cool metric to track, but also the fact that we support both PS3 and RPCS3, and naturally RPCS3 can be more susceptible to gameplay glitches depending on your settings. I just think it's better to distinguish the two in some way.

Eventually down the line, we'll also be able to track PPSSPP or Vita3K when those two games achieve networking support in LBP for the same reasons.

# How
We simply add a new property onto `GameSubmittedScore` that contains the platform. Then, we use a best-effort migration that tries to match each game to the most relevant platform. For the mainline games, this will be PS3, LBP Vita is Vita, and LBP PSP is PSP.

We obviously can't go back in time and tell if a particular score was done on RPCS3 so we just assume PS3 for now since that seems to be the more popular choice anyways.

We also expose the game version and platform the score was performed on to the API.