### PR TITLE
Make the Docker unhealthy check a little more portable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM mcr.microsoft.com/dotnet/runtime:8.0.3-bookworm-slim AS final
 # Add non-root user
 RUN set -eux && \
 apt update && \
-apt install -y gosu && \
+apt install -y gosu curl && \
 rm -rf /var/lib/apt/lists/* && \
 gosu nobody true && \
 groupadd -g 1001 refresh && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       BUNKUM_DATA_FOLDER: /refresh/data
     healthcheck:
       # Fails if the /_health endpoint contains 'Unhealthy'
-      test: ["CMD", "bash", "-c", "export UNHEALTHY=$(curl http://localhost:10061/_health --silent | grep -q Unhealthy); if [ '$UNHEALTHY' != '' ]; then exit 1; else exit 0; fi"]
+      test: ["CMD", "bash", "-c", "export UNHEALTHY=$(curl http://localhost:10061/_health --silent | grep -i Unhealthy); if [ '$UNHEALTHY' != '' ]; then exit 1; else exit 0; fi"]
       timeout: 3s
       interval: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       BUNKUM_DATA_FOLDER: /refresh/data
     healthcheck:
       # Fails if the /_health endpoint contains 'Unhealthy'
-      test: ["CMD", "bash", "-c", "exec 5<>/dev/tcp/127.0.0.1/10061 && echo -e 'GET /_health HTTP/1.1\nHost: localhost\n\n' >&5 && cat <&5 | grep -q Unhealthy && exit 1"]
+      test: ["CMD", "bash", "-c", "export UNHEALTHY=$(curl http://localhost:10061/_health --silent | grep -q Unhealthy); if [ '$UNHEALTHY' != '' ]; then exit 1; else exit 0; fi"]
       timeout: 3s
       interval: 5s
       retries: 5


### PR DESCRIPTION
Hello! I stumbled across this project while setting up a Project Lighthouse server (and dealing with a lack of documentation or working Docker configuration, eventually ending up with writing my own scripts and a badgering LICENSE VIOLATION warning all over the place), and decided to switch to it from there.

Upon doing so, I was greeted with what I thought was originally a critical error, but quickly resolved to an issue with the unhealthy check:
```
refresh-gameserver  |  ---> System.IndexOutOfRangeException: Index was outside the bounds of the array.
refresh-gameserver  |    at Bunkum.Protocols.Http.Socket.SocketHttpListener.ReadRequestIntoContext(Socket client, Stream stream)
refresh-gameserver  |    --- End of inner exception stack trace ---
refresh-gameserver  |    at Bunkum.Protocols.Http.Socket.SocketHttpListener.ReadRequestIntoContext(Socket client, Stream stream)
refresh-gameserver  |    at Bunkum.Protocols.Http.Socket.SocketHttpListener.WaitForConnectionAsyncInternal(Nullable`1 globalCt)
```

Upon further investigation, I found that it's because the referenced `/dev/tcp/127.0.0.1/10061` path doesn't exist on my Docker configuration. In fact, `/dev/tcp` doesn't exist in the container or on the host at all.

This is likely due to how I'm using macOS for my Docker host, although I can test this in Windows later to see if the issue is present there. Either way, the Docker container was being filled with the above error and reading the container as Unhealthy, even though everything was fine, clients could connect, website was good, etc.

I whipped up a few quick changes to make the Docker container report the proper status for my situation, and it should work just fine for other deployments.

LMK if there's an issue with something here!