### PR TITLE
Cool Levels May 2024 Rebalance

### DIFF
--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -104,7 +104,7 @@ public class CoolLevelsWorker : IWorker
         float score = level.IsReUpload ? 0 : 15;
         
         const float positiveRatingPoints = 5;
-        const float uniquePlayPoints = 1;
+        const float uniquePlayPoints = 0.1f;
         const float heartPoints = 5;
         const float trustedAuthorPoints = 5;
 

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -111,9 +111,20 @@ public class CoolLevelsWorker : IWorker
         if (level.TeamPicked)
             score += 50;
         
-        score += level.Ratings.Count(r => r._RatingType == (int)RatingType.Yay) * positiveRatingPoints;
-        score += level.UniquePlays.Count() * uniquePlayPoints;
+        int positiveRatings = level.Ratings.Count(r => r._RatingType == (int)RatingType.Yay);
+        int negativeRatings = level.Ratings.Count(r => r._RatingType == (int)RatingType.Boo);
+        int uniquePlays = level.UniquePlays.Count();
+        
+        score += positiveRatings * positiveRatingPoints;
+        score += uniquePlays * uniquePlayPoints;
         score += level.FavouriteRelations.Count() * heartPoints;
+        
+        // Reward for a good ratio between plays and yays
+        float ratingRatio = (positiveRatings - negativeRatings) / (float)uniquePlays;
+        if (ratingRatio > 0.5f)
+        {
+            score += positiveRatings * (positiveRatingPoints * ratingRatio);
+        }
 
         if (level.Publisher?.Role == GameUserRole.Trusted)
             score += trustedAuthorPoints;

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -48,8 +48,8 @@ public class CoolLevelsWorker : IWorker
                 
                 // Calculate positive & negative score separately so we don't run into issues with
                 // the multiplier having an opposite effect with the negative score as time passes
-                int positiveScore = CalculatePositiveScore(logger, level);
-                int negativeScore = CalculateNegativeScore(logger, level);
+                float positiveScore = CalculatePositiveScore(logger, level);
+                float negativeScore = CalculateNegativeScore(logger, level);
                 
                 // Increase to tweak how little negative score gets affected by decay
                 const int negativeScoreMultiplier = 2;
@@ -97,16 +97,16 @@ public class CoolLevelsWorker : IWorker
         return multiplier;
     }
 
-    private static int CalculatePositiveScore(Logger logger, GameLevel level)
+    private static float CalculatePositiveScore(Logger logger, GameLevel level)
     {
         // Start levels off with a few points to prevent one dislike from bombing the level
         // Don't apply this bonus to reuploads to discourage a flood of 15CR levels.
-        int score = level.IsReUpload ? 0 : 15;
+        float score = level.IsReUpload ? 0 : 15;
         
-        const int positiveRatingPoints = 5;
-        const int uniquePlayPoints = 1;
-        const int heartPoints = 5;
-        const int trustedAuthorPoints = 5;
+        const float positiveRatingPoints = 5;
+        const float uniquePlayPoints = 1;
+        const float heartPoints = 5;
+        const float trustedAuthorPoints = 5;
 
         if (level.TeamPicked)
             score += 50;
@@ -122,13 +122,13 @@ public class CoolLevelsWorker : IWorker
         return score;
     }
 
-    private static int CalculateNegativeScore(Logger logger, GameLevel level)
+    private static float CalculateNegativeScore(Logger logger, GameLevel level)
     {
-        int penalty = 0;
-        const int negativeRatingPenalty = 5;
-        const int noAuthorPenalty = 10;
-        const int restrictedAuthorPenalty = 50;
-        const int bannedAuthorPenalty = 100;
+        float penalty = 0;
+        const float negativeRatingPenalty = 5;
+        const float noAuthorPenalty = 10;
+        const float restrictedAuthorPenalty = 50;
+        const float bannedAuthorPenalty = 100;
         
         penalty += level.Ratings.Count(r => r._RatingType == (int)RatingType.Boo) * negativeRatingPenalty;
         

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -81,7 +81,7 @@ public class CoolLevelsWorker : IWorker
 
     private static float CalculateLevelDecayMultiplier(Logger logger, long now, GameLevel level)
     {
-        const int decayMonths = 3;
+        const int decayMonths = 2;
         const int decaySeconds = decayMonths * 30 * 24 * 3600;
         const float minimumMultiplier = 0.1f;
         

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -100,7 +100,7 @@ public class CoolLevelsWorker : IWorker
     private static int CalculatePositiveScore(Logger logger, GameLevel level)
     {
         // Start levels off with a few points to prevent one dislike from bombing the level
-        // Don't apply this bonus to reuploads.
+        // Don't apply this bonus to reuploads to discourage a flood of 15CR levels.
         int score = level.IsReUpload ? 0 : 15;
         
         const int positiveRatingPoints = 5;
@@ -109,7 +109,7 @@ public class CoolLevelsWorker : IWorker
         const int trustedAuthorPoints = 5;
 
         if (level.TeamPicked)
-            score += 10;
+            score += 50;
         
         score += level.Ratings.Count(r => r._RatingType == (int)RatingType.Yay) * positiveRatingPoints;
         score += level.UniquePlays.Count() * uniquePlayPoints;

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -99,7 +99,10 @@ public class CoolLevelsWorker : IWorker
 
     private static int CalculatePositiveScore(Logger logger, GameLevel level)
     {
-        int score = 15; // Start levels off with a few points to prevent one dislike from bombing the level
+        // Start levels off with a few points to prevent one dislike from bombing the level
+        // Don't apply this bonus to reuploads.
+        int score = level.IsReUpload ? 0 : 15;
+        
         const int positiveRatingPoints = 5;
         const int uniquePlayPoints = 1;
         const int heartPoints = 5;

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -105,7 +105,7 @@ public class CoolLevelsWorker : IWorker
         
         const float positiveRatingPoints = 5;
         const float uniquePlayPoints = 0.1f;
-        const float heartPoints = 5;
+        const float heartPoints = 10;
         const float trustedAuthorPoints = 5;
 
         if (level.TeamPicked)

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -52,10 +52,10 @@ public class CoolLevelsWorker : IWorker
                 float negativeScore = CalculateNegativeScore(logger, level);
                 
                 // Increase to tweak how little negative score gets affected by decay
-                const int negativeScoreMultiplier = 2;
+                const int negativeScoreDecayMultiplier = 2;
                 
                 // Weigh everything with the multiplier and set a final score
-                float finalScore = (positiveScore * decayMultiplier) - (negativeScore * Math.Min(1.0f, decayMultiplier * negativeScoreMultiplier));
+                float finalScore = (positiveScore * decayMultiplier) - (negativeScore * Math.Min(1.0f, decayMultiplier * negativeScoreDecayMultiplier));
                 
                 Log(logger, LogLevel.Debug, "Score for '{0}' ({1}) is {2}", level.Title, level.LevelId, finalScore);
                 scoresToSet.Add(level, finalScore);
@@ -130,6 +130,9 @@ public class CoolLevelsWorker : IWorker
         const float restrictedAuthorPenalty = 50;
         const float bannedAuthorPenalty = 100;
         
+        // The percentage of how much penalty should be applied at the end of the calculation.
+        const float penaltyMultiplier = 0.75f;
+        
         penalty += level.Ratings.Count(r => r._RatingType == (int)RatingType.Boo) * negativeRatingPenalty;
         
         if (level.Publisher == null)
@@ -140,6 +143,6 @@ public class CoolLevelsWorker : IWorker
             penalty += bannedAuthorPenalty;
 
         Log(logger, LogLevel.Trace, "negativeScore is {0}", penalty);
-        return penalty;
+        return penalty * penaltyMultiplier;
     }
 }


### PR DESCRIPTION
- Removes 15 CR bonus to new levels if they are reuploads
- Bumps the team pick bonus from 10 to 50
- Changes time required to fully decay from 3 months to 2 months
- Only reward 0.1 positive score per unique play (was 1 point before)
- Only apply 75% of the calculated negative score
- Adjust reward for hearts to 10 positive score
- Add a reward for a good ratio between plays and yays