### PR TITLE
"hash" hashed level hashes to generate unique level IDs

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -78,11 +78,25 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlElement("commentCount")] public int CommentCount { get; set; } = 0;
     [XmlElement("commentsEnabled")] public bool CommentsEnabled { get; set; } = true;
     
+    /// <summary>
+    /// Provides a unique level ID for ~1.1 billion hashed levels, uses the hash directly, so this is deterministic
+    /// </summary>
+    /// <param name="hash"></param>
+    /// <returns></returns>
+    public static int LevelIdFromHash(string hash)
+    {
+        const int rangeStart = 1_000_000_000;
+        const int rangeEnd = int.MaxValue;
+        const int range = rangeEnd - rangeStart;
+        
+        return rangeStart + Math.Abs(hash.GetHashCode()) % range;
+    }
+    
     public static GameLevelResponse FromHash(string hash)
     {
         return new GameLevelResponse
         {
-            LevelId = int.MaxValue,
+            LevelId = LevelIdFromHash(hash),
             Title = $"Hashed Level - {hash}",
             IconHash = "0",
             GameVersion = 0,

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -96,10 +96,10 @@ public class LevelEndpoints : EndpointGroup
     public GameLevelResponse? LevelById(RequestContext context, GameDatabaseContext database, MatchService matchService, 
         GameUser user, string slotType, int id, IDataStore dataStore, Token token, LevelListOverrideService overrideService)
     {
-        if (id == int.MaxValue && overrideService.GetLastHashOverrideForUser(token, out string hash))
-        {
+        // If the user has had a hash override in the past, and the level id they requested matches the level ID associated with that hash
+        if (overrideService.GetLastHashOverrideForUser(token, out string hash) && GameLevelResponse.LevelIdFromHash(hash) == id)
+            // Return the hashed level info
             return GameLevelResponse.FromHash(hash);
-        }
         
         return GameLevelResponse.FromOldWithExtraData(database.GetLevelByIdAndType(slotType, id), database,
             matchService, user, dataStore, token.TokenGame);


### PR DESCRIPTION
This fixes LBP3 which will complain about "upgrading" the level when the level ID is reused.