### PR TITLE
Presence: Implement `/lbp/planetStats/highestSlotId`

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/PresenceEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/PresenceEndpoints.cs
@@ -20,6 +20,10 @@ public class PresenceEndpoints : EndpointGroup
     [MinimumRole(GameUserRole.Restricted)]
     public int TotalPlayers(RequestContext context, MatchService match) => match.RoomAccessor.GetStatistics().PlayerCount;
 
+    [GameEndpoint("planetStats/highestSlotId")]
+    [MinimumRole(GameUserRole.Restricted)]
+    public int GetTotalLevelCount(RequestContext context, GameDatabaseContext database, Token token) => database.GetTotalLevelCount(token.TokenGame);
+    
     [GameEndpoint("planetStats", HttpMethods.Get, ContentType.Xml)]
     [MinimumRole(GameUserRole.Restricted)]
     public SerializedLevelStatisticsResponse GetLevelStatistics(RequestContext context, GameDatabaseContext database, Token token) => new()

--- a/RefreshTests.GameServer/Tests/Presence/PresenceEndpointTests.cs
+++ b/RefreshTests.GameServer/Tests/Presence/PresenceEndpointTests.cs
@@ -1,0 +1,22 @@
+using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Types.UserData;
+
+namespace RefreshTests.GameServer.Tests.Presence;
+
+public class PresenceEndpointTests : GameServerTest
+{
+    [Test]
+    public void GetTotalLevelCount()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+
+        HttpClient http = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet2, TokenPlatform.PS3, user);
+        
+        Assert.That(http.GetAsync("/lbp/planetStats/highestSlotId").Result.Content.ReadAsStringAsync().Result, Is.EqualTo("0"));
+        context.CreateLevel(user);
+        Assert.That(http.GetAsync("/lbp/planetStats/highestSlotId").Result.Content.ReadAsStringAsync().Result, Is.EqualTo("1"));
+        context.CreateLevel(user);
+        Assert.That(http.GetAsync("/lbp/planetStats/highestSlotId").Result.Content.ReadAsStringAsync().Result, Is.EqualTo("2"));
+    }
+}


### PR DESCRIPTION
Implementing this makes Deploy stop spamming us with requests to this endpoint