### PR TITLE
Allow new 'trusted' users to upload assets during read-only mode

### DIFF
--- a/Refresh.GameServer/Configuration/GameServerConfig.cs
+++ b/Refresh.GameServer/Configuration/GameServerConfig.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Bunkum.Core.Configuration;
 using Refresh.GameServer.Types.Assets;
+using Refresh.GameServer.Types.Roles;
 
 namespace Refresh.GameServer.Configuration;
 
@@ -27,6 +28,8 @@ public class GameServerConfig : Config
     public string WebExternalUrl { get; set; } = "https://refresh.example.com";
     public bool AllowInvalidTextureGuids { get; set; } = false;
     public bool BlockAssetUploads { get; set; } = false;
+    /// <seealso cref="GameUserRole.Trusted"/>
+    public bool BlockAssetUploadsForTrustedUsers { get; set; } = false;
     /// <summary>
     /// The amount of data the user is allowed to upload before all resource uploads get blocked, defaults to 100mb.
     /// </summary>

--- a/Refresh.GameServer/Endpoints/ApiV3/ResourceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ResourceApiEndpoints.cs
@@ -143,9 +143,15 @@ public class ResourceApiEndpoints : EndpointGroup
         [DocSummary("The SHA1 hash of the asset")] string hash,
         byte[] body, GameUser user)
     {
-        //If we block asset uploads, return unauthorized, unless the user is an admin
+        // If we're blocking asset uploads, throw unless the user is an admin.
+        // We also have the ability to block asset uploads for trusted users (when they would normally bypass this)
         if (config.BlockAssetUploads && user.Role != GameUserRole.Admin)
-            return ApiAuthenticationError.NoPermissionsForCreation;
+        {
+            if (user.Role < GameUserRole.Trusted || config.BlockAssetUploadsForTrustedUsers)
+            {
+                return ApiAuthenticationError.NoPermissionsForCreation;
+            }
+        }
         
         if (!CommonPatterns.Sha1Regex().IsMatch(hash)) return ApiValidationError.HashInvalidError;
 

--- a/Refresh.GameServer/Types/Roles/GameUserRole.cs
+++ b/Refresh.GameServer/Types/Roles/GameUserRole.cs
@@ -13,6 +13,10 @@ public enum GameUserRole : sbyte
     /// </summary>
     Admin = 127,
     /// <summary>
+    /// A user with special permissions. May upload assets when asset uploads are otherwise disabled.
+    /// </summary>
+    Trusted = 1,
+    /// <summary>
     /// A standard user. Can play the game, log in, play levels, review them, etc.
     /// </summary>
     User = 0,


### PR DESCRIPTION
We haven't heard back from the NCMEC yet, so here's a band-aid solution to let people upload things for the time being.

Requires a change to add the new role in refresh-web.