### PR TITLE
ReportingEndpoints: Handle player.Rectangle being null

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/ReportingEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ReportingEndpoints.cs
@@ -51,7 +51,8 @@ public class ReportingEndpoints : EndpointGroup
                     Username = player.Username,
                     DisplayName = player.Username,
                     // ReSharper disable PossibleLossOfFraction YES I KNOW THESE ARE INTEGERS
-                    BoundsList = $"{(float)(player.Rectangle.Left - imageSize.Width / 2) / (imageSize.Width / 2)}," +
+                    BoundsList = player.Rectangle == null 
+                        ? null : $"{(float)(player.Rectangle.Left - imageSize.Width / 2) / (imageSize.Width / 2)}," +
                                  $"{(float)(player.Rectangle.Top - imageSize.Height / 2) / (imageSize.Height / 2)}," +
                                  $"{(float)(player.Rectangle.Right - imageSize.Width / 2) / (imageSize.Width / 2)}," +
                                  $"{(float)(player.Rectangle.Bottom - imageSize.Height / 2) / (imageSize.Height / 2)}",


### PR DESCRIPTION
When making a grief report, if a player is outside of the visible area of the screenshot, the game wont supply a rectangle, and the deserializer will leave it null.

Found this yesterday, only happens when `RedirectGriefReportsToPhotos` is enabled, so it would explain why sometimes the screenshots never go through.