### PR TITLE
Search by publisher

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -348,7 +348,7 @@ public partial class GameDatabaseContext // Levels
         }
         
         // Try to look up a username to search by publisher.
-        GameUser? publisher = this.GetUserByUsername(query); 
+        GameUser? publisher = this.GetUserByUsername(query, false); 
         if (publisher != null)
         {
             levels.AddRange(validLevels.Where(l => l.Publisher == publisher));

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -346,8 +346,15 @@ public partial class GameDatabaseContext // Levels
                 levels.Add(idLevel);
             }
         }
+        
+        // Try to look up a username to search by publisher.
+        GameUser? publisher = this.GetUserByUsername(query); 
+        if (publisher != null)
+        {
+            levels.AddRange(validLevels.Where(l => l.Publisher == publisher));
+        }
 
-        return new DatabaseList<GameLevel>(levels, skip, count);
+        return new DatabaseList<GameLevel>(levels.OrderByDescending(l => l.Score), skip, count);
     }
 
     [Pure]

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using JetBrains.Annotations;
 using MongoDB.Bson;
+using Realms;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Types;
@@ -23,7 +24,7 @@ public partial class GameDatabaseContext // Users
     
     [Pure]
     [ContractAnnotation("null => null; notnull => canbenull")]
-    public GameUser? GetUserByUsername(string? username)
+    public GameUser? GetUserByUsername(string? username, bool caseSensitive = true)
     {
         if (username == null) return null;
         if (username == "!DeletedUser")
@@ -36,7 +37,10 @@ public partial class GameDatabaseContext // Users
                 Description = "I'm a fake user that represents a non existent publisher for re-published levels.",
                 FakeUser = true,
             };
-
+        
+        if (!caseSensitive)
+            return this._realm.All<GameUser>().FirstOrDefault(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
+        
         return this._realm.All<GameUser>().FirstOrDefault(u => u.Username == username);
     }
     

--- a/Refresh.GameServer/Endpoints/Game/Handshake/MetadataEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Handshake/MetadataEndpoints.cs
@@ -34,7 +34,7 @@ public class MetadataEndpoints : EndpointGroup
     {
         IEnumerable<GameUser> friends = body.FriendsList.Names
             .Take(128) // should be way more than enough - we'll see if this becomes a problem
-            .Select(database.GetUserByUsername)
+            .Select(username => database.GetUserByUsername(username))
             .Where(u => u != null)!;
         
         foreach (GameUser userToFavourite in friends)


### PR DESCRIPTION
This introduces a few changes to make this possible:

- We add the ability to find users by their usernames without requiring case sensitivity. This is controlled by a new optional parameter in `GetUserByUsername`. This is free to be used in other areas of the codebase when necessary, but for this PR it's just used in Search.
- I changed the ordering to sort by CR. Should hopefully improve ranking and help people find what they're looking for, e.g. the skateboard extreme everyone plays instead of the one that got reuploaded for the 7892364th time 2 minutes ago.