### PR TITLE
GetPageData slight refactor

### DIFF
--- a/Refresh.GameServer/Endpoints/ApiV3/ActivityApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ActivityApiEndpoints.cs
@@ -30,7 +30,7 @@ public class ActivityApiEndpoints : EndpointGroup
         string? tsStr = context.QueryString["timestamp"];
         if (tsStr != null && !long.TryParse(tsStr, out timestamp)) return ApiValidationError.NumberParseError;
         
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
 
         ActivityPage page = ActivityPage.GlobalActivity(database, new ActivityQueryParameters
         {
@@ -57,7 +57,7 @@ public class ActivityApiEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.Instance;
         
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
         
         ActivityPage page = ActivityPage.ApiLevelActivity(database, level, new ActivityQueryParameters
         {

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminUserApiEndpoints.cs
@@ -47,7 +47,7 @@ public class AdminUserApiEndpoints : EndpointGroup
     [DocUsesPageData]
     public ApiListResponse<ApiExtendedGameUserResponse> GetExtendedUsers(RequestContext context, GameDatabaseContext database, IDataStore dataStore)
     {
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
         DatabaseList<ApiExtendedGameUserResponse> list = DatabaseList<ApiExtendedGameUserResponse>.FromOldList<ApiExtendedGameUserResponse, GameUser>(database.GetUsers(count, skip));
         //Fill in the extra data of all the users
         foreach (ApiExtendedGameUserResponse user in list.Items) user.FillInExtraData(database, dataStore);

--- a/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
@@ -183,7 +183,7 @@ public class AuthenticationApiEndpoints : EndpointGroup
     [DocSummary("Retrieves a list of IP addresses that have attempted to connect.")]
     public ApiListResponse<ApiGameIpVerificationRequestResponse> GetVerificationRequests(RequestContext context, GameDatabaseContext database, GameUser user)
     {
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
 
         return DatabaseList<ApiGameIpVerificationRequestResponse>.FromOldList<ApiGameIpVerificationRequestResponse, GameIpVerificationRequest>
                 (database.GetIpVerificationRequestsForUser(user, count, skip));

--- a/Refresh.GameServer/Endpoints/ApiV3/LeaderboardApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LeaderboardApiEndpoints.cs
@@ -28,7 +28,7 @@ public class LeaderboardApiEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
         
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
 
         bool result = bool.TryParse(context.QueryString.Get("showAll") ?? "false", out bool showAll);
         if (!result) return ApiValidationError.BooleanParseError;

--- a/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
@@ -49,7 +49,7 @@ public class LevelApiEndpoints : EndpointGroup
         [DocSummary("The name of the category you'd like to retrieve levels from. " +
                     "Make a request to /levels to see a list of available categories")] string route)
     {
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
 
         DatabaseList<GameLevel>? list = categories.Categories
             .FirstOrDefault(c => c.ApiRoute.StartsWith(route))?

--- a/Refresh.GameServer/Endpoints/ApiV3/MatchingApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/MatchingApiEndpoints.cs
@@ -68,7 +68,7 @@ public class MatchingApiEndpoints : EndpointGroup
     [DocUsesPageData, DocSummary("Gets all rooms on the server")]
     public ApiListResponse<ApiGameRoomResponse> GetRooms(RequestContext context, MatchService service)
     {
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
         return new DatabaseList<ApiGameRoomResponse>(ApiGameRoomResponse.FromOldList(service.RoomAccessor.GetAllRooms()), skip, count);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/NotificationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/NotificationApiEndpoints.cs
@@ -22,7 +22,7 @@ public class NotificationApiEndpoints : EndpointGroup
     [DocUsesPageData, DocSummary("Gets a list of notifications stored for the user")]
     public ApiListResponse<ApiGameNotificationResponse> GetNotifications(RequestContext context, GameUser user, GameDatabaseContext database)
     {
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
         DatabaseList<GameNotification> notifications = database.GetNotificationsByUser(user, count, skip);
         return DatabaseList<ApiGameNotificationResponse>.FromOldList<ApiGameNotificationResponse, GameNotification>(notifications);
     }

--- a/Refresh.GameServer/Endpoints/ApiV3/PhotoApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/PhotoApiEndpoints.cs
@@ -36,7 +36,7 @@ public class PhotoApiEndpoints : EndpointGroup
     private static ApiListResponse<ApiGamePhotoResponse> PhotosByUser(RequestContext context, GameDatabaseContext database, GameUser? user, IDataStore dataStore)
     {
         if (user == null) return ApiNotFoundError.Instance;
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
 
         DatabaseList<GamePhoto> photos = database.GetPhotosByUser(user, count, skip);
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos);
@@ -47,7 +47,7 @@ public class PhotoApiEndpoints : EndpointGroup
     private static ApiListResponse<ApiGamePhotoResponse> PhotosWithUser(RequestContext context, GameDatabaseContext database, GameUser? user, IDataStore dataStore)
     {
         if (user == null) return ApiNotFoundError.Instance;
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
 
         DatabaseList<GamePhoto> photos = database.GetPhotosWithUser(user, count, skip);
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos);
@@ -58,7 +58,7 @@ public class PhotoApiEndpoints : EndpointGroup
     private static ApiListResponse<ApiGamePhotoResponse> PhotosInLevel(RequestContext context, GameDatabaseContext database, GameLevel? level, IDataStore dataStore)
     {
         if (level == null) return ApiNotFoundError.Instance;
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
 
         DatabaseList<GamePhoto> photos = database.GetPhotosInLevel(level, count, skip);
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos);
@@ -108,7 +108,7 @@ public class PhotoApiEndpoints : EndpointGroup
     [DocUsesPageData, DocSummary("Get all photos taken recently")]
     public ApiListResponse<ApiGamePhotoResponse> RecentPhotos(RequestContext context, GameDatabaseContext database, IDataStore dataStore)
     {
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
         DatabaseList<GamePhoto> photos = database.GetRecentPhotos(count, skip);
 
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos);

--- a/Refresh.GameServer/Endpoints/ApiV3/ReviewApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ReviewApiEndpoints.cs
@@ -25,7 +25,7 @@ public class ReviewApiEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
         
-        (int skip, int count) = context.GetPageData(true);
+        (int skip, int count) = context.GetPageData();
         
         DatabaseList<GameReview> reviews = database.GetReviewsForLevel(level, count, skip);
         DatabaseList<ApiGameReviewResponse> ret = DatabaseList<ApiGameScoreResponse>.FromOldList<ApiGameReviewResponse, GameReview>(reviews);

--- a/Refresh.GameServer/Extensions/RequestContextExtensions.cs
+++ b/Refresh.GameServer/Extensions/RequestContextExtensions.cs
@@ -6,15 +6,18 @@ namespace Refresh.GameServer.Extensions;
 public static class RequestContextExtensions
 {
     [Pure]
-    public static (int, int) GetPageData(this RequestContext context, bool api = false, int maxCount = 100)
+    public static (int, int) GetPageData(this RequestContext context)
     {
-        int.TryParse(context.QueryString[api ? "skip" : "pageStart"], out int skip);
-        if (skip != default) skip--;
+        const int maxCount = 100;
+        bool api = context.IsApi();
         
-        int.TryParse(context.QueryString[api ? "count" : "pageSize"], out int count);
-        if (count == default) count = 20;
-
-        if (count > maxCount) count = maxCount;
+        bool parsed = int.TryParse(context.QueryString[api ? "skip" : "pageStart"], out int skip);
+        if (parsed) skip--; // If we parsed, subtract the number of items to skip by one to prevent an off-by-one.
+        
+        parsed = int.TryParse(context.QueryString[api ? "count" : "pageSize"], out int count);
+        if (!parsed) count = 20; // Default items in a page
+        
+        count = Math.Clamp(count, 0, maxCount);
 
         return (skip, count);
     }
@@ -23,5 +26,5 @@ public static class RequestContextExtensions
     public static bool IsPSP(this RequestContext context) => context.RequestHeaders.Get("User-Agent") == "LBPPSP CLIENT";
 
     [Pure]
-    public static bool IsApi(this RequestContext context) => context.Url.AbsolutePath.StartsWith("/api");
+    public static bool IsApi(this RequestContext context) => context.Url.AbsolutePath.StartsWith("/api/");
 }


### PR DESCRIPTION
- Automatically determine `api` parameter
  Prevents us from mistakenly setting `api` to false in an API route and having the wrong behaviour be applied.
- Replace the `maxCount` parameter with a constant
  We weren't actually overriding the default of 100 anywhere.
- Properly use `int.TryParse`
  Before, we were checking against the default value. Why? I don't know. Now we use the boolean result as we should have been doing.