### PR TITLE
Fix server incorrectly calculating hint_start

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -169,7 +169,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
                     .AsEnumerable()
                     .Where(l => l.Level._GameVersion == (int)TokenGame.LittleBigPlanetPSP)
                     .Select(f => GameMinimalLevelResponse.FromOld(f.Level)).ToList()!;
-                this.FavouriteLevels = new SerializedMinimalFavouriteLevelList(new SerializedMinimalLevelList(favouriteLevels, favouriteLevels.Count));
+                this.FavouriteLevels = new SerializedMinimalFavouriteLevelList(new SerializedMinimalLevelList(favouriteLevels, favouriteLevels.Count, favouriteLevels.Count));
                 break;
             }
             case TokenGame.Website: break;

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -36,7 +36,7 @@ public class LevelEndpoints : EndpointGroup
                 .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame))
                 .ToList()!;
             
-            return new SerializedMinimalLevelList(overrides, overrides.Count);
+            return new SerializedMinimalLevelList(overrides, overrides.Count, overrides.Count);
         }
         
         (int skip, int count) = context.GetPageData();
@@ -50,7 +50,7 @@ public class LevelEndpoints : EndpointGroup
         IEnumerable<GameMinimalLevelResponse> category = levels.Items
             .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame))!;
         
-        return new SerializedMinimalLevelList(category, levels.TotalItems);
+        return new SerializedMinimalLevelList(category, levels.TotalItems, skip + count);
     }
 
     [GameEndpoint("slots/{route}/{username}", ContentType.Xml)]
@@ -137,7 +137,7 @@ public class LevelEndpoints : EndpointGroup
             .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame));
         
         return new SerializedMinimalLevelResultsList(levels?.Items
-            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame))!, levels?.TotalItems ?? 0);
+            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame))!, levels?.TotalItems ?? 0, skip + count);
     }
 
     #region Quirk workarounds

--- a/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
@@ -89,7 +89,7 @@ public class RelationEndpoints : EndpointGroup
         List<GameUser> users = database.GetUsersFavouritedByUser(user, count, skip)
             .ToList();
 
-        return new SerializedFavouriteUserList(GameUserResponse.FromOldListWithExtraData(users, token.TokenGame, database, dataStore).ToList(), users.Count);
+        return new SerializedFavouriteUserList(GameUserResponse.FromOldListWithExtraData(users, token.TokenGame, database, dataStore).ToList(), users.Count, skip + count);
     }
 
     [GameEndpoint("lolcatftw/add/user/{id}", HttpMethods.Post)]

--- a/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
@@ -53,7 +53,7 @@ public class SerializedCategory
         IEnumerable<GameMinimalLevelResponse> levels = categoryLevels?.Items
             .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame)) ?? Array.Empty<GameMinimalLevelResponse>();
 
-        category.Levels = new SerializedMinimalLevelList(levels, categoryLevels?.TotalItems ?? 0);
+        category.Levels = new SerializedMinimalLevelList(levels, categoryLevels?.TotalItems ?? 0, skip + count);
 
         return category;
     }

--- a/Refresh.GameServer/Types/Lists/SerializedFavouriteUserList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedFavouriteUserList.cs
@@ -11,10 +11,11 @@ public class SerializedFavouriteUserList : SerializedList<GameUserResponse>
 {
     public SerializedFavouriteUserList() {}
     
-    public SerializedFavouriteUserList(List<GameUserResponse> list, int count)
+    public SerializedFavouriteUserList(List<GameUserResponse> list, int total, int skip)
     {
-        this.Total = count;
+        this.Total = total;
         this.Items = list;
+        this.NextPageStart = skip + 1;
     }
     
     [XmlElement("user")]

--- a/Refresh.GameServer/Types/Lists/SerializedFriendsList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedFriendsList.cs
@@ -12,6 +12,8 @@ public class SerializedFriendsList : SerializedList<GameUserResponse>
     public SerializedFriendsList(List<GameUserResponse> items)
     {
         this.Items = items;
+        this.Total = items.Count;
+        this.NextPageStart = items.Count + 1;
     }
 
     public SerializedFriendsList() {}

--- a/Refresh.GameServer/Types/Lists/SerializedList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedList.cs
@@ -7,12 +7,7 @@ public abstract class SerializedList<TItem>
     [XmlAttribute("total")]
     public int Total { get; set; }
 
-    [XmlAttribute("hint_start")] public int NextPageStart
-    {
-        get => this.Items.Count + 1;
-        // ReSharper disable once ValueParameterNotUsed (will not serialize without setter)
-        set {}
-    }
+    [XmlAttribute("hint_start")] public int NextPageStart { get; set; }
     
     [XmlIgnore]
     public abstract List<TItem> Items { get; set; }

--- a/Refresh.GameServer/Types/Lists/SerializedMinimalFavouriteLevelList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedMinimalFavouriteLevelList.cs
@@ -14,6 +14,7 @@ public class SerializedMinimalFavouriteLevelList : SerializedList<GameMinimalLev
     public SerializedMinimalFavouriteLevelList(SerializedMinimalLevelList list)
     {
         this.Total = list.Total;
+        this.NextPageStart = list.NextPageStart;
         this.Items = list.Items;
     }
     

--- a/Refresh.GameServer/Types/Lists/SerializedMinimalFavouriteUserList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedMinimalFavouriteUserList.cs
@@ -19,6 +19,7 @@ public class SerializedMinimalFavouriteUserList : SerializedList<SerializedUserH
     {
         this.Total = count;
         this.Items = list;
+        this.NextPageStart = count + 1;
     }
     
     [XmlElement("user")]

--- a/Refresh.GameServer/Types/Lists/SerializedMinimalLevelList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedMinimalLevelList.cs
@@ -11,10 +11,11 @@ public class SerializedMinimalLevelList : SerializedList<GameMinimalLevelRespons
 {
     public SerializedMinimalLevelList() {}
     
-    public SerializedMinimalLevelList(IEnumerable<GameMinimalLevelResponse> list, int total)
+    public SerializedMinimalLevelList(IEnumerable<GameMinimalLevelResponse> list, int total, int skip)
     {
         this.Total = total;
         this.Items = list.ToList();
+        this.NextPageStart = skip + 1;
     }
 
     [XmlElement("slot")]

--- a/Refresh.GameServer/Types/Lists/SerializedMinimalLevelResultsList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedMinimalLevelResultsList.cs
@@ -9,9 +9,10 @@ public class SerializedMinimalLevelResultsList : SerializedMinimalLevelList
 {
     public SerializedMinimalLevelResultsList() {}
     
-    public SerializedMinimalLevelResultsList(IEnumerable<GameMinimalLevelResponse>? list, int total)
+    public SerializedMinimalLevelResultsList(IEnumerable<GameMinimalLevelResponse>? list, int total, int skip)
     {
         this.Total = total;
-        this.Items = list?.ToList() ?? new List<GameMinimalLevelResponse>();
+        this.Items = list?.ToList() ?? [];
+        this.NextPageStart = skip + 1;
     }
 }

--- a/RefreshTests.GameServer/Tests/Lists/ListTests.cs
+++ b/RefreshTests.GameServer/Tests/Lists/ListTests.cs
@@ -1,0 +1,60 @@
+using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.Lists;
+using Refresh.GameServer.Types.UserData;
+using RefreshTests.GameServer.Extensions;
+
+namespace RefreshTests.GameServer.Tests.Lists;
+
+public class ListTests : GameServerTest
+{
+    [Test]
+    public async Task LevelListPaginatesCorrectly()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
+
+        const int pages = 5;
+        const int pageSize = 10;
+        
+        for (int i = 0; i < pageSize * pages; i++)
+        {
+            context.CreateLevel(user, i.ToString());
+        }
+
+        int page = 0;
+        while (true)
+        {
+            HttpResponseMessage message = await client.GetAsync($"/lbp/slots/newest?pageStart={(pageSize * page) + 1}&pageSize={pageSize}");
+            SerializedMinimalLevelList levelList = message.Content.ReadAsXML<SerializedMinimalLevelList>();
+
+            if (pageSize * page >= levelList.Total) break;
+            Assert.Multiple(() =>
+            {
+                Assert.That(levelList.Items[0].LevelId, Is.EqualTo((pageSize * page) + 1), $"first item is invalid on page {page + 1}");
+                Assert.That(levelList.Items[9].LevelId, Is.EqualTo((pageSize * page) + 10), $"last item is invalid on page {page + 1}");
+            });
+
+            page++;
+        }
+    }
+
+    [Test]
+    public async Task LevelListReturnsCorrectHintStart()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
+
+        for (int i = 0; i < 20; i++)
+        {
+            context.CreateLevel(user, i.ToString());
+        }
+        
+        HttpResponseMessage message = await client.GetAsync("/lbp/slots/newest?pageStart=11&pageSize=10");
+        string response = await message.Content.ReadAsStringAsync();
+        
+        Assert.That(response, Contains.Substring("hint_start=\"21\""));
+    }
+}


### PR DESCRIPTION
# Why
A while ago, I wrote the common `SerializedList` class that most serialized objects use for pagination. Turns out this had a pretty significant bug that causes the `hint_start` attribute (the number the game uses to determine how far to skip into the list) to be set to the number of items the page, and it would **not** take into account the current page the user was on.

This means that after the second page, it would keep repeating the second page over and over because it kept returning the same `hint_start `variable.

# How
Simply add a `skip` parameter to all classes extending `SerializedList` so we can appropriately set the hint. In some cases, `hint_star` is not actually entirely necessary, so in those cases we simply re-use the count of items in the list as was the logic before. 