### PR TITLE
Hide sub levels from people who didn't publish them

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -171,20 +171,20 @@ public partial class GameDatabaseContext // Levels
         => this._realm.All<GameLevel>().Where(l => l._Source == (int)GameLevelSource.User).FilterByGameVersion(gameVersion);
 
     [Pure]
-    public DatabaseList<GameLevel> GetLevelsByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings)
+    public DatabaseList<GameLevel> GetLevelsByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor)
     {
         if (user.Username == DeletedUser.Username)
         {
-            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(null, levelFilterSettings).Where(l => l.Publisher == null), skip, count);
+            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.Publisher == null), skip, count);
         }
 
         if (user.Username.StartsWith("!"))
         {
             string withoutPrefix = user.Username[1..];
-            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(null, levelFilterSettings).Where(l => l.OriginalPublisher == withoutPrefix), skip, count);
+            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.OriginalPublisher == withoutPrefix), skip, count);
         }
         
-        return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(null, levelFilterSettings).Where(l => l.Publisher == user), skip, count);
+        return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.Publisher == user), skip, count);
     }
 
     [Pure]

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -17,12 +17,12 @@ public partial class GameDatabaseContext // Relations
         .FirstOrDefault(r => r.Level == level && r.User == user) != null;
 
     [Pure]
-    public DatabaseList<GameLevel> GetLevelsFavouritedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings) 
+    public DatabaseList<GameLevel> GetLevelsFavouritedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor) 
         => new(this._realm.All<FavouriteLevelRelation>()
         .Where(r => r.User == user)
         .AsEnumerable()
         .Select(r => r.Level)
-        .FilterByLevelFilterSettings(null, levelFilterSettings)
+        .FilterByLevelFilterSettings(accessor, levelFilterSettings)
         .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     
     public bool FavouriteLevel(GameLevel level, GameUser user)
@@ -131,12 +131,12 @@ public partial class GameDatabaseContext // Relations
         .FirstOrDefault(r => r.Level == level && r.User == user) != null;
 
     [Pure]
-    public DatabaseList<GameLevel> GetLevelsQueuedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings)
+    public DatabaseList<GameLevel> GetLevelsQueuedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor)
         => new(this._realm.All<QueueLevelRelation>()
         .Where(r => r.User == user)
         .AsEnumerable()
         .Select(r => r.Level)
-        .FilterByLevelFilterSettings(null, levelFilterSettings)
+        .FilterByLevelFilterSettings(accessor, levelFilterSettings)
         .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     
     public bool QueueLevel(GameLevel level, GameUser user)

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -34,7 +34,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 120;
+    protected override ulong SchemaVersion => 122;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -34,7 +34,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 122;
+    protected override ulong SchemaVersion => 120;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiLevelCategoryResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiLevelCategoryResponse.cs
@@ -68,7 +68,7 @@ public class ApiLevelCategoryResponse : IApiResponse, IDataConvertableFrom<ApiLe
     {
         return oldList.Select(category =>
         {
-            DatabaseList<GameLevel>? list = category.Fetch(context, 0, 1, matchService, database, user, new LevelFilterSettings(context, TokenGame.Website));
+            DatabaseList<GameLevel>? list = category.Fetch(context, 0, 1, matchService, database, user, new LevelFilterSettings(context, TokenGame.Website), user);
             GameLevel? level = list?.Items.FirstOrDefault();
             
             return FromOld(category, level);

--- a/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
@@ -53,7 +53,7 @@ public class LevelApiEndpoints : EndpointGroup
 
         DatabaseList<GameLevel>? list = categories.Categories
             .FirstOrDefault(c => c.ApiRoute.StartsWith(route))?
-            .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, TokenGame.Website));
+            .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, TokenGame.Website), user);
 
         if (list == null) return ApiNotFoundError.Instance;
 

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -44,7 +44,7 @@ public class LevelEndpoints : EndpointGroup
 
         DatabaseList<GameLevel>? levels = categoryService.Categories
             .FirstOrDefault(c => c.GameRoutes.Any(r => r.StartsWith(route)))?
-            .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame));
+            .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame), user);
 
         if (levels == null) return null;
         
@@ -137,7 +137,7 @@ public class LevelEndpoints : EndpointGroup
 
         DatabaseList<GameLevel>? levels = categories.Categories
             .FirstOrDefault(c => c.ApiRoute.StartsWith(apiRoute))?
-            .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame));
+            .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame), user);
         
         return new SerializedMinimalLevelResultsList(levels?.Items
             .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame))!, levels?.TotalItems ?? 0, skip + count);

--- a/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
+++ b/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
@@ -66,6 +66,9 @@ public static class LevelEnumerableExtensions
         // MoveFilterType.False => levels.Where(l => !l.MoveCompatible),
         // _ => throw new ArgumentOutOfRangeException()
         // };
+        
+        // Filter out sub levels that weren't published by self
+        levels = levels.Where(l => !l.IsSubLevel || l.Publisher == user);
 
         return levels;
     }
@@ -103,6 +106,9 @@ public static class LevelEnumerableExtensions
         // MoveFilterType.False => levels.Where(l => !l.MoveCompatible),
         // _ => throw new ArgumentOutOfRangeException()
         // };
+        
+        // Filter out sub levels that weren't published by self
+        levels = levels.Where(l => !l.IsSubLevel || l.Publisher?.UserId ==  user?.UserId);
 
         return levels;
     }

--- a/Refresh.GameServer/Types/Levels/Categories/ByUserLevelCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/ByUserLevelCategory.cs
@@ -19,8 +19,8 @@ public class ByUserLevelCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user, 
-        LevelFilterSettings levelFilterSettings)
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor, 
+        LevelFilterSettings levelFilterSettings, GameUser? user)
     {
         // Prefer username from query, but fallback to user passed into this category if it's missing
         string? username = context.QueryString["u"];
@@ -28,6 +28,6 @@ public class ByUserLevelCategory : LevelCategory
 
         if (user == null) return null;
         
-        return database.GetLevelsByUser(user, count, skip, levelFilterSettings);
+        return database.GetLevelsByUser(user, count, skip, levelFilterSettings, accessor);
     }
 }

--- a/Refresh.GameServer/Types/Levels/Categories/ContestCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/ContestCategory.cs
@@ -18,7 +18,7 @@ public class ContestCategory : LevelCategory
     }
     
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService,
-        GameDatabaseContext database, GameUser? user, LevelFilterSettings levelFilterSettings)
+        GameDatabaseContext database, GameUser? accessor, LevelFilterSettings levelFilterSettings, GameUser? _)
     {
         // try to find a contest by the query parameter
         string? contestId = context.QueryString["contest"];
@@ -31,6 +31,6 @@ public class ContestCategory : LevelCategory
         if (contest == null)
             return null;
         
-        return database.GetLevelsFromContest(contest, count, skip, user, levelFilterSettings);
+        return database.GetLevelsFromContest(contest, count, skip, accessor, levelFilterSettings);
     }
 }

--- a/Refresh.GameServer/Types/Levels/Categories/CoolLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/CoolLevelsCategory.cs
@@ -17,8 +17,8 @@ public class CoolLevelsCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService,
-        GameDatabaseContext database, GameUser? user, LevelFilterSettings levelFilterSettings)
+        GameDatabaseContext database, GameUser? accessor, LevelFilterSettings levelFilterSettings, GameUser? _)
     {
-        return database.GetCoolLevels(count, skip, user, levelFilterSettings);
+        return database.GetCoolLevels(count, skip, accessor, levelFilterSettings);
     }
 }

--- a/Refresh.GameServer/Types/Levels/Categories/CurrentlyPlayingCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/CurrentlyPlayingCategory.cs
@@ -18,7 +18,7 @@ public class CurrentlyPlayingCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user,
-        LevelFilterSettings levelFilterSettings) 
-        => database.GetBusiestLevels(count, skip, matchService, user, levelFilterSettings);
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor,
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
+        => database.GetBusiestLevels(count, skip, matchService, accessor, levelFilterSettings);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/DeveloperLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/DeveloperLevelsCategory.cs
@@ -19,7 +19,7 @@ public class DeveloperLevelsCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user,
-        LevelFilterSettings levelFilterSettings) 
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor,
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
         => database.GetDeveloperLevels(count, skip, levelFilterSettings);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/FavouriteSlotsByUserCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/FavouriteSlotsByUserCategory.cs
@@ -17,11 +17,11 @@ public class FavouriteSlotsByUserCategory : LevelCategory
         this.IconHash = "g820611";
     }
     
-    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? user,
-        LevelFilterSettings levelFilterSettings)
+    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? accessor,
+        LevelFilterSettings levelFilterSettings, GameUser? user)
     {
         if (user == null) return null;
         
-        return database.GetLevelsFavouritedByUser(user, count, skip, levelFilterSettings);
+        return database.GetLevelsFavouritedByUser(user, count, skip, levelFilterSettings, accessor);
     }
 }

--- a/Refresh.GameServer/Types/Levels/Categories/HighestRatedLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/HighestRatedLevelsCategory.cs
@@ -18,7 +18,7 @@ public class HighestRatedLevelsCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user,
-        LevelFilterSettings levelFilterSettings) 
-        => database.GetHighestRatedLevels(count, skip, user, levelFilterSettings);
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor,
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
+        => database.GetHighestRatedLevels(count, skip, accessor, levelFilterSettings);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/LevelCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/LevelCategory.cs
@@ -34,6 +34,6 @@ public abstract class LevelCategory
     [JsonProperty] public readonly bool RequiresUser;
 
     [Pure]
-    public abstract DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? user,
-        LevelFilterSettings levelFilterSettings);
+    public abstract DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? accessor,
+        LevelFilterSettings levelFilterSettings, GameUser? user);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/MostHeartedLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/MostHeartedLevelsCategory.cs
@@ -18,7 +18,7 @@ public class MostHeartedLevelsCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user, 
-        LevelFilterSettings levelFilterSettings) 
-        => database.GetMostHeartedLevels(count, skip, user, levelFilterSettings);
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor, 
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
+        => database.GetMostHeartedLevels(count, skip, accessor, levelFilterSettings);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/MostReplayedLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/MostReplayedLevelsCategory.cs
@@ -18,7 +18,7 @@ public class MostReplayedLevelsCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user, 
-        LevelFilterSettings levelFilterSettings) 
-        => database.GetMostReplayedLevels(count, skip, user, levelFilterSettings);
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor, 
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
+        => database.GetMostReplayedLevels(count, skip, accessor, levelFilterSettings);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/MostUniquelyPlayedLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/MostUniquelyPlayedLevelsCategory.cs
@@ -18,7 +18,7 @@ public class MostUniquelyPlayedLevelsCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user,
-        LevelFilterSettings levelFilterSettings) 
-        => database.GetMostUniquelyPlayedLevels(count, skip, user, levelFilterSettings);
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor,
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
+        => database.GetMostUniquelyPlayedLevels(count, skip, accessor, levelFilterSettings);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/NewestLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/NewestLevelsCategory.cs
@@ -17,7 +17,7 @@ public class NewestLevelsCategory : LevelCategory
         this.FontAwesomeIcon = "calendar";
     }
     
-    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? user,
-        LevelFilterSettings levelFilterSettings) 
-        => database.GetNewestLevels(count, skip, user, levelFilterSettings);
+    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? accessor,
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
+        => database.GetNewestLevels(count, skip, accessor, levelFilterSettings);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/QueuedLevelsByUserCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/QueuedLevelsByUserCategory.cs
@@ -17,11 +17,11 @@ public class QueuedLevelsByUserCategory : LevelCategory
         this.IconHash = "g820614";
     }
     
-    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? user, 
-        LevelFilterSettings levelFilterSettings)
+    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? accessor, 
+        LevelFilterSettings levelFilterSettings, GameUser? user)
     {
         if (user == null) return null;
 
-        return database.GetLevelsQueuedByUser(user, count, skip, levelFilterSettings);
+        return database.GetLevelsQueuedByUser(user, count, skip, levelFilterSettings, accessor);
     }
 }

--- a/Refresh.GameServer/Types/Levels/Categories/RandomLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/RandomLevelsCategory.cs
@@ -17,7 +17,7 @@ public class RandomLevelsCategory : LevelCategory
         this.IconHash = "g820605";
     }
     
-    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? user, 
-        LevelFilterSettings levelFilterSettings) 
-        => database.GetRandomLevels(count, skip, user, levelFilterSettings);
+    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, MatchService matchService, GameDatabaseContext database, GameUser? accessor, 
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
+        => database.GetRandomLevels(count, skip, accessor, levelFilterSettings);
 }

--- a/Refresh.GameServer/Types/Levels/Categories/SearchLevelCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/SearchLevelCategory.cs
@@ -21,13 +21,13 @@ public class SearchLevelCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user, 
-        LevelFilterSettings levelFilterSettings)
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor, 
+        LevelFilterSettings levelFilterSettings, GameUser? _)
     {
         string? query = context.QueryString["query"]
                         ?? context.QueryString["textFilter"]; // LBP3 sends this instead of query
         if (query == null) return null;
 
-        return database.SearchForLevels(count, skip, user, levelFilterSettings, query);
+        return database.SearchForLevels(count, skip, accessor, levelFilterSettings, query);
     }
 }

--- a/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
@@ -55,7 +55,7 @@ public class SerializedCategory
     {
         SerializedCategory category = FromLevelCategory(levelCategory);
         
-        DatabaseList<GameLevel> categoryLevels = levelCategory.Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame));
+        DatabaseList<GameLevel> categoryLevels = levelCategory.Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame), user);
         
         IEnumerable<GameMinimalLevelResponse> levels = categoryLevels?.Items
             .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame)) ?? Array.Empty<GameMinimalLevelResponse>();

--- a/Refresh.GameServer/Types/Levels/Categories/TeamPickedLevelsCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/TeamPickedLevelsCategory.cs
@@ -18,7 +18,7 @@ public class TeamPickedLevelsCategory : LevelCategory
     }
 
     public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count,
-        MatchService matchService, GameDatabaseContext database, GameUser? user, 
-        LevelFilterSettings levelFilterSettings) 
-        => database.GetTeamPickedLevels(count, skip, user, levelFilterSettings);
+        MatchService matchService, GameDatabaseContext database, GameUser? accessor, 
+        LevelFilterSettings levelFilterSettings, GameUser? _) 
+        => database.GetTeamPickedLevels(count, skip, accessor, levelFilterSettings);
 }

--- a/RefreshTests.GameServer/Tests/Levels/PublishEndpointsTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/PublishEndpointsTests.cs
@@ -413,7 +413,7 @@ public class PublishEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/unpublish/{level.LevelId}", new ReadOnlyMemoryContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
 
-        DatabaseList<GameLevel> levelsByUser = context.Database.GetLevelsByUser(user, 1, 0, new LevelFilterSettings(TokenGame.LittleBigPlanet3));
+        DatabaseList<GameLevel> levelsByUser = context.Database.GetLevelsByUser(user, 1, 0, new LevelFilterSettings(TokenGame.LittleBigPlanet3), user);
         Assert.That(levelsByUser.TotalItems, Is.EqualTo(0));
     }
 
@@ -442,7 +442,7 @@ public class PublishEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/unpublish/{level.LevelId}", new ReadOnlyMemoryContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(Unauthorized));
 
-        DatabaseList<GameLevel> levelsByUser = context.Database.GetLevelsByUser(user1, 1, 0, new LevelFilterSettings(TokenGame.LittleBigPlanet3));
+        DatabaseList<GameLevel> levelsByUser = context.Database.GetLevelsByUser(user1, 1, 0, new LevelFilterSettings(TokenGame.LittleBigPlanet3), user1);
         Assert.That(levelsByUser.TotalItems, Is.EqualTo(1));
     }
 }


### PR DESCRIPTION
Fixes #332, #347

This required a minor category refactor due to how they previously used the accessor and content user interchangeably 

![image](https://github.com/LittleBigRefresh/Refresh/assets/51852312/479c6101-0363-4d66-bb66-33538aa773aa)
![image](https://github.com/LittleBigRefresh/Refresh/assets/51852312/e03499cc-821a-42de-b48f-20b16d0a5064)
