### PR TITLE
Add option to unescape XML for filter requests.

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -163,6 +163,9 @@ public partial class GameDatabaseContext // Users
 
             if (data.RedirectGriefReportsToPhotos != null)
                 user.RedirectGriefReportsToPhotos = data.RedirectGriefReportsToPhotos.Value;
+            
+            if (data.UnescapeXmlSequences != null)
+                user.UnescapeXmlSequences = data.UnescapeXmlSequences.Value;
 
             if (data.EmailAddress != null)
                 user.EmailAddress = data.EmailAddress;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -299,6 +299,14 @@ public partial class GameDatabaseContext // Users
         });
     }
 
+    public void SetUnescapeXmlSequences(GameUser user, bool value)
+    {
+        this._realm.Write(() =>
+        {
+            user.UnescapeXmlSequences = value;
+        });
+    }
+    
     public void SetUserGriefReportRedirection(GameUser user, bool value)
     {
         this._realm.Write(() =>

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -32,7 +32,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 110;
+    protected override ulong SchemaVersion => 111;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiUpdateUserRequest.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiUpdateUserRequest.cs
@@ -11,6 +11,7 @@ public class ApiUpdateUserRequest
     public bool? RpcnAuthenticationAllowed { get; set; }
     
     public bool? RedirectGriefReportsToPhotos { get; set; }
+    public bool? UnescapeXmlSequences { get; set; }
     
     public string? EmailAddress { get; set; }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiExtendedGameUserResponse.cs
@@ -31,6 +31,7 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     public required bool PsnAuthenticationAllowed { get; set; }
     
     public bool RedirectGriefReportsToPhotos { get; set; } 
+    public bool UnescapeXmlSequences { get; set; } 
     
     public required string? EmailAddress { get; set; }
     public required bool EmailAddressVerified { get; set; }
@@ -60,6 +61,7 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
             EmailAddressVerified = user.EmailAddressVerified,
             ShouldResetPassword = user.ShouldResetPassword,
             RedirectGriefReportsToPhotos = user.RedirectGriefReportsToPhotos,
+            UnescapeXmlSequences = user.UnescapeXmlSequences,
         };
     }
     

--- a/Refresh.GameServer/Endpoints/Game/ModerationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ModerationEndpoints.cs
@@ -1,5 +1,6 @@
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
+using Bunkum.Core.Endpoints.Debugging;
 using Bunkum.Listener.Protocol;
 using Bunkum.Protocols.Http;
 using Refresh.GameServer.Authentication;
@@ -46,7 +47,17 @@ public class ModerationEndpoints : EndpointGroup
     public string Filter(RequestContext context, CommandService commandService, string body, GameUser user, Token token, GameDatabaseContext database)
     {
         // TODO: Add actual filtering/censoring
-        
+
+        //If the user has enabled unescaping of XML sequences, lets unescape all the XML tags in the body
+        if (user.UnescapeXmlSequences)
+        {
+            body = body.Replace("&apos;", "'");
+            body = body.Replace("&quot;", "\"");
+            body = body.Replace("&gt;", ">");
+            body = body.Replace("&lt;", "<");
+            body = body.Replace("&amp;", "&");
+        }
+
         if (commandService.IsPublishing(user.UserId))
         {
             context.Logger.LogInfo(BunkumCategory.UserLevels, $"Publish filter: '{body}'");

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -114,6 +114,16 @@ public class CommandService : EndpointService
                 database.SetUserGriefReportRedirection(user, false);
                 break;
             }
+            case "unescapexmlon":
+            {
+                database.SetUnescapeXmlSequences(user, true);
+                break;
+            }
+            case "unescapexmloff":
+            {
+                database.SetUnescapeXmlSequences(user, false);
+                break;
+            }
             case "play":
             {
                 GameLevel? level = database.GetLevelById(int.Parse(command.Arguments));

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -96,6 +96,10 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     /// If `true`, turn all grief reports into photo uploads
     /// </summary>
     public bool RedirectGriefReportsToPhotos { get; set; }
+    /// <summary>
+    /// If `true`, unescape XML tags sent to /filter
+    /// </summary>
+    public bool UnescapeXmlSequences { get; set; }
     
     [Ignored] public GameUserRole Role
     {


### PR DESCRIPTION
This allows you to use special tags like `<em>`, `<font>`, `<player>` for advanced text editing.

This is already possible by modifying plan files or by using a proxy to intercept the /filter requests, this option just makes it *much* more accessible to users.

Requires a change in refresh-web.