### PR TITLE
Move request tracking submission to background worker

### DIFF
--- a/Refresh.GameServer/Configuration/GameServerConfig.cs
+++ b/Refresh.GameServer/Configuration/GameServerConfig.cs
@@ -9,7 +9,7 @@ namespace Refresh.GameServer.Configuration;
 [SuppressMessage("ReSharper", "RedundantDefaultMemberInitializer")]
 public class GameServerConfig : Config
 {
-    public override int CurrentConfigVersion => 14;
+    public override int CurrentConfigVersion => 15;
     public override int Version { get; set; } = 0;
 
     protected override void Migrate(int oldVer, dynamic oldConfig) {}
@@ -26,7 +26,6 @@ public class GameServerConfig : Config
     public string InstanceDescription { get; set; } = "A server running Refresh!";
     public bool MaintenanceMode { get; set; } = false;
     public bool RequireGameLoginToRegister { get; set; } = false;
-    public bool TrackRequestStatistics { get; set; } = false;
     /// <summary>
     /// Whether to use deflate compression for responses.
     /// If this is disabled, large enough responses will cause LBP to overflow its read buffer and eventually corrupt its own memory to the point of crashing.

--- a/Refresh.GameServer/Database/GameDatabaseContext.Statistics.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Statistics.cs
@@ -18,21 +18,21 @@ public partial class GameDatabaseContext // Statistics
         return statistics;
     }
     
-    public void IncrementApiRequests()
+    public void IncrementApiRequests(int count)
     {
         RequestStatistics statistics = this.GetRequestStatistics();
         this._realm.Write(() => {
-            statistics.TotalRequests++;
-            statistics.ApiRequests++;
+            statistics.TotalRequests += count;
+            statistics.ApiRequests += count;
         });
     }
     
-    public void IncrementGameRequests()
+    public void IncrementGameRequests(int count)
     {
         RequestStatistics statistics = this.GetRequestStatistics();
         this._realm.Write(() => {
-            statistics.TotalRequests++;
-            statistics.GameRequests++;
+            statistics.TotalRequests += count;
+            statistics.GameRequests += count;
         });
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
@@ -18,20 +18,7 @@ public class InstanceApiEndpoints : EndpointGroup
     [DocSummary("Retrieves various statistics about the Refresh instance.")]
     public ApiResponse<ApiStatisticsResponse> GetStatistics(RequestContext context, GameDatabaseContext database, MatchService match, GameServerConfig config)
     {
-        ApiRequestStatisticsResponse requestStatistics;
-        if (!config.TrackRequestStatistics)
-        {
-            requestStatistics = new ApiRequestStatisticsResponse
-            {
-                TotalRequests = -1,
-                ApiRequests = -1,
-                GameRequests = -1,
-            };
-        }
-        else
-        {
-            requestStatistics = ApiRequestStatisticsResponse.FromOld(database.GetRequestStatistics())!;
-        }
+        ApiRequestStatisticsResponse requestStatistics = ApiRequestStatisticsResponse.FromOld(database.GetRequestStatistics())!;
 
         RoomStatistics statistics = match.RoomAccessor.GetStatistics();
         

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -149,6 +149,7 @@ public class RefreshGameServer : RefreshServer
         this.WorkerManager.AddWorker<PunishmentExpiryWorker>();
         this.WorkerManager.AddWorker<ExpiredObjectWorker>();
         this.WorkerManager.AddWorker<CoolLevelsWorker>();
+        this.WorkerManager.AddWorker<RequestStatisticSubmitWorker>();
         
         if ((this._integrationConfig?.DiscordWebhookEnabled ?? false) && this._config != null)
         {

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -130,8 +130,7 @@ public class RefreshGameServer : RefreshServer
         this.Server.AddService<RoleService>();
         this.Server.AddService<SmtpService>();
 
-        if (this._config!.TrackRequestStatistics)
-            this.Server.AddService<RequestStatisticTrackingService>();
+        this.Server.AddService<RequestStatisticTrackingService>();
         
         this.Server.AddService<LevelListOverrideService>();
         

--- a/Refresh.GameServer/Workers/RequestStatisticSubmitWorker.cs
+++ b/Refresh.GameServer/Workers/RequestStatisticSubmitWorker.cs
@@ -1,8 +1,6 @@
 using Bunkum.Core.Storage;
 using NotEnoughLogs;
 using Refresh.GameServer.Database;
-using Refresh.GameServer.Services;
-
 using TrackingService = Refresh.GameServer.Services.RequestStatisticTrackingService;
 
 namespace Refresh.GameServer.Workers;
@@ -13,12 +11,9 @@ public class RequestStatisticSubmitWorker : IWorker
     
     public void DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database)
     {
-        lock (TrackingService.TrackerLock)
-        {
-            database.IncrementGameRequests(TrackingService.GameRequestsToSubmit);
-            database.IncrementApiRequests(TrackingService.ApiRequestsToSubmit);
-            
-            TrackingService.ClearRequests();
-        }
+        (int game, int api) = TrackingService.SubmitAndClearRequests();
+        
+        database.IncrementGameRequests(game);
+        database.IncrementApiRequests(api);
     }
 }

--- a/Refresh.GameServer/Workers/RequestStatisticSubmitWorker.cs
+++ b/Refresh.GameServer/Workers/RequestStatisticSubmitWorker.cs
@@ -1,0 +1,24 @@
+using Bunkum.Core.Storage;
+using NotEnoughLogs;
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Services;
+
+using TrackingService = Refresh.GameServer.Services.RequestStatisticTrackingService;
+
+namespace Refresh.GameServer.Workers;
+
+public class RequestStatisticSubmitWorker : IWorker
+{
+    public int WorkInterval => 5_000;
+    
+    public void DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database)
+    {
+        lock (TrackingService.TrackerLock)
+        {
+            database.IncrementGameRequests(TrackingService.GameRequestsToSubmit);
+            database.IncrementApiRequests(TrackingService.ApiRequestsToSubmit);
+            
+            TrackingService.ClearRequests();
+        }
+    }
+}


### PR DESCRIPTION
This massively improves performance of ***all*** requests by incrementing the request counters in a background thread every 5 seconds, as opposed to the previous solution of incrementing by one upon every request.

Since we are no longer committing to Realm every request, we also remove the ability to disable request tracking as there is no performance penalty for having it on.

This brings all requests down from roughly an average of 8-16ms all the way down to 1-2ms. For large swarms of requests such as a level downloader grabbing assets from us at high speeds, this can reduce write speeds of up to 30mb/s to practically nothing, as well as reducing peak request times from 130ms to the same 1-2ms.