### PR TITLE
Fix score ranks starting at 0

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
@@ -64,7 +64,7 @@ public partial class GameDatabaseContext // Leaderboard
         scores = scores.DistinctBy(s => new ScoreLevelWithPlayer(s.Level, s.Players[0]))
             .ToList();
 
-        return scores.Select((s, i) => new ScoreWithRank(s, i))
+        return scores.Select((s, i) => new ScoreWithRank(s, i + 1))
             .Skip(Math.Min(scores.Count, scores.IndexOf(score) - count / 2)) // center user's score around other scores
             .Take(count);
     }

--- a/Refresh.GameServer/Types/UserData/Leaderboard/SerializedMultiLeaderboardResponse.cs
+++ b/Refresh.GameServer/Types/UserData/Leaderboard/SerializedMultiLeaderboardResponse.cs
@@ -32,7 +32,7 @@ public class SerializedMultiLeaderboardResponse
                 PlayerCount = type,
             };
 
-            int i = 0;
+            int i = 1;
             foreach (GameSubmittedScore score in scores.Items)
             {
                 leaderboard.Scores.Add(SerializedLeaderboardScore.FromOld(score, i));


### PR DESCRIPTION
Closes #135

# Why

LBP uses the raw values for a leaderboard entry's rank written in a response. It doesn't increment by itself - each score is expected to have a correct rank value. Turns out we were calculating these via iteration. While not a problem itself, the problem stems from the fact that we were starting the calculation from 0 and not 1.

This caused leaderboard results to start from `#0` which is obviously invalid. LBP1 would show a minor visual glitch (no rank at all for the first player, then the second score would continue on from `#1`) and LBP2 would refuse to display the leaderboard entirely.

# How

Simply start calculating ranks from 1, or add 1 to the current index. Both methods are used where it's convenient to do so.