### PR TITLE
Revert "Filter out sub-levels from level results"

### DIFF
--- a/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
+++ b/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
@@ -60,9 +60,6 @@ public static class LevelEnumerableExtensions
         // _ => throw new ArgumentOutOfRangeException()
         // };
 
-        //Filter out sub-levels, unless the user is the publisher
-        levels = levels.Where(l => !l.IsSubLevel || l.Publisher == user);
-
         return levels;
     }
     
@@ -94,9 +91,6 @@ public static class LevelEnumerableExtensions
         // MoveFilterType.False => levels.Where(l => !l.MoveCompatible),
         // _ => throw new ArgumentOutOfRangeException()
         // };
-        
-        //Filter out sub-levels, unless the user is the publisher
-        levels = levels.Where(l => !l.IsSubLevel || l.Publisher == user);
 
         return levels;
     }


### PR DESCRIPTION
#333 broke the ability for level authors to view their own sublevels.

In my opinion, it's better to show them wrongly than to hide them wrongly, so let's just revert this for now.