### PR TITLE
Add the ability for beta builds to have their own isolated space

### DIFF
--- a/Refresh.GameServer/Authentication/TokenGame.cs
+++ b/Refresh.GameServer/Authentication/TokenGame.cs
@@ -10,6 +10,7 @@ public enum TokenGame
     LittleBigPlanetVita = 3,
     LittleBigPlanetPSP = 4,
     Website = 5,
+    BetaBuild = 6,
 }
 
 public static class TokenGameExtensions
@@ -22,6 +23,7 @@ public static class TokenGameExtensions
             TokenGame.LittleBigPlanet3 => 2,
             TokenGame.LittleBigPlanetVita => 1,
             TokenGame.LittleBigPlanetPSP => 0,
+            TokenGame.BetaBuild => 1, // treat beta levels as LBP2 for now.
             TokenGame.Website => throw new InvalidOperationException("https://osuhow.com/"),
             _ => throw new ArgumentOutOfRangeException(),
         };
@@ -60,7 +62,12 @@ public static class TokenGameExtensions
                     return false;
                             
                 break;
-            //Allow all for website
+            //Allow all for website and beta
+            case TokenGame.BetaBuild:
+                if (level.GameVersion != TokenGame.BetaBuild)
+                    return false;
+                
+                break;
             case TokenGame.Website:
                 break;
             default:

--- a/Refresh.GameServer/Authentication/TokenGame.cs
+++ b/Refresh.GameServer/Authentication/TokenGame.cs
@@ -62,12 +62,13 @@ public static class TokenGameExtensions
                     return false;
                             
                 break;
-            //Allow all for website and beta
+            // Isolate beta builds' levels
             case TokenGame.BetaBuild:
                 if (level.GameVersion != TokenGame.BetaBuild)
                     return false;
                 
                 break;
+            //Allow all for website
             case TokenGame.Website:
                 break;
             default:

--- a/Refresh.GameServer/Authentication/TokenGameUtility.cs
+++ b/Refresh.GameServer/Authentication/TokenGameUtility.cs
@@ -24,11 +24,6 @@ public static class TokenGameUtility
         
         "NPJA00052", // JP Digital
         "BCJS30018", // JP Disc
-        
-        // Betas/Debug/Prerelease
-        "BCET70002", // EU "Online Trial" Beta Test
-        "BCET70011", // EU Water Beta Test
-        "NPUA70045", // US Demo
     };
 
     private static readonly string[] LittleBigPlanet2Titles =
@@ -53,11 +48,6 @@ public static class TokenGameUtility
         
         "BCJS30058", // JP Disc
         // missing japan digital?
-        
-        // Betas/Debug/Prerelease
-        "NPUA70117", // US Private Beta
-        "BCET70055", // LBP Hub (real title id)
-        "NPEA00449", // LBP HUB (sent title id)
     };
 
     // PS4 title ids are not here on purpose.
@@ -86,11 +76,6 @@ public static class TokenGameUtility
         
         "NPJG00073", // JP Digital
         "NPHG00033", // Asia Digital
-        
-        // Betas/Debug/Prerelease
-        "NPUG70064", // US Demo
-        "NPEG90019", // EU Demo
-        "NPHG00035", // Asia Demo
     };
 
     private static readonly string[] LittleBigPlanetVitaTitles =
@@ -106,8 +91,26 @@ public static class TokenGameUtility
         
         "PCSC00013", // JP Digital
         "VCJS10006", // JP Cartridge
+    };
+
+    private static readonly string[] BetaBuildTitles =
+    {
+        // LBP1
+        "BCET70002", // EU "Online Trial" Beta Test
+        "BCET70011", // EU Water Beta Test
+        "NPUA70045", // US Demo
         
-        // Betas/Debug/Prerelease
+        // LBP2
+        "NPUA70117", // US Private Beta
+        "BCET70055", // LBP Hub (real title id)
+        "NPEA00449", // LBP HUB (sent title id)
+        
+        // PSP
+        "NPUG70064", // US Demo
+        "NPEG90019", // EU Demo
+        "NPHG00035", // Asia Demo
+        
+        // Vita
         "PCSA00061", // US Beta
         "PCSF00152", // EU Beta
     };
@@ -119,6 +122,7 @@ public static class TokenGameUtility
         if (LittleBigPlanet3Titles.Contains(titleId)) return TokenGame.LittleBigPlanet3;
         if (LittleBigPlanetPSPTitles.Contains(titleId)) return TokenGame.LittleBigPlanetPSP;
         if (LittleBigPlanetVitaTitles.Contains(titleId)) return TokenGame.LittleBigPlanetVita;
+        if (BetaBuildTitles.Contains(titleId)) return TokenGame.BetaBuild;
         
         return null;
     }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -96,6 +96,9 @@ public partial class GameDatabaseContext // Users
                     case TokenGame.LittleBigPlanetVita:
                         user.VitaPlanetsHash = data.PlanetsHash;
                         break;
+                    case TokenGame.BetaBuild:
+                        user.BetaPlanetsHash = data.PlanetsHash;
+                        break;
                 }
 
             // ReSharper disable once InvertIf
@@ -130,6 +133,9 @@ public partial class GameDatabaseContext // Users
                         //PSP icons are special and use a GUID system separate from the mainline games,
                         //so we separate PSP icons to another field
                         user.PspIconHash = data.IconHash;
+                        break;
+                    case TokenGame.BetaBuild:
+                        user.BetaIconHash = data.IconHash;
                         break;
                 }
         });

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -331,7 +331,6 @@ public partial class GameDatabaseContext // Users
         });
     }
     
-    #if DEBUG
     public void ForceUserTokenGame(Token token, TokenGame game)
     {
         this._realm.Write(() =>
@@ -347,5 +346,4 @@ public partial class GameDatabaseContext // Users
             token.TokenPlatform = platform;
         });
     }
-    #endif
 }

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -32,7 +32,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 112;
+    protected override ulong SchemaVersion => 113;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -363,6 +363,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
                     TokenGame.LittleBigPlanet3 => TokenPlatform.PS3,
                     TokenGame.LittleBigPlanetVita => TokenPlatform.Vita,
                     TokenGame.LittleBigPlanetPSP => TokenPlatform.PSP,
+                    TokenGame.BetaBuild => TokenPlatform.RPCS3,
                     TokenGame.Website => throw new InvalidOperationException($"what? score id {newScore.ScoreId} by {newScore.Players[0].Username} is fucked"),
                     _ => throw new ArgumentOutOfRangeException(),
                 };

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -117,6 +117,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             TokenGame.LittleBigPlanetVita => old.VitaPlanetsHash,
             TokenGame.LittleBigPlanetPSP => "0",
             TokenGame.Website => "0",
+            TokenGame.BetaBuild => old.Lbp2PlanetsHash, // TODO: Planet hash for beta builds
             _ => throw new ArgumentOutOfRangeException(nameof(gameVersion), gameVersion, null),
         };
 
@@ -130,6 +131,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
                 //Fill out LBP2/LBP1 levels
                 goto case TokenGame.LittleBigPlanet2;
             }
+            case TokenGame.BetaBuild:
             case TokenGame.LittleBigPlanet2: {
                 //Match all LBP2 levels
                 this.UsedSlotsLBP2 = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.LittleBigPlanet2);

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -117,7 +117,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             TokenGame.LittleBigPlanetVita => old.VitaPlanetsHash,
             TokenGame.LittleBigPlanetPSP => "0",
             TokenGame.Website => "0",
-            TokenGame.BetaBuild => old.Lbp2PlanetsHash, // TODO: Planet hash for beta builds
+            TokenGame.BetaBuild => old.BetaPlanetsHash,
             _ => throw new ArgumentOutOfRangeException(nameof(gameVersion), gameVersion, null),
         };
 
@@ -131,7 +131,6 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
                 //Fill out LBP2/LBP1 levels
                 goto case TokenGame.LittleBigPlanet2;
             }
-            case TokenGame.BetaBuild:
             case TokenGame.LittleBigPlanet2: {
                 //Match all LBP2 levels
                 this.UsedSlotsLBP2 = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.LittleBigPlanet2);
@@ -172,6 +171,20 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
                     .Where(l => l.Level._GameVersion == (int)TokenGame.LittleBigPlanetPSP)
                     .Select(f => GameMinimalLevelResponse.FromOld(f.Level)).ToList()!;
                 this.FavouriteLevels = new SerializedMinimalFavouriteLevelList(new SerializedMinimalLevelList(favouriteLevels, favouriteLevels.Count, favouriteLevels.Count));
+                break;
+            }
+            case TokenGame.BetaBuild:
+            {
+                // only beta levels
+                this.UsedSlots = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.BetaBuild);
+                this.FreeSlots = MaximumLevels - this.UsedSlotsLBP2;
+                
+                // use the same values for LBP3 and LBP2 since they're all shared under one count
+                this.UsedSlotsLBP3 = this.UsedSlots;
+                this.FreeSlotsLBP3 = this.FreeSlots;
+                
+                this.UsedSlotsLBP2 = this.UsedSlots;
+                this.FreeSlotsLBP2 = this.FreeSlots;
                 break;
             }
             case TokenGame.Website: break;

--- a/Refresh.GameServer/Endpoints/Game/Handshake/AuthenticationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Handshake/AuthenticationEndpoints.cs
@@ -133,7 +133,13 @@ public class AuthenticationEndpoints : EndpointGroup
             }
         }
 
-        TokenGame? game = TokenGameUtility.FromTitleId(ticket.TitleId);
+        TokenGame? game = null;
+
+        // check if we're connecting from a beta build
+        bool parsedBeta = byte.TryParse(context.QueryString.Get("beta"), out byte isBeta);
+        if (parsedBeta && isBeta == 1) game = TokenGame.BetaBuild;
+
+        game ??= TokenGameUtility.FromTitleId(ticket.TitleId);
 
         if (platform == null)
         {

--- a/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
+++ b/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
@@ -15,6 +15,7 @@ public static class LevelEnumerableExtensions
             TokenGame.LittleBigPlanet3 => levels.Where(l => l._GameVersion <= (int)TokenGame.LittleBigPlanet3),
             TokenGame.LittleBigPlanetVita => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetVita),
             TokenGame.LittleBigPlanetPSP => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetPSP),
+            TokenGame.BetaBuild => levels.Where(l => l._GameVersion == (int)TokenGame.BetaBuild),
             TokenGame.Website => levels,
             _ => throw new ArgumentOutOfRangeException(nameof(gameVersion), gameVersion, null),
         };
@@ -27,6 +28,7 @@ public static class LevelEnumerableExtensions
             TokenGame.LittleBigPlanet3 => levels.Where(l => l._GameVersion <= (int)TokenGame.LittleBigPlanet3),
             TokenGame.LittleBigPlanetVita => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetVita),
             TokenGame.LittleBigPlanetPSP => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetPSP),
+            TokenGame.BetaBuild => levels.Where(l => l._GameVersion == (int)TokenGame.BetaBuild),
             TokenGame.Website => levels,
             _ => throw new ArgumentOutOfRangeException(nameof(gameVersion), gameVersion, null),
         };
@@ -36,14 +38,17 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.ExcludeMyLevels && user != null)
             levels = levels.Where(l => l.Publisher != user);
 
-        levels = levelFilterSettings.GameFilterType switch {
-            GameFilterType.LittleBigPlanet1 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet1),
-            GameFilterType.LittleBigPlanet2 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet2),
-            //NOTE: ideally this should be .Where(l => l._GameVersion == (int)TokenGame.LittleBigPlane1 || l._GameVersion == (int)TokenGame.LittleBigPlane2)
-            //      however, there should be no differences in all real-world cases
-            GameFilterType.Both => levels,
-            _ => throw new ArgumentOutOfRangeException(),
-        };
+        if (levelFilterSettings.GameVersion != TokenGame.BetaBuild)
+        {
+            levels = levelFilterSettings.GameFilterType switch {
+                GameFilterType.LittleBigPlanet1 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet1),
+                GameFilterType.LittleBigPlanet2 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet2),
+                //NOTE: ideally this should be .Where(l => l._GameVersion == (int)TokenGame.LittleBigPlane1 || l._GameVersion == (int)TokenGame.LittleBigPlane2)
+                //      however, there should be no differences in all real-world cases
+                GameFilterType.Both => levels,
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+        }
 
         if (levelFilterSettings.Players != 0) 
             levels = levels.Where(l => l.MaxPlayers >= levelFilterSettings.Players && l.MinPlayers <= levelFilterSettings.Players);
@@ -68,14 +73,17 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.ExcludeMyLevels && user != null)
             levels = levels.Where(l => l.Publisher != user);
 
-        levels = levelFilterSettings.GameFilterType switch {
-            GameFilterType.LittleBigPlanet1 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet1),
-            GameFilterType.LittleBigPlanet2 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet2),
-            //NOTE: ideally this should be .Where(l => l._GameVersion == (int)TokenGame.LittleBigPlane1 || l._GameVersion == (int)TokenGame.LittleBigPlane2)
-            //      however, there should be no differences in all real-world cases
-            GameFilterType.Both => levels,
-            _ => throw new ArgumentOutOfRangeException(),
-        };
+        if (levelFilterSettings.GameVersion != TokenGame.BetaBuild)
+        {
+            levels = levelFilterSettings.GameFilterType switch {
+                GameFilterType.LittleBigPlanet1 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet1),
+                GameFilterType.LittleBigPlanet2 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet2),
+                //NOTE: ideally this should be .Where(l => l._GameVersion == (int)TokenGame.LittleBigPlane1 || l._GameVersion == (int)TokenGame.LittleBigPlane2)
+                //      however, there should be no differences in all real-world cases
+                GameFilterType.Both => levels,
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+        }
 
         if (levelFilterSettings.Players != 0) 
             levels = levels.Where(l => l.MaxPlayers >= levelFilterSettings.Players && l.MinPlayers <= levelFilterSettings.Players);

--- a/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
+++ b/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
@@ -38,6 +38,8 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.ExcludeMyLevels && user != null)
             levels = levels.Where(l => l.Publisher != user);
 
+        // Don't allow beta builds to use this filtering option
+        // If the client specifies this option then it will filter out *all* levels.
         if (levelFilterSettings.GameVersion != TokenGame.BetaBuild)
         {
             levels = levelFilterSettings.GameFilterType switch {
@@ -73,6 +75,8 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.ExcludeMyLevels && user != null)
             levels = levels.Where(l => l.Publisher != user);
 
+        // Don't allow beta builds to use this filtering option
+        // If the client specifies this option then it will filter out *all* levels.
         if (levelFilterSettings.GameVersion != TokenGame.BetaBuild)
         {
             levels = levelFilterSettings.GameFilterType switch {

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -138,6 +138,10 @@ public class CommandService : EndpointService
                 database.ForceUserTokenGame(token, TokenGame.BetaBuild);
                 break;
             }
+            case "revoketoken":
+            {
+                database.RevokeToken(token);
+            }
             #if DEBUG
             case "tokengame":
             {

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -141,6 +141,7 @@ public class CommandService : EndpointService
             case "revoketoken":
             {
                 database.RevokeToken(token);
+                break;
             }
             #if DEBUG
             case "tokengame":

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -133,6 +133,11 @@ public class CommandService : EndpointService
                 }
                 break;
             }
+            case "beta":
+            {
+                database.ForceUserTokenGame(token, TokenGame.BetaBuild);
+                break;
+            }
             #if DEBUG
             case "tokengame":
             {

--- a/Refresh.GameServer/Services/GuidCheckerService.cs
+++ b/Refresh.GameServer/Services/GuidCheckerService.cs
@@ -60,6 +60,7 @@ public class GuidCheckerService : EndpointService
             TokenGame.LittleBigPlanet3 => this._validMainlineTextureGuids.TryGetValue(guid, out _),
             TokenGame.LittleBigPlanetVita => this._validVitaTextureGuids.TryGetValue(guid, out _),
             TokenGame.LittleBigPlanetPSP => guid is >= 0 and <= 63, //PSP avatar GUIDs can be g0 - g63
+            TokenGame.BetaBuild => this._validMainlineTextureGuids.TryGetValue(guid, out _),
             _ => throw new ArgumentOutOfRangeException(nameof(game), game, null),
         };
     }

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -43,6 +43,10 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     /// Vita GUIDs do not map to mainline GUIDs, so we dont want someone to set their Vita icon, and it map to an invalid GUID on PS3.
     /// </remarks>
     public string VitaIconHash { get; set; } = "0";
+    /// <summary>
+    /// The <see cref="IconHash"/>, except only for clients in beta mode.
+    /// </summary>
+    public string BetaIconHash { get; set; } = "0";
 
     public string Description { get; set; } = "";
     public GameLocation Location { get; set; } = GameLocation.Zero;
@@ -77,6 +81,7 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     public IList<GameIpVerificationRequest> IpVerificationRequests { get; }
     #nullable restore
 
+    public string BetaPlanetsHash { get; set; } = "0";
     public string Lbp2PlanetsHash { get; set; } = "0";
     public string Lbp3PlanetsHash { get; set; } = "0";
     public string VitaPlanetsHash { get; set; } = "0";


### PR DESCRIPTION
Some beta builds can end up posting levels that can crash players playing on mainline versions of the game. For example, a player playing on a deploy build can upload a level that will be registered as an LBP1 level. This causes a hard crash upon loading in LBP1.

This also introduces 2 commands that are __not__ debug commands:
- `/beta`: Switches the token to be `TokenGame.BetaBuild`. Can be used for builds that do not properly identify themselves as beta builds, e.g. deploy.
- `/revoketoken`: Revokes the token, essentially forcing the game to redo the handshake with the server. This can be used to switch away from beta mode, can also just be generally useful.

This was vaguely tested.