### PR TITLE
Add new "SafeMedia" tier between Safe and PotentiallyUnwanted

### DIFF
--- a/Refresh.GameServer/Configuration/GameServerConfig.cs
+++ b/Refresh.GameServer/Configuration/GameServerConfig.cs
@@ -9,14 +9,16 @@ namespace Refresh.GameServer.Configuration;
 [SuppressMessage("ReSharper", "RedundantDefaultMemberInitializer")]
 public class GameServerConfig : Config
 {
-    public override int CurrentConfigVersion => 11;
+    public override int CurrentConfigVersion => 12;
     public override int Version { get; set; } = 0;
 
     protected override void Migrate(int oldVer, dynamic oldConfig) {}
 
     public string LicenseText { get; set; } = "Welcome to Refresh!";
 
-    public AssetSafetyLevel MaximumAssetSafetyLevel { get; set; } = AssetSafetyLevel.Safe;
+    public AssetSafetyLevel MaximumAssetSafetyLevel { get; set; } = AssetSafetyLevel.SafeMedia;
+    /// <seealso cref="GameUserRole.Trusted"/>
+    public AssetSafetyLevel MaximumAssetSafetyLevelForTrustedUsers { get; set; } = AssetSafetyLevel.SafeMedia;
     public bool AllowUsersToUseIpAuthentication { get; set; } = false;
     public bool UseTicketVerification { get; set; } = true;
     public bool RegistrationEnabled { get; set; } = true;

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiInstanceResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiInstanceResponse.cs
@@ -40,6 +40,7 @@ public class ApiInstanceResponse : IApiResponse
     
     public required bool RegistrationEnabled { get; set; }
     public required AssetSafetyLevel MaximumAssetSafetyLevel { get; set; }
+    public required AssetSafetyLevel MaximumAssetSafetyLevelForTrustedUsers { get; set; }
     
     public required IEnumerable<ApiGameAnnouncementResponse> Announcements { get; set; }
     public required ApiRichPresenceConfigurationResponse RichPresenceConfiguration { get; set; }

--- a/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
@@ -6,6 +6,7 @@ using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Assets;
 using Refresh.GameServer.Types.Matching;
 using Refresh.GameServer.Types.RichPresence;
 
@@ -68,11 +69,14 @@ public class InstanceApiEndpoints : EndpointGroup
             SoftwareLicenseName = "AGPL-3.0",
             SoftwareLicenseUrl = "https://www.gnu.org/licenses/agpl-3.0.txt",
             MaximumAssetSafetyLevel = gameConfig.MaximumAssetSafetyLevel,
+            MaximumAssetSafetyLevelForTrustedUsers = gameConfig.MaximumAssetSafetyLevelForTrustedUsers,
             Announcements = ApiGameAnnouncementResponse.FromOldList(database.GetAnnouncements()),
             MaintenanceModeEnabled = gameConfig.MaintenanceMode,
-            RichPresenceConfiguration = ApiRichPresenceConfigurationResponse.FromOld(RichPresenceConfiguration.Create(gameConfig, richConfig))!,
+            RichPresenceConfiguration = ApiRichPresenceConfigurationResponse.FromOld(RichPresenceConfiguration.Create(
+                gameConfig,
+                richConfig))!,
             GrafanaDashboardUrl = integrationConfig.GrafanaDashboardUrl,
-            
+
             ContactInfo = new ApiContactInfoResponse
             {
                 AdminName = contactInfoConfig.AdminName,

--- a/Refresh.GameServer/Types/Assets/AssetSafetyLevel.cs
+++ b/Refresh.GameServer/Types/Assets/AssetSafetyLevel.cs
@@ -5,15 +5,20 @@ public enum AssetSafetyLevel
     /// <summary>
     /// This asset is used in normal gameplay/operation and is okay to be uploaded.
     /// </summary>
+    /// <seealso cref="SafeMedia"/>
     Safe = 0,
+    /// <summary>
+    /// This asset is still used in normal gameplay similar to <see cref="Safe"/>, and is okay to be uploaded, but the distinction can be useful.
+    /// </summary>
+    SafeMedia = 1,
     /// <summary>
     /// This asset may disrupt the "vanilla" feel of a server and it's content, but is otherwise harmless.
     /// </summary>
-    PotentiallyUnwanted = 1,
+    PotentiallyUnwanted = 2,
     /// <summary>
     /// This asset may cause harm if uploaded.
     /// </summary>
-    Dangerous = 2,
+    Dangerous = 3,
 }
 
 public static class AssetSafetyLevelExtensions
@@ -24,16 +29,17 @@ public static class AssetSafetyLevelExtensions
         {
             GameAssetType.Level => AssetSafetyLevel.Safe,
             GameAssetType.Plan => AssetSafetyLevel.Safe,
-            GameAssetType.Texture => AssetSafetyLevel.Safe,
-            GameAssetType.Jpeg => AssetSafetyLevel.Safe,
-            GameAssetType.Png => AssetSafetyLevel.Safe,
-            GameAssetType.Tga => AssetSafetyLevel.Safe,
             GameAssetType.MoveRecording => AssetSafetyLevel.Safe,
-            GameAssetType.VoiceRecording => AssetSafetyLevel.Safe,
-            GameAssetType.Painting => AssetSafetyLevel.Safe,
             GameAssetType.SyncedProfile => AssetSafetyLevel.Safe,
-            GameAssetType.Mip => AssetSafetyLevel.Safe,
             GameAssetType.GriefSongState => AssetSafetyLevel.Safe,
+            
+            GameAssetType.VoiceRecording => AssetSafetyLevel.SafeMedia,
+            GameAssetType.Painting => AssetSafetyLevel.SafeMedia,
+            GameAssetType.Texture => AssetSafetyLevel.SafeMedia,
+            GameAssetType.Jpeg => AssetSafetyLevel.SafeMedia,
+            GameAssetType.Png => AssetSafetyLevel.SafeMedia,
+            GameAssetType.Tga => AssetSafetyLevel.SafeMedia,
+            GameAssetType.Mip => AssetSafetyLevel.SafeMedia,
             
             GameAssetType.GfxMaterial => AssetSafetyLevel.PotentiallyUnwanted,
             GameAssetType.Material => AssetSafetyLevel.PotentiallyUnwanted,


### PR DESCRIPTION
This PR introduces a new tier for asset safety levels named "SafeMedia". It's intended to represent assets that are images or audio to help administrators single out images during content blocking.

Hopefully, this should replace our need to disable asset uploads on production.