### PR TITLE
Fix blank OriginalPublisher issues

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -138,10 +138,18 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         }
         else
         {
+            string publisher;
+            if (!old.IsReUpload)
+                publisher = "!DeletedUser";
+            else
+                publisher = string.IsNullOrEmpty(old.OriginalPublisher)
+                    ? "!UnknownPublisher"
+                    : "!" + old.OriginalPublisher;
+            
             response.Handle = new SerializedUserHandle
             {
                 IconHash = "0",
-                Username = string.IsNullOrEmpty(old.OriginalPublisher) ? "!DeletedUser" : "!" + old.OriginalPublisher,
+                Username = publisher,
             };
         }
         


### PR DESCRIPTION
When the OriginalPublisher was null, but a level was marked as a reupload, it would lead to issues. This PR fixes that.

![image](https://github.com/LittleBigRefresh/Refresh/assets/51852312/34317428-01dd-47a2-85e3-ca4170fcac00)
