### PR TITLE
Resolve most build warnings

### DIFF
--- a/Refresh.Analyzers/Refresh.Analyzers.csproj
+++ b/Refresh.Analyzers/Refresh.Analyzers.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>11</LangVersion>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiResetUserPasswordRequest.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiResetUserPasswordRequest.cs
@@ -1,5 +1,7 @@
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 
+#nullable disable
+
 public class ApiResetUserPasswordRequest
 {
     public string PasswordSha512 { get; set; }

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -20,7 +20,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
     [XmlElement("location")] public required GameLocation Location { get; set; }
     [XmlElement("planets")] public required string PlanetsHash { get; set; }
     
-    [XmlElement("npHandle")] public SerializedUserHandle Handle { get; set; }
+    [XmlElement("npHandle")] public required SerializedUserHandle Handle { get; set; }
     [XmlElement("commentCount")] public int CommentCount { get; set; }
     [XmlElement("commentsEnabled")] public bool CommentsEnabled { get; set; }
     [XmlElement("favouriteSlotCount")] public int FavouriteLevelCount { get; set; }

--- a/Refresh.GameServer/Importing/Importer.cs
+++ b/Refresh.GameServer/Importing/Importer.cs
@@ -16,7 +16,7 @@ public abstract class Importer
     private readonly Logger _logger;
     protected readonly Stopwatch Stopwatch;
     
-    public static Lazy<byte[]?> PSPKey;
+    public static Lazy<byte[]?> PSPKey = null!;
 
     protected Importer(Logger? logger = null)
     {

--- a/Refresh.GameServer/Importing/Mip/MipHeader.cs
+++ b/Refresh.GameServer/Importing/Mip/MipHeader.cs
@@ -5,15 +5,15 @@ namespace Refresh.GameServer.Importing.Mip;
 public class MipHeader
 {
     public uint ClutOffset;
-    public uint Width;
-    public uint Height;
-    public byte Bpp;
-    public byte NumBlocks;
-    public byte TexMode;
-    public bool Alpha;
+    public required uint Width;
+    public required uint Height;
+    public required byte Bpp;
+    public required byte NumBlocks;
+    public required byte TexMode;
+    public required bool Alpha;
     public uint DataOffset;
 
-    public Rgba32[] ColorLookupTable;
+    public required Rgba32[] ColorLookupTable;
     
     public static MipHeader Read(Stream stream)
     {

--- a/Refresh.GameServer/Types/Activity/ActivityPage.cs
+++ b/Refresh.GameServer/Types/Activity/ActivityPage.cs
@@ -26,10 +26,10 @@ public class ActivityPage
     public IEnumerable<Event> Events { get; set; }
     
     [XmlIgnore]
-    public List<GameUser> Users { get; set; }
-    
+    public List<GameUser> Users { get; set; } = null!;
+
     [XmlIgnore]
-    public List<GameLevel> Levels { get; set; }
+    public List<GameLevel> Levels { get; set; } = null!;
 
     [JsonIgnore]
     [XmlElement("groups")]

--- a/Refresh.GameServer/Types/Matching/Responses/SerializedRoomMatchResponse.cs
+++ b/Refresh.GameServer/Types/Matching/Responses/SerializedRoomMatchResponse.cs
@@ -1,5 +1,7 @@
 namespace Refresh.GameServer.Types.Matching.Responses;
 
+#nullable disable
+
 [JsonObject(MemberSerialization.OptIn)]
 public class SerializedRoomMatchResponse
 {

--- a/Refresh.GameServer/Types/Notifications/GameAnnouncement.cs
+++ b/Refresh.GameServer/Types/Notifications/GameAnnouncement.cs
@@ -3,6 +3,8 @@ using Realms;
 
 namespace Refresh.GameServer.Types.Notifications;
 
+#nullable disable
+
 /// <summary>
 /// An announcement posted by a server administrator.
 /// </summary>

--- a/Refresh.GameServer/Types/Photos/GamePhotoSubject.cs
+++ b/Refresh.GameServer/Types/Photos/GamePhotoSubject.cs
@@ -10,6 +10,7 @@ public partial class GamePhotoSubject : IEmbeddedObject
 {
     public GameUser? User { get; set; }
 
+#nullable disable
     public string DisplayName { get; set; }
     public IList<float> Bounds { get; }
 }

--- a/Refresh.GameServer/Types/SequentialIdStorage.cs
+++ b/Refresh.GameServer/Types/SequentialIdStorage.cs
@@ -2,6 +2,8 @@ using Realms;
 
 namespace Refresh.GameServer.Types;
 
+#nullable disable
+
 public partial class SequentialIdStorage : IRealmObject
 {
     public string TypeName { get; set; }

--- a/RefreshTests.GameServer/GameServer/GameServerTest.cs
+++ b/RefreshTests.GameServer/GameServer/GameServerTest.cs
@@ -7,7 +7,7 @@ using RefreshTests.GameServer.Time;
 namespace RefreshTests.GameServer.GameServer;
 
 [Parallelizable]
-[Timeout(2000)]
+[CancelAfter(2000)]
 public class GameServerTest
 {
     protected static readonly Logger Logger = new(new []

--- a/RefreshTests.GameServer/Tests/ApiV3/LevelApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/LevelApiTests.cs
@@ -42,10 +42,14 @@ public class LevelApiTests : GameServerTest
         ApiListResponse<ApiLevelCategoryResponse>? categories = context.Http.GetList<ApiLevelCategoryResponse>("/api/v3/levels?includePreviews=true");
         Assert.That(categories, Is.Not.Null);
         
-        ApiLevelCategoryResponse? category = categories.Data.FirstOrDefault(c => c.ApiRoute == "newest");
+        ApiLevelCategoryResponse? category = categories?.Data?.FirstOrDefault(c => c.ApiRoute == "newest");
         Assert.That(category, Is.Not.Null);
-        Assert.That(category!.PreviewLevel, Is.Not.Null);
-        Assert.That(category.PreviewLevel!.LevelId, Is.EqualTo(level.LevelId));
+        
+        Assert.Multiple(() =>
+        {
+            Assert.That(category!.PreviewLevel, Is.Not.Null);
+            Assert.That(category.PreviewLevel!.LevelId, Is.EqualTo(level.LevelId));
+        });
     }
     
     [Test]

--- a/RefreshTests.GameServer/Tests/Authentication/AuthenticationIntegrationTests.cs
+++ b/RefreshTests.GameServer/Tests/Authentication/AuthenticationIntegrationTests.cs
@@ -49,8 +49,7 @@ public class AuthenticationIntegrationTests : GameServerTest
         // (GameUser? user, HttpResponseMessage response) = authedClient.GetJsonObjectAsync<GameUser>("/api/v3/user/me");
         Assert.Multiple(async () =>
         {
-            // Assert.That(user, Is.Not.Null);
-            Assert.That(response.Content.ReadAsStringAsync().Result, Contains.Substring(token!.User.UserId.ToString()));
+            Assert.That(await response.Content.ReadAsStringAsync(), Contains.Substring(token!.User.UserId.ToString()));
             Assert.That(response.StatusCode, Is.EqualTo(OK));
         });
     }

--- a/RefreshTests.GameServer/Tests/Middlewares/ApiV2MiddlewareTests.cs
+++ b/RefreshTests.GameServer/Tests/Middlewares/ApiV2MiddlewareTests.cs
@@ -15,7 +15,7 @@ public class ApiV2MiddlewareTests : GameServerTest
         Assert.Multiple(async () =>
         {
             Assert.That(response.StatusCode, Is.EqualTo(Gone));
-            Assert.That(response.Content.ReadAsStringAsync().Result, Does.Contain("error"));
+            Assert.That(await response.Content.ReadAsStringAsync(), Does.Contain("error"));
         });
     }
     
@@ -30,7 +30,7 @@ public class ApiV2MiddlewareTests : GameServerTest
         Assert.Multiple(async () =>
         {
             Assert.That(response.StatusCode, Is.EqualTo(OK));
-            Assert.That(response.Content.ReadAsStringAsync().Result, Does.Not.Contain("error"));
+            Assert.That(await response.Content.ReadAsStringAsync(), Does.Not.Contain("error"));
         });
     }
 }

--- a/RefreshTests.GameServer/Tests/Middlewares/LegacyAdapterMiddlewareTests.cs
+++ b/RefreshTests.GameServer/Tests/Middlewares/LegacyAdapterMiddlewareTests.cs
@@ -35,7 +35,7 @@ public class LegacyAdapterMiddlewareTests : GameServerTest
         Assert.Multiple(async () =>
         {
             Assert.That(response.StatusCode, Is.EqualTo(OK));
-            Assert.That(response.Content.ReadAsStringAsync().Result, Is.EqualTo("test"));
+            Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo("test"));
         });
     }
 }


### PR DESCRIPTION
# Remarks
Realm's source generator still generates some nullability warnings (17 as of this PR), but unfortunately we don't have any reasonable control over them. This PR just resolves the warnings that we *can* resolve.