### PR TITLE
LBP will sometimes send rectangles which are stupendously large.

### DIFF
--- a/Refresh.GameServer/Types/Report/Rect.cs
+++ b/Refresh.GameServer/Types/Report/Rect.cs
@@ -7,14 +7,14 @@ namespace Refresh.GameServer.Types.Report;
 public partial class Rect : IEmbeddedObject 
 { 
     [XmlAttribute(AttributeName="t")] 
-    public int Top { get; set; } 
+    public long Top { get; set; } 
 
     [XmlAttribute(AttributeName="l")] 
-    public int Left { get; set; } 
+    public long Left { get; set; } 
 
     [XmlAttribute(AttributeName="b")] 
-    public int Bottom { get; set; } 
+    public long Bottom { get; set; } 
 
     [XmlAttribute(AttributeName="r")] 
-    public int Right { get; set; } 
+    public long Right { get; set; } 
 }


### PR DESCRIPTION
This was noticed when doing a grief report of a photo containing a photo containing a photo, it seems that the game sends the rects of every single player in every single photo, and the logic for that seems to break down, and start sending nonsense values

`<screenRect><rect t="4294967236" l="4294967214" b="9" r="109"/></screenRect>`