### PR TITLE
Tweaks to object expiry

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
@@ -104,7 +104,7 @@ public partial class GameDatabaseContext // Registration
             Username = username,
             EmailAddress = emailAddress,
             PasswordBcrypt = passwordBcrypt,
-            ExpiryDate = this._time.Now + TimeSpan.FromDays(1), // This registration expires in 1 day
+            ExpiryDate = this._time.Now + TimeSpan.FromHours(1),
         };
 
         this._realm.Write(() =>

--- a/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
@@ -132,6 +132,11 @@ public partial class GameDatabaseContext // Tokens
             this._realm.RemoveRange(this._realm.All<Token>().Where(t => t.User == user && t._TokenType == (int)type));
         });
     }
+    
+    public bool IsTokenExpired(Token token) => token.ExpiresAt < this._time.Now;
+    
+    public DatabaseList<Token> GetAllTokens()
+        => new(this._realm.All<Token>());
 
     public void AddIpVerificationRequest(GameUser user, string ipAddress)
     {

--- a/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
@@ -263,8 +263,8 @@ public class AuthenticationApiEndpoints : EndpointGroup
             database.AddRegistrationToQueue(body.Username, body.EmailAddress, passwordBcrypt);
             return new ApiAuthenticationError(
                 "Your account has been put into the registration queue, but it is not yet activated. " +
-                "To complete registration, simply log in from LBP within the next hour and your new account will be activated. " +
-                "You will be unable to sign in until you are patched and playing.", true);
+                "To complete registration, patch your games to our servers and start playing within the next hour and your new account will be activated. " +
+                "You will be unable to sign in until you are patched and playing. For more instructions on patching, please visit https://docs.littlebigrefresh.com", true);
         }
 
         GameUser user = database.CreateUser(body.Username, body.EmailAddress, true);

--- a/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
@@ -262,8 +262,9 @@ public class AuthenticationApiEndpoints : EndpointGroup
         {
             database.AddRegistrationToQueue(body.Username, body.EmailAddress, passwordBcrypt);
             return new ApiAuthenticationError(
-                "Your account has been created, but it is not yet activated. " +
-                "To complete registration, simply log in from LBP and your new account will be activated.", true);
+                "Your account has been put into the registration queue, but it is not yet activated. " +
+                "To complete registration, simply log in from LBP within the next hour and your new account will be activated. " +
+                "You will be unable to sign in until you are patched and playing.", true);
         }
 
         GameUser user = database.CreateUser(body.Username, body.EmailAddress, true);

--- a/Refresh.GameServer/Workers/ExpiredObjectWorker.cs
+++ b/Refresh.GameServer/Workers/ExpiredObjectWorker.cs
@@ -8,7 +8,7 @@ namespace Refresh.GameServer.Workers;
 
 public class ExpiredObjectWorker : IWorker
 {
-    public int WorkInterval => 300_000; // 5 minutes
+    public int WorkInterval => 60_000; // 1 minute
     public void DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database)
     {
         foreach (QueuedRegistration registration in database.GetAllQueuedRegistrations().Items)

--- a/Refresh.GameServer/Workers/ExpiredObjectWorker.cs
+++ b/Refresh.GameServer/Workers/ExpiredObjectWorker.cs
@@ -1,5 +1,6 @@
 using Bunkum.Core.Storage;
 using NotEnoughLogs;
+using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.UserData;
 
@@ -24,6 +25,14 @@ public class ExpiredObjectWorker : IWorker
             
             logger.LogInfo(RefreshContext.Worker, $"Removed {code.User}'s verification code since it has expired");
             database.RemoveEmailVerificationCode(code);
+        }
+        
+        foreach (Token token in database.GetAllTokens().Items)
+        {
+            if (!database.IsTokenExpired(token)) continue;
+            
+            logger.LogInfo(RefreshContext.Worker, $"Removed {token.User}'s {token.TokenType} token since it has expired {DateTimeOffset.Now - token.ExpiresAt} ago");
+            database.RevokeToken(token);
         }
     }
 }


### PR DESCRIPTION
- [Make registrations expire in 1 hour](https://github.com/LittleBigRefresh/Refresh/commit/75a777670f85ddbff1fd668d1d8906c23b1a98c7)
    Hopefully shouldn't backfire. The goal is to help users who accidentally signed up with the wrong usernames. Should result in less admin intervention.
- [Remove tokens when expired](https://github.com/LittleBigRefresh/Refresh/commit/5d1bdab6fc22b88973014dc258ff7ca4f5b29aaf)
    We were originally storing these for historical purposes, but we never used this data.
    The first time this runs, it will take a very long time (roughly 10-30 minutes) on production as we don't do any batching when removing these tokens from Realm, but it won't be an issue as new tokens expire. **This will not block startup. This operation will run in the background.**

    Closes #418.
- [Shorten ExpiredObjectWorker work interval to 1 minute](https://github.com/LittleBigRefresh/Refresh/commit/d978f3a00c52511e0948e8a21e1b0295d246d1a8)
    Don't see why not.