### PR TITLE
Send locked status in minimal response

### DIFF
--- a/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
@@ -38,7 +38,8 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
 
     [XmlElement("playerCount")] public int PlayerCount { get; set; }
     
-
+    [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
+    
     private GameMinimalLevelResponse() {}
     
     public static GameMinimalLevelResponse? FromOldWithExtraData(GameLevelResponse? old, MatchService matchService, GameDatabaseContext database, IDataStore dataStore, TokenGame game)
@@ -94,6 +95,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
             YourStarRating = level.YourStarRating,
             YourRating = level.YourRating,
             AverageStarRating = level.AverageStarRating,
+            IsLocked = level.IsLocked,
         };
     }
 

--- a/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
@@ -39,6 +39,8 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     [XmlElement("playerCount")] public int PlayerCount { get; set; }
     
     [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
+    [XmlElement("isSubLevel")] public bool IsSubLevel { get; set; }
+    [XmlElement("shareable")] public int IsCopyable { get; set; }
     
     private GameMinimalLevelResponse() {}
     
@@ -96,6 +98,8 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
             YourRating = level.YourRating,
             AverageStarRating = level.AverageStarRating,
             IsLocked = level.IsLocked,
+            IsSubLevel = level.IsSubLevel,
+            IsCopyable = level.IsCopyable,
         };
     }
 


### PR DESCRIPTION
Before this patch, you could play a locked level by clicking on it from the level browse list before it loads the full information.