### PR TITLE
Allow server owners to specify contact information

### DIFF
--- a/Refresh.GameServer/Configuration/ContactInfoConfig.cs
+++ b/Refresh.GameServer/Configuration/ContactInfoConfig.cs
@@ -1,0 +1,32 @@
+using Bunkum.Core.Configuration;
+
+namespace Refresh.GameServer.Configuration;
+
+/// <summary>
+/// A configuration holding basic contact information for those operating this instance.
+/// </summary>
+public class ContactInfoConfig : Config
+{
+    public override int CurrentConfigVersion => 1;
+    public override int Version { get; set; }
+    
+    protected override void Migrate(int oldVer, dynamic oldConfig)
+    {}
+
+    /// <summary>
+    /// The owner's screen name.
+    /// </summary>
+    public string AdminName { get; set; } = "Administrator";
+    /// <summary>
+    /// The owner's email address.
+    /// </summary>
+    public string EmailAddress { get; set; } = "refresh@example.com";
+    /// <summary>
+    /// A link to a Discord server.
+    /// </summary>
+    public string? DiscordServerInvite { get; set; }
+    /// <summary>
+    /// The owner's personal Discord account.
+    /// </summary>
+    public string? AdminDiscordUsername { get; set; }
+}

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiContactInfoResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiContactInfoResponse.cs
@@ -1,0 +1,22 @@
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiContactInfoResponse : IApiResponse
+{
+    /// <summary>
+    /// The owner's screen name.
+    /// </summary>
+    public required string AdminName { get; set; }
+    /// <summary>
+    /// The owner's email address.
+    /// </summary>
+    public required string EmailAddress { get; set; }
+    /// <summary>
+    /// A link to a Discord server.
+    /// </summary>
+    public required string? DiscordServerInvite { get; set; }
+    /// <summary>
+    /// The owner's personal Discord account.
+    /// </summary>
+    public required string? AdminDiscordUsername { get; set; }
+}

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiInstanceResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiInstanceResponse.cs
@@ -46,4 +46,6 @@ public class ApiInstanceResponse : IApiResponse
     
     public required bool MaintenanceModeEnabled { get; set; }
     public required string? GrafanaDashboardUrl { get; set; }
+    
+    public ApiContactInfoResponse ContactInfo { get; set; }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
@@ -55,6 +55,7 @@ public class InstanceApiEndpoints : EndpointGroup
         GameServerConfig gameConfig,
         RichPresenceConfig richConfig,
         IntegrationConfig integrationConfig,
+        ContactInfoConfig contactInfoConfig,
         GameDatabaseContext database) 
         => new ApiInstanceResponse
         {
@@ -71,7 +72,14 @@ public class InstanceApiEndpoints : EndpointGroup
             MaintenanceModeEnabled = gameConfig.MaintenanceMode,
             RichPresenceConfiguration = ApiRichPresenceConfigurationResponse.FromOld(RichPresenceConfiguration.Create(gameConfig, richConfig))!,
             GrafanaDashboardUrl = integrationConfig.GrafanaDashboardUrl,
-
+            
+            ContactInfo = new ApiContactInfoResponse
+            {
+                AdminName = contactInfoConfig.AdminName,
+                EmailAddress = contactInfoConfig.EmailAddress,
+                DiscordServerInvite = contactInfoConfig.DiscordServerInvite,
+                AdminDiscordUsername = contactInfoConfig.AdminDiscordUsername,
+            },
 #if DEBUG
             SoftwareType = "Debug",
 #else

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -99,6 +99,7 @@ public class RefreshGameServer : RefreshServer
         this.Server.AddConfig(config);
         this.Server.AddConfig(integrationConfig);
         this.Server.AddConfigFromJsonFile<RichPresenceConfig>("rpc.json");
+        this.Server.AddConfigFromJsonFile<ContactInfoConfig>("contactInfo.json");
     }
     
     protected override void SetupServices()

--- a/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
+++ b/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
@@ -28,6 +28,7 @@ public class TestRefreshGameServer : RefreshGameServer
         this.Server.AddConfig(this._config = new GameServerConfig());
         this.Server.AddConfig(new RichPresenceConfig());
         this.Server.AddConfig(new IntegrationConfig());
+        this.Server.AddConfig(new ContactInfoConfig());
     }
 
     public GameServerConfig GameServerConfig => this._config!;


### PR DESCRIPTION
Servers owner can now specify some essential contact information. Primarily we want name and email, and optionally Discord information.

Name and email **requires** support in refresh-web, but Discord can be excluded for now.