### PR TITLE
Make all our slot endpoints slotType agnostic

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -351,24 +351,18 @@ public partial class GameDatabaseContext // Levels
     [Pure]
     public GameLevel? GetLevelByIdAndType(string slotType, int id)
     {
-        GameLevel? level;
-        
         switch (slotType)
         {
             case "user":
-                level = this.GetLevelById(id);
-                break;
+                return this.GetLevelById(id);
             case "developer":
                 if (id < 0)
                     return null;
                 
-                level = this.GetStoryLevelById(id);
-                break;
+                return this.GetStoryLevelById(id);
             default:
                 return null;
         }
-        
-        return level;
     }
     
     [Pure]

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -349,6 +349,29 @@ public partial class GameDatabaseContext // Levels
     public int GetTotalTeamPickCount(TokenGame game) => this._realm.All<GameLevel>().FilterByGameVersion(game).Count(l => l.TeamPicked);
 
     [Pure]
+    public GameLevel? GetLevelByIdAndType(string slotType, int id)
+    {
+        GameLevel? level;
+        
+        switch (slotType)
+        {
+            case "user":
+                level = this.GetLevelById(id);
+                break;
+            case "developer":
+                if (id < 0)
+                    return null;
+                
+                level = this.GetStoryLevelById(id);
+                break;
+            default:
+                return null;
+        }
+        
+        return level;
+    }
+    
+    [Pure]
     public GameLevel? GetLevelById(int id) => this._realm.All<GameLevel>().FirstOrDefault(l => l.LevelId == id);
 
     private void SetLevelPickStatus(GameLevel level, bool status)

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -73,11 +73,11 @@ public class LevelEndpoints : EndpointGroup
         return this.GetLevels(context, database, categories, matchService, overrideService, user, token, dataStore, route);
     }
 
-    [GameEndpoint("s/user/{id}", ContentType.Xml)]
+    [GameEndpoint("s/{slotType}/{id}", ContentType.Xml)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
-    public GameLevelResponse? LevelById(RequestContext context, GameDatabaseContext database, MatchService matchService, GameUser user, int id, IDataStore dataStore, Token token)
-        => GameLevelResponse.FromOldWithExtraData(database.GetLevelById(id), database, matchService, user, dataStore, token.TokenGame);
+    public GameLevelResponse? LevelById(RequestContext context, GameDatabaseContext database, MatchService matchService, GameUser user, string slotType, int id, IDataStore dataStore, Token token)
+        => GameLevelResponse.FromOldWithExtraData(database.GetLevelByIdAndType(slotType, id), database, matchService, user, dataStore, token.TokenGame);
 
     [GameEndpoint("slotList", ContentType.Xml)]
     [NullStatusCode(BadRequest)]

--- a/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
@@ -17,10 +17,10 @@ namespace Refresh.GameServer.Endpoints.Game;
 
 public class RelationEndpoints : EndpointGroup
 {
-    [GameEndpoint("favourite/slot/user/{id}", HttpMethods.Post)]
-    public Response FavouriteLevel(RequestContext context, GameDatabaseContext database, GameUser user, int id)
+    [GameEndpoint("favourite/slot/{slotType}/{id}", HttpMethods.Post)]
+    public Response FavouriteLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id)
     {
-        GameLevel? level = database.GetLevelById(id);
+        GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         // On PSP, we have to lie or else the client will begin spamming the server
         // https://discord.com/channels/1049223665243389953/1049225857350254632/1153468991675838474 
         if (level == null) return context.IsPSP() ? OK : NotFound;
@@ -32,10 +32,10 @@ public class RelationEndpoints : EndpointGroup
         return context.IsPSP() ? OK : Unauthorized;
     }
     
-    [GameEndpoint("unfavourite/slot/user/{id}", HttpMethods.Post)]
-    public Response UnfavouriteLevel(RequestContext context, GameDatabaseContext database, GameUser user, int id)
+    [GameEndpoint("unfavourite/slot/{slotType}/{id}", HttpMethods.Post)]
+    public Response UnfavouriteLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id)
     {
-        GameLevel? level = database.GetLevelById(id);
+        GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         // On PSP, we have to lie or else the client will begin spamming the server
         // https://discord.com/channels/1049223665243389953/1049225857350254632/1153468991675838474 
         if (level == null) return context.IsPSP() ? OK : NotFound;
@@ -92,10 +92,10 @@ public class RelationEndpoints : EndpointGroup
         return new SerializedFavouriteUserList(GameUserResponse.FromOldListWithExtraData(users, token.TokenGame, database, dataStore).ToList(), users.Count, skip + count);
     }
 
-    [GameEndpoint("lolcatftw/add/user/{id}", HttpMethods.Post)]
-    public Response QueueLevel(RequestContext context, GameDatabaseContext database, GameUser user, int id)
+    [GameEndpoint("lolcatftw/add/{slotType}/{id}", HttpMethods.Post)]
+    public Response QueueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id)
     {
-        GameLevel? level = database.GetLevelById(id);
+        GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
         
         if (database.QueueLevel(level, user))
@@ -104,10 +104,10 @@ public class RelationEndpoints : EndpointGroup
         return Unauthorized;
     }
     
-    [GameEndpoint("lolcatftw/remove/user/{id}", HttpMethods.Post)]
-    public Response DequeueLevel(RequestContext context, GameDatabaseContext database, GameUser user, int id)
+    [GameEndpoint("lolcatftw/remove/{slotType}/{id}", HttpMethods.Post)]
+    public Response DequeueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id)
     {
-        GameLevel? level = database.GetLevelById(id);
+        GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
         
         if (database.DequeueLevel(level, user))

--- a/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
@@ -220,7 +220,7 @@ public class ScoreLeaderboardTests : GameServerTest
         }; 
         
         HttpResponseMessage message = client.PostAsync($"/lbp/scoreboard/developer/-1", new StringContent(score.AsXML())).Result;
-        Assert.That(message.StatusCode, Is.EqualTo(BadRequest));
+        Assert.That(message.StatusCode, Is.EqualTo(NotFound));
     }
     
     [Test]
@@ -232,7 +232,7 @@ public class ScoreLeaderboardTests : GameServerTest
         using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
 
         HttpResponseMessage message = client.GetAsync($"/lbp/scoreboard/developer/-1").Result;
-        Assert.That(message.StatusCode, Is.EqualTo(BadRequest));
+        Assert.That(message.StatusCode, Is.EqualTo(NotFound));
     }
     
     [Test]
@@ -244,7 +244,7 @@ public class ScoreLeaderboardTests : GameServerTest
         using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
 
         HttpResponseMessage message = client.GetAsync($"/lbp/topscores/developer/-1/1").Result;
-        Assert.That(message.StatusCode, Is.EqualTo(BadRequest));
+        Assert.That(message.StatusCode, Is.EqualTo(NotFound));
     }
     
     /// <param name="count">The number of scores to try to fetch from the database</param>

--- a/RefreshTests.GameServer/Tests/Relations/ReviewTests.cs
+++ b/RefreshTests.GameServer/Tests/Relations/ReviewTests.cs
@@ -19,6 +19,8 @@ public class ReviewTests : GameServerTest
 
         GameLevel level = slotType == "developer" ? context.Database.GetStoryLevelById(1) : context.CreateLevel(levelPublisher);
 
+        int levelId = slotType == "developer" ? 1 : level.LevelId;
+        
         context.Database.PlayLevel(level, reviewPublisher, 1);
         context.Database.Refresh();
         
@@ -30,9 +32,9 @@ public class ReviewTests : GameServerTest
             Text = "moku Sutolokanopu",
         };
         
-        Assert.That(reviewerClient.PostAsync($"/lbp/postReview/{slotType}/{level.LevelId}", new StringContent(review.AsXML())).Result.StatusCode, Is.EqualTo(OK));
+        Assert.That(reviewerClient.PostAsync($"/lbp/postReview/{slotType}/{levelId}", new StringContent(review.AsXML())).Result.StatusCode, Is.EqualTo(OK));
 
-        HttpResponseMessage response = reviewerClient.GetAsync($"/lbp/reviewsFor/{slotType}/{level.LevelId}").Result;
+        HttpResponseMessage response = reviewerClient.GetAsync($"/lbp/reviewsFor/{slotType}/{levelId}").Result;
         Assert.That(response.StatusCode, Is.EqualTo(OK));
 
         SerializedGameReviewResponse levelReviews = response.Content.ReadAsXML<SerializedGameReviewResponse>();
@@ -69,7 +71,7 @@ public class ReviewTests : GameServerTest
         
         using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
         
-        Assert.That(client.GetAsync($"/lbp/reviewsFor/badType/{level.LevelId}").Result.StatusCode, Is.EqualTo(BadRequest));
+        Assert.That(client.GetAsync($"/lbp/reviewsFor/badType/{level.LevelId}").Result.StatusCode, Is.EqualTo(NotFound));
     }
     
     [Test]
@@ -105,7 +107,7 @@ public class ReviewTests : GameServerTest
             Text = "moku Sutolokanopu",
         };
         
-        Assert.That(reviewerClient.PostAsync($"/lbp/postReview/badType/{level.LevelId}", new StringContent(review.AsXML())).Result.StatusCode, Is.EqualTo(BadRequest));
+        Assert.That(reviewerClient.PostAsync($"/lbp/postReview/badType/{level.LevelId}", new StringContent(review.AsXML())).Result.StatusCode, Is.EqualTo(NotFound));
         
         context.Database.Refresh();
         Assert.That(level.Reviews, Is.Empty);


### PR DESCRIPTION
This de-duplicates a lot of code, and also implements a bunch of currently unimplemented endpoints.

This changes behavior somewhat, but the changes are not important (returning `NotFound` for invalid slot types, rather than `BadRequest`). I can see arguments for both of these being valid to respond with, but its simplest to return NotFound here.