### PR TITLE
Refactor RefreshGameServer to support multiple server types

### DIFF
--- a/Refresh.Common/Refresh.Common.csproj
+++ b/Refresh.Common/Refresh.Common.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Bunkum" Version="4.4.3" />
+      <PackageReference Include="Bunkum.Protocols.Http" Version="4.4.3" />
+    </ItemGroup>
+
+</Project>

--- a/Refresh.Common/RefreshServer.cs
+++ b/Refresh.Common/RefreshServer.cs
@@ -1,0 +1,91 @@
+﻿using System.Globalization;
+using System.Reflection;
+using Bunkum.Core;
+using Bunkum.Protocols.Http;
+using NotEnoughLogs;
+using NotEnoughLogs.Behaviour;
+using NotEnoughLogs.Sinks;
+
+namespace Refresh.Common;
+
+/// <summary>
+/// A common implementation of a Refresh server.
+/// </summary>
+public abstract class RefreshServer : IDisposable
+{
+    public BunkumHttpServer Server { get; protected init; }
+    public Logger Logger => this.Server.Logger;
+
+    protected RefreshServer(BunkumHttpListener? listener = null)
+    {
+        // ReSharper disable once VirtualMemberCallInConstructor
+        (LoggerConfiguration logConfig, List<ILoggerSink>? sinks) = this.GetLoggerConfiguration();
+        
+        this.Server = new BunkumHttpServer(logConfig, sinks);
+        if(listener != null) this.Server.UseListener(listener);
+        
+        this.Logger.LogDebug(BunkumCategory.Startup, $"Initializing {nameof(RefreshServer)} of type {this.GetType().Name}");
+        
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+    }
+
+    // must be called when extending RefreshServer
+    protected void SetupInitializer(Action preServerInitializer)
+    {
+        this.Server.Initialize = _ =>
+        {
+            this.SetupConfiguration();
+            preServerInitializer();
+            this.Initialize();
+        };
+    }
+    
+    /// <summary>
+    /// Starts the server. Does not block for you - to do so you must call <c>Task.Delay(-1)</c> 
+    /// </summary>
+    public virtual void Start()
+    {
+        this.Server.Start();
+    }
+
+    /// <summary>
+    /// Triggers the server to stop accepting new connections and dispose Bunkum's internal objects.
+    /// </summary>
+    public virtual void Stop()
+    {
+        this.Server.Stop();
+    }
+    
+    protected virtual void Initialize()
+    {
+        this.SetupServices();
+        this.SetupMiddlewares();
+        
+        this.Server.DiscoverEndpointsFromAssembly(Assembly.GetCallingAssembly());
+    }
+
+    protected abstract void SetupServices();
+    protected abstract void SetupMiddlewares();
+    protected abstract void SetupConfiguration();
+    
+    protected virtual (LoggerConfiguration logConfig, List<ILoggerSink>? sinks) GetLoggerConfiguration()
+    {
+        LoggerConfiguration logConfig = new()
+        {
+            Behaviour = new QueueLoggingBehaviour(),
+#if DEBUG
+            MaxLevel = LogLevel.Debug,
+#else
+            MaxLevel = LogLevel.Info,
+#endif
+        };
+        
+        return (logConfig, null);
+    }
+
+    public virtual void Dispose()
+    {
+        this.Logger.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -81,6 +81,7 @@
             <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
             <OutputItemType>Analyzer</OutputItemType>
         </ProjectReference>
+        <ProjectReference Include="..\Refresh.Common\Refresh.Common.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -226,8 +226,7 @@ public class RefreshGameServer : RefreshServer
 
     public override void Dispose()
     {
-        this.Logger.Dispose();
         this._databaseProvider.Dispose();
-        GC.SuppressFinalize(this);
+        base.Dispose();
     }
 }

--- a/Refresh.sln
+++ b/Refresh.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refresh.Analyzers", "Refres
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RefreshTests.GameServer", "RefreshTests.GameServer\RefreshTests.GameServer.csproj", "{8DC15128-D9C9-498B-AD3B-537C50966C91}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refresh.Common", "Refresh.Common\Refresh.Common.csproj", "{A3D76B31-8732-4134-907B-F36773DF70D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,12 @@ Global
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.DebugLocalBunkum|Any CPU.ActiveCfg = DebugLocalBunkum|Any CPU
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.DebugLocalBunkum|Any CPU.Build.0 = DebugLocalBunkum|Any CPU
+		{A3D76B31-8732-4134-907B-F36773DF70D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3D76B31-8732-4134-907B-F36773DF70D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3D76B31-8732-4134-907B-F36773DF70D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3D76B31-8732-4134-907B-F36773DF70D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3D76B31-8732-4134-907B-F36773DF70D3}.DebugLocalBunkum|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3D76B31-8732-4134-907B-F36773DF70D3}.DebugLocalBunkum|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection

--- a/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
+++ b/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
@@ -23,19 +23,17 @@ public class TestRefreshGameServer : RefreshGameServer
     public TestRefreshGameServer(BunkumHttpListener listener, Func<GameDatabaseProvider> provider, IDataStore? dataStore = null) : base(listener, provider, null, dataStore ?? new InMemoryDataStore())
     {}
 
-    public BunkumHttpServer Server => this._server;
-
     protected override void SetupConfiguration()
     {
-        this._server.AddConfig(new GameServerConfig());
-        this._server.AddConfig(new RichPresenceConfig());
-        this._server.AddConfig(new IntegrationConfig());
+        this.Server.AddConfig(new GameServerConfig());
+        this.Server.AddConfig(new RichPresenceConfig());
+        this.Server.AddConfig(new IntegrationConfig());
     }
 
     public override void Start()
     {
-        this._server.Start(0);
-        // this._workerManager.Start();
+        this.Server.Start(0);
+        // this.WorkerManager.Start();
     }
 
     public IDateTimeProvider DateTimeProvider { get; set; } = new MockDateTimeProvider();
@@ -65,20 +63,20 @@ public class TestRefreshGameServer : RefreshGameServer
 
     protected override void SetupServices()
     {
-        this._server.AddService<TimeProviderService>(this.DateTimeProvider);
-        this._server.AddService<CategoryService>();
-        this._server.AddService<MatchService>();
-        this._server.AddService<ImportService>();
-        this._server.AddService<LevelListOverrideService>();
-        this._server.AddService<CommandService>();
-        this._server.AddService<GuidCheckerService>();
+        this.Server.AddService<TimeProviderService>(this.DateTimeProvider);
+        this.Server.AddService<CategoryService>();
+        this.Server.AddService<MatchService>();
+        this.Server.AddService<ImportService>();
+        this.Server.AddService<LevelListOverrideService>();
+        this.Server.AddService<CommandService>();
+        this.Server.AddService<GuidCheckerService>();
     }
     
     [Pure]
     public TService GetService<TService>() where TService : Service
     {
         List<Service> services = (List<Service>)typeof(BunkumServer).GetField("_services", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(this._server)!;
+            .GetValue(this.Server)!;
 
         return (TService)services.First(s => typeof(TService) == s.GetType());
     }


### PR DESCRIPTION
# Why
I am currently starting the beginnings of the Room Server discussed in #282. While creating the new project I noticed I was rewriting a lot of code regarding management and bootstrapping, so I decided to do a bit of refactoring.

# How
I created a new project named `Refresh.Common` which contains a new `RefreshServer` class. The normal `RefreshGameServer` extends from this.

`RefreshServer` bootstraps Bunkum and logging functionality, and `RefreshGameServer` now solely manages the workers and injecting of services into Bunkum.

# Remarks
Had to do some weird stuff regarding initialization due to some Bunkum weirdness that came back to bite me in the ass, but it all works out in the end.