### PR TITLE
Replace `FillInExtraData` system with a new `DataContext` object in `IDataConvertableFrom`

### DIFF
--- a/Refresh.GameServer/Database/DatabaseList.cs
+++ b/Refresh.GameServer/Database/DatabaseList.cs
@@ -1,4 +1,5 @@
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Database;
 
@@ -54,11 +55,12 @@ public class DatabaseList<TObject> where TObject : class
     //     return newList;
     // }
     
-    public static DatabaseList<TNewObject> FromOldList<TNewObject, TOldObject>(DatabaseList<TOldObject> oldList)
+    public static DatabaseList<TNewObject> FromOldList<TNewObject, TOldObject>(DatabaseList<TOldObject> oldList,
+        DataContext dataContext)
         where TNewObject : class, IDataConvertableFrom<TNewObject, TOldObject>
         where TOldObject : class
     {
-        DatabaseList<TNewObject> newList = new(oldList.TotalItems, oldList.NextPageIndex, TNewObject.FromOldList(oldList.Items));
+        DatabaseList<TNewObject> newList = new(oldList.TotalItems, oldList.NextPageIndex, TNewObject.FromOldList(oldList.Items, dataContext));
         return newList;
     }
 

--- a/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
@@ -4,10 +4,14 @@ namespace Refresh.GameServer.Database;
 
 public partial class GameDatabaseContext // AssetConfiguration
 {
-    public GameAsset? GetAssetFromHash(string hash) =>
-        this._realm.All<GameAsset>()
+    public GameAsset? GetAssetFromHash(string hash)
+    {
+        if (hash == "0" || hash.StartsWith('g')) return null;
+        
+        return this._realm.All<GameAsset>()
             .FirstOrDefault(a => a.AssetHash == hash);
-
+    }
+    
     public GameAssetType? GetConvertedType(string hash)
     {
         IQueryable<GameAsset> assets = this._realm.All<GameAsset>();

--- a/Refresh.GameServer/Endpoints/ApiV3/ActivityApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ActivityApiEndpoints.cs
@@ -10,6 +10,7 @@ using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Activity;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.UserData;
 
@@ -23,7 +24,8 @@ public class ActivityApiEndpoints : EndpointGroup
     [DocUsesPageData, DocSummary("Fetch a list of recent happenings on the server.")]
     [DocQueryParam("timestamp", "A timestamp in unix seconds, used to search backwards.")]
     [DocError(typeof(ApiValidationError), ApiValidationError.NumberParseErrorWhen)]
-    public ApiResponse<ApiActivityPageResponse> GetRecentActivity(RequestContext context, GameDatabaseContext database, IDataStore dataStore)
+    public ApiResponse<ApiActivityPageResponse> GetRecentActivity(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         long timestamp = 0;
 
@@ -37,8 +39,8 @@ public class ActivityApiEndpoints : EndpointGroup
             Timestamp = timestamp,
             Count = count,
             Skip = skip,
-        }, false);
-        return ApiActivityPageResponse.FromOldWithExtraData(page, database, dataStore);
+        }, dataContext, false);
+        return ApiActivityPageResponse.FromOldWithExtraData(page, database, dataStore, dataContext);
     }
     
     [ApiV3Endpoint("levels/id/{id}/activity"), Authentication(false)]
@@ -46,8 +48,9 @@ public class ActivityApiEndpoints : EndpointGroup
     [DocQueryParam("timestamp", "A timestamp in unix seconds, used to search backwards")]
     [DocError(typeof(ApiValidationError), ApiValidationError.NumberParseErrorWhen)]
     [DocError(typeof(ApiNotFoundError), "The level could not be found")]
-    public ApiResponse<ApiActivityPageResponse> GetRecentActivityForLevel(RequestContext context, GameDatabaseContext database, IDataStore dataStore, GameUser? user,
-        [DocSummary("The ID of the level")] int id)
+    public ApiResponse<ApiActivityPageResponse> GetRecentActivityForLevel(RequestContext context,
+        GameDatabaseContext database, IDataStore dataStore, GameUser? user,
+        [DocSummary("The ID of the level")] int id, DataContext dataContext)
     {
         long timestamp = 0;
 
@@ -65,7 +68,7 @@ public class ActivityApiEndpoints : EndpointGroup
             Skip = skip,
             Count = count,
             User = user,
-        }, false);
-        return ApiActivityPageResponse.FromOldWithExtraData(page, database, dataStore);
+        }, dataContext, false);
+        return ApiActivityPageResponse.FromOldWithExtraData(page, database, dataStore, dataContext);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/ActivityApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ActivityApiEndpoints.cs
@@ -40,7 +40,7 @@ public class ActivityApiEndpoints : EndpointGroup
             Count = count,
             Skip = skip,
         }, dataContext, false);
-        return ApiActivityPageResponse.FromOldWithExtraData(page, database, dataStore, dataContext);
+        return ApiActivityPageResponse.FromOld(page, dataContext);
     }
     
     [ApiV3Endpoint("levels/id/{id}/activity"), Authentication(false)]
@@ -69,6 +69,6 @@ public class ActivityApiEndpoints : EndpointGroup
             Count = count,
             User = user,
         }, dataContext, false);
-        return ApiActivityPageResponse.FromOldWithExtraData(page, database, dataStore, dataContext);
+        return ApiActivityPageResponse.FromOld(page, dataContext);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminAnnouncementsApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminAnnouncementsApiEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Notifications;
 using Refresh.GameServer.Types.Roles;
 
@@ -18,10 +19,11 @@ public class AdminAnnouncementsApiEndpoints : EndpointGroup
 {
     [ApiV3Endpoint("admin/announcements", HttpMethods.Post), MinimumRole(GameUserRole.Admin)]
     [DocSummary("Creates an announcement that shows up in the Instance API endpoint")]
-    public ApiResponse<ApiGameAnnouncementResponse> CreateAnnouncement(RequestContext context, GameDatabaseContext database, ApiGameAnnouncementRequest body)
+    public ApiResponse<ApiGameAnnouncementResponse> CreateAnnouncement(RequestContext context,
+        GameDatabaseContext database, ApiGameAnnouncementRequest body, DataContext dataContext)
     {
         GameAnnouncement announcement = database.AddAnnouncement(body.Title, body.Text);
-        return ApiGameAnnouncementResponse.FromOld(announcement);
+        return ApiGameAnnouncementResponse.FromOld(announcement, dataContext);
     }
 
     [ApiV3Endpoint("admin/announcements/{idStr}", HttpMethods.Delete), MinimumRole(GameUserRole.Admin)]

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminContestApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminContestApiEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Types.Contests;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
@@ -21,7 +22,8 @@ public class AdminContestApiEndpoints : EndpointGroup
     [DocError(typeof(ApiValidationError), ApiValidationError.ResourceExistsErrorWhen)]
     [DocError(typeof(ApiValidationError), ApiValidationError.ObjectIdParseErrorWhen)]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiResponse<ApiContestResponse> CreateContest(RequestContext context, GameDatabaseContext database, ApiContestRequest body, string id)
+    public ApiResponse<ApiContestResponse> CreateContest(RequestContext context, GameDatabaseContext database,
+        ApiContestRequest body, string id, DataContext dataContext)
     {
         if (database.GetContestById(id) != null)
             return ApiValidationError.ResourceExistsError;
@@ -52,7 +54,7 @@ public class AdminContestApiEndpoints : EndpointGroup
         
         database.CreateContest(contest);
         
-        return ApiContestResponse.FromOld(contest);
+        return ApiContestResponse.FromOld(contest, dataContext);
     }
     
     [ApiV3Endpoint("admin/contests/{id}", HttpMethods.Delete), MinimumRole(GameUserRole.Admin)]

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -44,15 +45,16 @@ public class AdminLevelApiEndpoints : EndpointGroup
     [DocSummary("Updates a level.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     [DocError(typeof(ApiAuthenticationError), ApiAuthenticationError.NoPermissionsForObjectWhen)]
-    public ApiResponse<ApiGameLevelResponse> EditLevelById(RequestContext context, GameDatabaseContext database, GameUser user,
-        [DocSummary("The ID of the level")] int id, ApiAdminEditLevelRequest body)
+    public ApiResponse<ApiGameLevelResponse> EditLevelById(RequestContext context, GameDatabaseContext database,
+        GameUser user,
+        [DocSummary("The ID of the level")] int id, ApiAdminEditLevelRequest body, DataContext dataContext)
     {
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
         level = database.UpdateLevel(body, level);
 
-        return ApiGameLevelResponse.FromOld(level);
+        return ApiGameLevelResponse.FromOld(level, dataContext);
     }
     
     [ApiV3Endpoint("admin/levels/id/{id}", HttpMethods.Delete), MinimumRole(GameUserRole.Admin)]

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminRegistrationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminRegistrationApiEndpoints.cs
@@ -8,6 +8,7 @@ using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Admin;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
@@ -17,15 +18,16 @@ public class AdminRegistrationApiEndpoints : EndpointGroup
 {
     [ApiV3Endpoint("admin/registrations"), MinimumRole(GameUserRole.Admin)]
     [DocSummary("Retrieves all queued registrations on the server.")]
-    public ApiListResponse<ApiAdminQueuedRegistrationResponse> GetAllQueuedRegistrations(RequestContext context, GameDatabaseContext database) 
-        => new(ApiAdminQueuedRegistrationResponse.FromOldList(database.GetAllQueuedRegistrations().Items));
+    public ApiListResponse<ApiAdminQueuedRegistrationResponse> GetAllQueuedRegistrations(RequestContext context,
+        GameDatabaseContext database, DataContext dataContext) 
+        => new(ApiAdminQueuedRegistrationResponse.FromOldList(database.GetAllQueuedRegistrations().Items, dataContext));
 
     [ApiV3Endpoint("admin/registrations/{uuid}"), MinimumRole(GameUserRole.Admin)]
     [DocSummary("Retrieves a single registration by its UUID.")]
     [DocError(typeof(ApiValidationError), ApiValidationError.ObjectIdParseErrorWhen)]
     [DocError(typeof(ApiNotFoundError), "The registration could not be found")]
     public ApiResponse<ApiAdminQueuedRegistrationResponse> GetQueuedRegistrationByUuid(RequestContext context,
-        GameDatabaseContext database, string uuid)
+        GameDatabaseContext database, string uuid, DataContext dataContext)
     {
         bool parsed = ObjectId.TryParse(uuid, out ObjectId id);
         if (!parsed) return ApiValidationError.ObjectIdParseError;
@@ -33,7 +35,7 @@ public class AdminRegistrationApiEndpoints : EndpointGroup
         QueuedRegistration? registration = database.GetQueuedRegistrationByObjectId(id);
         if (registration == null) return ApiNotFoundError.Instance;
         
-        return ApiAdminQueuedRegistrationResponse.FromOld(registration);
+        return ApiAdminQueuedRegistrationResponse.FromOld(registration, dataContext);
     }
 
     [ApiV3Endpoint("admin/registrations/{uuid}", HttpMethods.Delete), MinimumRole(GameUserRole.Admin)]

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminUserApiEndpoints.cs
@@ -12,6 +12,7 @@ using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Admin;
 using Refresh.GameServer.Extensions;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 using Refresh.GameServer.Verification;
@@ -23,32 +24,35 @@ public class AdminUserApiEndpoints : EndpointGroup
     [ApiV3Endpoint("admin/users/name/{username}"), MinimumRole(GameUserRole.Admin)]
     [DocSummary("Gets a user by their name with extended information.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiResponse<ApiExtendedGameUserResponse> GetExtendedUserByUsername(RequestContext context, GameDatabaseContext database, string username, IDataStore dataStore)
+    public ApiResponse<ApiExtendedGameUserResponse> GetExtendedUserByUsername(RequestContext context,
+        GameDatabaseContext database, string username, IDataStore dataStore, DataContext dataContext)
     {
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return ApiNotFoundError.UserMissingError;
 
-        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore);
+        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
     }
 
     [ApiV3Endpoint("admin/users/uuid/{uuid}"), MinimumRole(GameUserRole.Admin)]
     [DocSummary("Gets a user by their UUID with extended information.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiResponse<ApiExtendedGameUserResponse> GetExtendedUserByUuid(RequestContext context, GameDatabaseContext database, string uuid, IDataStore dataStore)
+    public ApiResponse<ApiExtendedGameUserResponse> GetExtendedUserByUuid(RequestContext context,
+        GameDatabaseContext database, string uuid, IDataStore dataStore, DataContext dataContext)
     {
         GameUser? user = database.GetUserByUuid(uuid);
         if (user == null) return ApiNotFoundError.UserMissingError;
 
-        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore);
+        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
     }
 
     [ApiV3Endpoint("admin/users"), MinimumRole(GameUserRole.Admin)]
     [DocSummary("Gets all users with extended information.")]
     [DocUsesPageData]
-    public ApiListResponse<ApiExtendedGameUserResponse> GetExtendedUsers(RequestContext context, GameDatabaseContext database, IDataStore dataStore)
+    public ApiListResponse<ApiExtendedGameUserResponse> GetExtendedUsers(RequestContext context,
+        GameDatabaseContext database, IDataStore dataStore, DataContext dataContext)
     {
         (int skip, int count) = context.GetPageData();
-        DatabaseList<ApiExtendedGameUserResponse> list = DatabaseList<ApiExtendedGameUserResponse>.FromOldList<ApiExtendedGameUserResponse, GameUser>(database.GetUsers(count, skip));
+        DatabaseList<ApiExtendedGameUserResponse> list = DatabaseList<ApiExtendedGameUserResponse>.FromOldList<ApiExtendedGameUserResponse, GameUser>(database.GetUsers(count, skip), dataContext);
         //Fill in the extra data of all the users
         foreach (ApiExtendedGameUserResponse user in list.Items) user.FillInExtraData(database, dataStore);
         return list;

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminUserApiEndpoints.cs
@@ -30,7 +30,7 @@ public class AdminUserApiEndpoints : EndpointGroup
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return ApiNotFoundError.UserMissingError;
 
-        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
+        return ApiExtendedGameUserResponse.FromOld(user, dataContext);
     }
 
     [ApiV3Endpoint("admin/users/uuid/{uuid}"), MinimumRole(GameUserRole.Admin)]
@@ -42,7 +42,7 @@ public class AdminUserApiEndpoints : EndpointGroup
         GameUser? user = database.GetUserByUuid(uuid);
         if (user == null) return ApiNotFoundError.UserMissingError;
 
-        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
+        return ApiExtendedGameUserResponse.FromOld(user, dataContext);
     }
 
     [ApiV3Endpoint("admin/users"), MinimumRole(GameUserRole.Admin)]
@@ -53,8 +53,6 @@ public class AdminUserApiEndpoints : EndpointGroup
     {
         (int skip, int count) = context.GetPageData();
         DatabaseList<ApiExtendedGameUserResponse> list = DatabaseList<ApiExtendedGameUserResponse>.FromOldList<ApiExtendedGameUserResponse, GameUser>(database.GetUsers(count, skip), dataContext);
-        //Fill in the extra data of all the users
-        foreach (ApiExtendedGameUserResponse user in list.Items) user.FillInExtraData(database, dataStore);
         return list;
     }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
@@ -15,6 +15,7 @@ using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 using Refresh.GameServer.Verification;
@@ -181,12 +182,13 @@ public class AuthenticationApiEndpoints : EndpointGroup
     // IP Verification
     [ApiV3Endpoint("verificationRequests"), MinimumRole(GameUserRole.Restricted)]
     [DocSummary("Retrieves a list of IP addresses that have attempted to connect.")]
-    public ApiListResponse<ApiGameIpVerificationRequestResponse> GetVerificationRequests(RequestContext context, GameDatabaseContext database, GameUser user)
+    public ApiListResponse<ApiGameIpVerificationRequestResponse> GetVerificationRequests(RequestContext context,
+        GameDatabaseContext database, GameUser user, DataContext dataContext)
     {
         (int skip, int count) = context.GetPageData();
 
         return DatabaseList<ApiGameIpVerificationRequestResponse>.FromOldList<ApiGameIpVerificationRequestResponse, GameIpVerificationRequest>
-                (database.GetIpVerificationRequestsForUser(user, count, skip));
+                (database.GetIpVerificationRequestsForUser(user, count, skip), dataContext);
     }
 
     [ApiV3Endpoint("verificationRequests/approve", HttpMethods.Put)]

--- a/Refresh.GameServer/Endpoints/ApiV3/ContestApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ContestApiEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Types.Contests;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
@@ -19,27 +20,30 @@ public class ContestApiEndpoints : EndpointGroup
     [ApiV3Endpoint("contests"), Authentication(false)]
     [DocSummary("Gets all contests.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ContestMissingErrorWhen)]
-    public ApiListResponse<ApiContestResponse> GetAllContests(RequestContext context, GameDatabaseContext database)
+    public ApiListResponse<ApiContestResponse> GetAllContests(RequestContext context, GameDatabaseContext database,
+        DataContext dataContext)
     {
-        return new ApiListResponse<ApiContestResponse>(ApiContestResponse.FromOldList(database.GetAllContests()));
+        return new ApiListResponse<ApiContestResponse>(ApiContestResponse.FromOldList(database.GetAllContests(), dataContext));
     }
     
     [ApiV3Endpoint("contests/{id}"), Authentication(false)]
     [DocSummary("Gets a contest by the contest's unique ID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ContestMissingErrorWhen)]
-    public ApiResponse<ApiContestResponse> GetContest(RequestContext context, GameDatabaseContext database, string id)
+    public ApiResponse<ApiContestResponse> GetContest(RequestContext context, GameDatabaseContext database, string id,
+        DataContext dataContext)
     {
         GameContest? contest = database.GetContestById(id);
         if (contest == null) return ApiNotFoundError.ContestMissingError;
         
-        return ApiContestResponse.FromOld(contest);
+        return ApiContestResponse.FromOld(contest, dataContext);
     }
     
     [ApiV3Endpoint("contests/{id}", HttpMethods.Patch)]
     [DocSummary("Allows an admin/organizer to update their contest details")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ContestMissingErrorWhen)]
     [DocError(typeof(ApiAuthenticationError), ApiAuthenticationError.NoPermissionsForObjectWhen)]
-    public ApiResponse<ApiContestResponse> UpdateContest(RequestContext context, GameDatabaseContext database, string id, ApiContestRequest body, GameUser user)
+    public ApiResponse<ApiContestResponse> UpdateContest(RequestContext context, GameDatabaseContext database,
+        string id, ApiContestRequest body, GameUser user, DataContext dataContext)
     {
         GameContest? contest = database.GetContestById(id);
         if (contest == null) return ApiNotFoundError.ContestMissingError;
@@ -57,6 +61,6 @@ public class ContestApiEndpoints : EndpointGroup
         
         database.UpdateContest(body, contest, organizer);
         
-        return ApiContestResponse.FromOld(contest);
+        return ApiContestResponse.FromOld(contest, dataContext);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/IDataConvertableFrom.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/IDataConvertableFrom.cs
@@ -1,8 +1,10 @@
+using Refresh.GameServer.Types.Data;
+
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes;
 
 public interface IDataConvertableFrom<out TNew, in TOld> where TNew : IDataConvertableFrom<TNew, TOld>
 {
-    public static abstract TNew? FromOld(TOld? old);
+    public static abstract TNew? FromOld(TOld? old, DataContext dataContext);
 
-    public static abstract IEnumerable<TNew> FromOldList(IEnumerable<TOld> oldList);
+    public static abstract IEnumerable<TNew> FromOldList(IEnumerable<TOld> oldList, DataContext dataContext);
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Admin/ApiAdminQueuedRegistrationResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Admin/ApiAdminQueuedRegistrationResponse.cs
@@ -1,3 +1,4 @@
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Admin;
@@ -10,7 +11,7 @@ public class ApiAdminQueuedRegistrationResponse : IApiResponse, IDataConvertable
     public required string EmailAddress { get; set; }
     public required DateTimeOffset ExpiryDate { get; set; }
     
-    public static ApiAdminQueuedRegistrationResponse? FromOld(QueuedRegistration? old)
+    public static ApiAdminQueuedRegistrationResponse? FromOld(QueuedRegistration? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -23,5 +24,6 @@ public class ApiAdminQueuedRegistrationResponse : IApiResponse, IDataConvertable
         };
     }
 
-    public static IEnumerable<ApiAdminQueuedRegistrationResponse> FromOldList(IEnumerable<QueuedRegistration> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiAdminQueuedRegistrationResponse> FromOldList(IEnumerable<QueuedRegistration> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiActivityPageResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiActivityPageResponse.cs
@@ -26,24 +26,6 @@ public class ApiActivityPageResponse : IApiResponse, IDataConvertableFrom<ApiAct
         };
     }
 
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore)
-    {
-        foreach (ApiGameScoreResponse score in this.Scores) score.FillInExtraData(database, dataStore);
-        foreach (ApiGameUserResponse user in this.Users) user.FillInExtraData(database, dataStore);
-        foreach (ApiGameLevelResponse level in this.Levels) level.FillInExtraData(database, dataStore);
-    }
-    
-    public static ApiActivityPageResponse? FromOldWithExtraData(ActivityPage? old, GameDatabaseContext database,
-        IDataStore dataStore, DataContext dataContext)
-    {
-        if (old == null) return null;
-
-        ApiActivityPageResponse response = FromOld(old, dataContext)!;
-        response.FillInExtraData(database, dataStore);
-
-        return response;
-    }
-
     public static IEnumerable<ApiActivityPageResponse> FromOldList(IEnumerable<ActivityPage> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiActivityPageResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiActivityPageResponse.cs
@@ -1,6 +1,7 @@
 using Bunkum.Core.Storage;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.Activity;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
@@ -12,16 +13,16 @@ public class ApiActivityPageResponse : IApiResponse, IDataConvertableFrom<ApiAct
     public required IEnumerable<ApiGameLevelResponse> Levels { get; set; }
     public required IEnumerable<ApiGameScoreResponse> Scores { get; set; }
     
-    public static ApiActivityPageResponse? FromOld(ActivityPage? old)
+    public static ApiActivityPageResponse? FromOld(ActivityPage? old, DataContext dataContext)
     {
         if (old == null) return null;
 
         return new ApiActivityPageResponse
         {
-            Events = ApiEventResponse.FromOldList(old.Events),
-            Users = ApiGameUserResponse.FromOldList(old.Users),
-            Levels = ApiGameLevelResponse.FromOldList(old.Levels),
-            Scores = ApiGameScoreResponse.FromOldList(old.Scores),
+            Events = ApiEventResponse.FromOldList(old.Events, dataContext),
+            Users = ApiGameUserResponse.FromOldList(old.Users, dataContext),
+            Levels = ApiGameLevelResponse.FromOldList(old.Levels, dataContext),
+            Scores = ApiGameScoreResponse.FromOldList(old.Scores, dataContext),
         };
     }
 
@@ -32,15 +33,17 @@ public class ApiActivityPageResponse : IApiResponse, IDataConvertableFrom<ApiAct
         foreach (ApiGameLevelResponse level in this.Levels) level.FillInExtraData(database, dataStore);
     }
     
-    public static ApiActivityPageResponse? FromOldWithExtraData(ActivityPage? old, GameDatabaseContext database, IDataStore dataStore)
+    public static ApiActivityPageResponse? FromOldWithExtraData(ActivityPage? old, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         if (old == null) return null;
 
-        ApiActivityPageResponse response = FromOld(old)!;
+        ApiActivityPageResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, dataStore);
 
         return response;
     }
 
-    public static IEnumerable<ApiActivityPageResponse> FromOldList(IEnumerable<ActivityPage> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiActivityPageResponse> FromOldList(IEnumerable<ActivityPage> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiContestResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiContestResponse.cs
@@ -1,5 +1,6 @@
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Types.Contests;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
@@ -20,13 +21,13 @@ public class ApiContestResponse : IApiResponse, IDataConvertableFrom<ApiContestR
     public required IEnumerable<TokenGame> AllowedGames { get; set; }
     public required ApiGameLevelResponse? TemplateLevel { get; set; }
     
-    public static ApiContestResponse? FromOld(GameContest? old)
+    public static ApiContestResponse? FromOld(GameContest? old, DataContext dataContext)
     {
         if (old == null) return null;
         return new ApiContestResponse
         {
             ContestId = old.ContestId,
-            Organizer = ApiGameUserResponse.FromOld(old.Organizer)!,
+            Organizer = ApiGameUserResponse.FromOld(old.Organizer, dataContext)!,
             CreationDate = old.CreationDate,
             StartDate = old.StartDate,
             EndDate = old.EndDate,
@@ -37,9 +38,9 @@ public class ApiContestResponse : IApiResponse, IDataConvertableFrom<ApiContestR
             ContestDetails = old.ContestDetails,
             ContestTheme = old.ContestTheme,
             AllowedGames = old.AllowedGames,
-            TemplateLevel = ApiGameLevelResponse.FromOld(old.TemplateLevel),
+            TemplateLevel = ApiGameLevelResponse.FromOld(old.TemplateLevel, dataContext),
         };
     }
     
-    public static IEnumerable<ApiContestResponse> FromOldList(IEnumerable<GameContest> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiContestResponse> FromOldList(IEnumerable<GameContest> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiErrorResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiErrorResponse.cs
@@ -1,9 +1,10 @@
 using AttribDoc;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class ApiErrorResponse : IApiResponse, IDataConvertableFrom<ApiErrorResponse, Error>
+public class ApiErrorResponse : IApiResponse
 {
     public required string Name { get; set; }
     public required string OccursWhen { get; set; }
@@ -19,5 +20,5 @@ public class ApiErrorResponse : IApiResponse, IDataConvertableFrom<ApiErrorRespo
         };
     }
 
-    public static IEnumerable<ApiErrorResponse> FromOldList(IEnumerable<Error> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiErrorResponse> FromOldList(IEnumerable<Error> oldList) => oldList.Select(old => FromOld(old)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiEventResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiEventResponse.cs
@@ -1,4 +1,5 @@
 using Refresh.GameServer.Types.Activity;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
@@ -13,7 +14,7 @@ public class ApiEventResponse : IApiResponse, IDataConvertableFrom<ApiEventRespo
     public required int? StoredSequentialId { get; set; }
     public required string? StoredObjectId { get; set; }
     
-    public static ApiEventResponse? FromOld(Event? old)
+    public static ApiEventResponse? FromOld(Event? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -29,5 +30,5 @@ public class ApiEventResponse : IApiResponse, IDataConvertableFrom<ApiEventRespo
         };
     }
 
-    public static IEnumerable<ApiEventResponse> FromOldList(IEnumerable<Event> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiEventResponse> FromOldList(IEnumerable<Event> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiExtendedGameUserResponse.cs
@@ -47,7 +47,7 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
         {
             UserId = user.UserId.ToString()!,
             Username = user.Username,
-            IconHash = user.IconHash,
+            IconHash = dataContext.Database.GetAssetFromHash(user.IconHash)?.GetAsIcon(TokenGame.Website, dataContext) ?? user.IconHash,
             Description = user.Description,
             Location = ApiGameLocationResponse.FromGameLocation(user.Location)!,
             JoinDate = user.JoinDate,
@@ -65,26 +65,7 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
             UnescapeXmlSequences = user.UnescapeXmlSequences,
         };
     }
-    
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore)
-    {
-        this.IconHash = database.GetAssetFromHash(this.IconHash)?.GetAsIcon(TokenGame.Website, database, dataStore) ?? this.IconHash;
-    }
-    
-    public static ApiExtendedGameUserResponse? FromOldWithExtraData(GameUser? old, GameDatabaseContext database,
-        IDataStore dataStore, DataContext dataContext)
-    {
-        if (old == null) return null;
-
-        ApiExtendedGameUserResponse response = FromOld(old, dataContext)!;
-        response.FillInExtraData(database, dataStore);
-
-        return response;
-    }
 
     public static IEnumerable<ApiExtendedGameUserResponse> FromOldList(IEnumerable<GameUser> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
-    
-    public static IEnumerable<ApiExtendedGameUserResponse> FromOldListWithExtraData(IEnumerable<GameUser> oldList,
-        GameDatabaseContext database, IDataStore dataStore, DataContext dataContext) => oldList.Select(old => FromOldWithExtraData(old, database, dataStore, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiExtendedGameUserResponse.cs
@@ -2,6 +2,7 @@ using Bunkum.Core.Storage;
 using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
@@ -38,7 +39,7 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     public required bool ShouldResetPassword { get; set; }
     
     [ContractAnnotation("null => null; notnull => notnull")]
-    public static ApiExtendedGameUserResponse? FromOld(GameUser? user)
+    public static ApiExtendedGameUserResponse? FromOld(GameUser? user, DataContext dataContext)
     {
         if (user == null) return null;
         
@@ -70,17 +71,20 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
         this.IconHash = database.GetAssetFromHash(this.IconHash)?.GetAsIcon(TokenGame.Website, database, dataStore) ?? this.IconHash;
     }
     
-    public static ApiExtendedGameUserResponse? FromOldWithExtraData(GameUser? old, GameDatabaseContext database, IDataStore dataStore)
+    public static ApiExtendedGameUserResponse? FromOldWithExtraData(GameUser? old, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         if (old == null) return null;
 
-        ApiExtendedGameUserResponse response = FromOld(old)!;
+        ApiExtendedGameUserResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, dataStore);
 
         return response;
     }
 
-    public static IEnumerable<ApiExtendedGameUserResponse> FromOldList(IEnumerable<GameUser> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiExtendedGameUserResponse> FromOldList(IEnumerable<GameUser> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
     
-    public static IEnumerable<ApiExtendedGameUserResponse> FromOldListWithExtraData(IEnumerable<GameUser> oldList, GameDatabaseContext database, IDataStore dataStore) => oldList.Select(old => FromOldWithExtraData(old, database, dataStore)).ToList()!;
+    public static IEnumerable<ApiExtendedGameUserResponse> FromOldListWithExtraData(IEnumerable<GameUser> oldList,
+        GameDatabaseContext database, IDataStore dataStore, DataContext dataContext) => oldList.Select(old => FromOldWithExtraData(old, database, dataStore, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameAnnouncementResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameAnnouncementResponse.cs
@@ -1,3 +1,4 @@
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Notifications;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -10,7 +11,7 @@ public class ApiGameAnnouncementResponse : IApiResponse, IDataConvertableFrom<Ap
     public required string Text { get; set; }
     public required DateTimeOffset CreatedAt { get; set; }
     
-    public static ApiGameAnnouncementResponse? FromOld(GameAnnouncement? old)
+    public static ApiGameAnnouncementResponse? FromOld(GameAnnouncement? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -23,5 +24,6 @@ public class ApiGameAnnouncementResponse : IApiResponse, IDataConvertableFrom<Ap
         };
     }
 
-    public static IEnumerable<ApiGameAnnouncementResponse> FromOldList(IEnumerable<GameAnnouncement> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameAnnouncementResponse> FromOldList(IEnumerable<GameAnnouncement> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameAssetResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameAssetResponse.cs
@@ -1,6 +1,7 @@
 using Bunkum.Core.Storage;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.Assets;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
@@ -13,25 +14,26 @@ public class ApiGameAssetResponse : IApiResponse, IDataConvertableFrom<ApiGameAs
     public required GameAssetType AssetType { get; set; }
     public required IEnumerable<string> Dependencies { get; set; }
     
-    public static ApiGameAssetResponse? FromOld(GameAsset? old)
+    public static ApiGameAssetResponse? FromOld(GameAsset? old, DataContext dataContext)
     {
         if (old == null) return null;
 
         return new ApiGameAssetResponse
         {
             AssetHash = old.AssetHash,
-            OriginalUploader = ApiGameUserResponse.FromOld(old.OriginalUploader),
+            OriginalUploader = ApiGameUserResponse.FromOld(old.OriginalUploader, dataContext),
             UploadDate = old.UploadDate,
             AssetType = old.AssetType,
             Dependencies = old.Dependencies,
         };
     }
 
-    public static ApiGameAssetResponse? FromOldWithExtraData(GameAsset? old, GameDatabaseContext database, IDataStore dataStore)
+    public static ApiGameAssetResponse? FromOldWithExtraData(GameAsset? old, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         if (old == null) return null;
 
-        ApiGameAssetResponse response = FromOld(old)!;
+        ApiGameAssetResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, dataStore);
 
         return response;
@@ -42,5 +44,5 @@ public class ApiGameAssetResponse : IApiResponse, IDataConvertableFrom<ApiGameAs
         this.OriginalUploader?.FillInExtraData(database, dataStore);
     }
 
-    public static IEnumerable<ApiGameAssetResponse> FromOldList(IEnumerable<GameAsset> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameAssetResponse> FromOldList(IEnumerable<GameAsset> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameAssetResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameAssetResponse.cs
@@ -28,21 +28,5 @@ public class ApiGameAssetResponse : IApiResponse, IDataConvertableFrom<ApiGameAs
         };
     }
 
-    public static ApiGameAssetResponse? FromOldWithExtraData(GameAsset? old, GameDatabaseContext database,
-        IDataStore dataStore, DataContext dataContext)
-    {
-        if (old == null) return null;
-
-        ApiGameAssetResponse response = FromOld(old, dataContext)!;
-        response.FillInExtraData(database, dataStore);
-
-        return response;
-    }
-
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore)
-    {
-        this.OriginalUploader?.FillInExtraData(database, dataStore);
-    }
-
     public static IEnumerable<ApiGameAssetResponse> FromOldList(IEnumerable<GameAsset> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameIpVerificationRequestResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameIpVerificationRequestResponse.cs
@@ -1,3 +1,4 @@
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -8,7 +9,7 @@ public class ApiGameIpVerificationRequestResponse : IApiResponse, IDataConvertab
     public required string IpAddress { get; set; }
     public required DateTimeOffset CreatedAt { get; set; }
     
-    public static ApiGameIpVerificationRequestResponse? FromOld(GameIpVerificationRequest? old)
+    public static ApiGameIpVerificationRequestResponse? FromOld(GameIpVerificationRequest? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -19,5 +20,6 @@ public class ApiGameIpVerificationRequestResponse : IApiResponse, IDataConvertab
         };
     }
 
-    public static IEnumerable<ApiGameIpVerificationRequestResponse> FromOldList(IEnumerable<GameIpVerificationRequest> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameIpVerificationRequestResponse> FromOldList(
+        IEnumerable<GameIpVerificationRequest> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameLevelResponse.cs
@@ -1,6 +1,7 @@
 using Bunkum.Core.Storage;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Reviews;
 
@@ -45,14 +46,14 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
     public required bool IsCopyable { get; set; }
     public required float Score { get; set; }
 
-    public static ApiGameLevelResponse? FromOld(GameLevel? level)
+    public static ApiGameLevelResponse? FromOld(GameLevel? level, DataContext dataContext)
     {
         if (level == null) return null;
         
         return new ApiGameLevelResponse
         {
             Title = level.Title,
-            Publisher = ApiGameUserResponse.FromOld(level.Publisher),
+            Publisher = ApiGameUserResponse.FromOld(level.Publisher, dataContext),
             OriginalPublisher = level.OriginalPublisher,
             IsReUpload = level.IsReUpload,
             LevelId = level.LevelId,
@@ -68,7 +69,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
             MaxPlayers = level.MaxPlayers,
             EnforceMinMaxPlayers = level.EnforceMinMaxPlayers,
             SameScreenGame = level.SameScreenGame,
-            SkillRewards = ApiGameSkillRewardResponse.FromOldList(level.SkillRewards),
+            SkillRewards = ApiGameSkillRewardResponse.FromOldList(level.SkillRewards, dataContext),
             YayRatings = level.Ratings.Count(r => r._RatingType == (int)RatingType.Yay),
             BooRatings = level.Ratings.Count(r => r._RatingType == (int)RatingType.Boo),
             Hearts = level.FavouriteRelations.Count(),
@@ -92,15 +93,16 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
         this.IconHash = database.GetAssetFromHash(this._originalIconHash ?? "0")?.GetAsIcon(TokenGame.Website, database, dataStore) ?? this.IconHash;
     }
     
-    public static ApiGameLevelResponse? FromOldWithExtraData(GameLevel? old, GameDatabaseContext database, IDataStore dataStore)
+    public static ApiGameLevelResponse? FromOldWithExtraData(GameLevel? old, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         if (old == null) return null;
 
-        ApiGameLevelResponse response = FromOld(old)!;
+        ApiGameLevelResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, dataStore);
 
         return response;
     }
 
-    public static IEnumerable<ApiGameLevelResponse> FromOldList(IEnumerable<GameLevel> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameLevelResponse> FromOldList(IEnumerable<GameLevel> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameNotificationResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameNotificationResponse.cs
@@ -1,3 +1,4 @@
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Notifications;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -13,7 +14,7 @@ public class ApiGameNotificationResponse : IApiResponse, IDataConvertableFrom<Ap
     
     public required string FontAwesomeIcon { get; set; }
     
-    public static ApiGameNotificationResponse? FromOld(GameNotification? old)
+    public static ApiGameNotificationResponse? FromOld(GameNotification? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -27,5 +28,6 @@ public class ApiGameNotificationResponse : IApiResponse, IDataConvertableFrom<Ap
         };
     }
 
-    public static IEnumerable<ApiGameNotificationResponse> FromOldList(IEnumerable<GameNotification> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameNotificationResponse> FromOldList(IEnumerable<GameNotification> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGamePhotoResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGamePhotoResponse.cs
@@ -52,26 +52,5 @@ public class ApiGamePhotoResponse : IApiResponse, IDataConvertableFrom<ApiGamePh
         };
     }
 
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore)
-    {
-        foreach (ApiGamePhotoSubjectResponse subject in this.Subjects)
-        {
-            subject.FillInExtraData(database, dataStore);
-        }
-        
-        this.Publisher.FillInExtraData(database, dataStore);
-    }
-
-    public static ApiGamePhotoResponse? FromOldWithExtraData(GamePhoto? old, GameDatabaseContext database,
-        IDataStore dataStore, DataContext dataContext)
-    {
-        if (old == null) return null;
-
-        ApiGamePhotoResponse response = FromOld(old, dataContext)!;
-        response.FillInExtraData(database, dataStore);
-
-        return response;
-    }
-
     public static IEnumerable<ApiGamePhotoResponse> FromOldList(IEnumerable<GamePhoto> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGamePhotoResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGamePhotoResponse.cs
@@ -1,5 +1,6 @@
 using Bunkum.Core.Storage;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Photos;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -25,7 +26,7 @@ public class ApiGamePhotoResponse : IApiResponse, IDataConvertableFrom<ApiGamePh
     
     public required IEnumerable<ApiGamePhotoSubjectResponse> Subjects { get; set; }
     
-    public static ApiGamePhotoResponse? FromOld(GamePhoto? old)
+    public static ApiGamePhotoResponse? FromOld(GamePhoto? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -35,8 +36,8 @@ public class ApiGamePhotoResponse : IApiResponse, IDataConvertableFrom<ApiGamePh
             TakenAt = old.TakenAt,
             PublishedAt = old.PublishedAt,
 
-            Publisher = ApiGameUserResponse.FromOld(old.Publisher)!,
-            Level = ApiGameLevelResponse.FromOld(old.Level),
+            Publisher = ApiGameUserResponse.FromOld(old.Publisher, dataContext)!,
+            Level = ApiGameLevelResponse.FromOld(old.Level, dataContext),
 
             LevelName = old.LevelName,
             LevelType = old.LevelType,
@@ -47,7 +48,7 @@ public class ApiGamePhotoResponse : IApiResponse, IDataConvertableFrom<ApiGamePh
             LargeHash = old.LargeAsset.IsPSP ? $"psp/{old.LargeAsset.AssetHash}" : old.LargeAsset.AssetHash,
             PlanHash = old.PlanHash,
 
-            Subjects = ApiGamePhotoSubjectResponse.FromOldList(old.Subjects),
+            Subjects = ApiGamePhotoSubjectResponse.FromOldList(old.Subjects, dataContext),
         };
     }
 
@@ -61,15 +62,16 @@ public class ApiGamePhotoResponse : IApiResponse, IDataConvertableFrom<ApiGamePh
         this.Publisher.FillInExtraData(database, dataStore);
     }
 
-    public static ApiGamePhotoResponse? FromOldWithExtraData(GamePhoto? old, GameDatabaseContext database, IDataStore dataStore)
+    public static ApiGamePhotoResponse? FromOldWithExtraData(GamePhoto? old, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         if (old == null) return null;
 
-        ApiGamePhotoResponse response = FromOld(old)!;
+        ApiGamePhotoResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, dataStore);
 
         return response;
     }
 
-    public static IEnumerable<ApiGamePhotoResponse> FromOldList(IEnumerable<GamePhoto> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGamePhotoResponse> FromOldList(IEnumerable<GamePhoto> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGamePhotoSubjectResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGamePhotoSubjectResponse.cs
@@ -24,26 +24,6 @@ public class ApiGamePhotoSubjectResponse : IApiResponse,IDataConvertableFrom<Api
         };
     }
 
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore)
-    {
-        this.User?.FillInExtraData(database, dataStore);
-    }
-
-    public static ApiGamePhotoSubjectResponse? FromOldWithExtraData(GamePhotoSubject? old, GameDatabaseContext database,
-        IDataStore dataStore, DataContext dataContext)
-    {
-        if (old == null) return null;
-
-        ApiGamePhotoSubjectResponse response = FromOld(old, dataContext)!;
-        response.FillInExtraData(database, dataStore);
-
-        return response;
-    }
-
     public static IEnumerable<ApiGamePhotoSubjectResponse> FromOldList(IEnumerable<GamePhotoSubject> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
-    
-    public static IEnumerable<ApiGamePhotoSubjectResponse> FromOldListWithExtraData(
-        IEnumerable<GamePhotoSubject> oldList, GameDatabaseContext database, IDataStore dataStore,
-        DataContext dataContext) => oldList.Select(old => FromOldWithExtraData(old, database, dataStore, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGamePhotoSubjectResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGamePhotoSubjectResponse.cs
@@ -1,5 +1,6 @@
 using Bunkum.Core.Storage;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Photos;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -11,13 +12,13 @@ public class ApiGamePhotoSubjectResponse : IApiResponse,IDataConvertableFrom<Api
     public required string DisplayName { get; set; }
     public required IEnumerable<float> Bounds { get; set; }
 
-    public static ApiGamePhotoSubjectResponse? FromOld(GamePhotoSubject? old)
+    public static ApiGamePhotoSubjectResponse? FromOld(GamePhotoSubject? old, DataContext dataContext)
     {
         if (old == null) return null;
 
         return new ApiGamePhotoSubjectResponse
         {
-            User = ApiGameUserResponse.FromOld(old.User),
+            User = ApiGameUserResponse.FromOld(old.User, dataContext),
             DisplayName = old.DisplayName,
             Bounds = old.Bounds,
         };
@@ -28,17 +29,21 @@ public class ApiGamePhotoSubjectResponse : IApiResponse,IDataConvertableFrom<Api
         this.User?.FillInExtraData(database, dataStore);
     }
 
-    public static ApiGamePhotoSubjectResponse? FromOldWithExtraData(GamePhotoSubject? old, GameDatabaseContext database, IDataStore dataStore)
+    public static ApiGamePhotoSubjectResponse? FromOldWithExtraData(GamePhotoSubject? old, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         if (old == null) return null;
 
-        ApiGamePhotoSubjectResponse response = FromOld(old)!;
+        ApiGamePhotoSubjectResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, dataStore);
 
         return response;
     }
 
-    public static IEnumerable<ApiGamePhotoSubjectResponse> FromOldList(IEnumerable<GamePhotoSubject> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGamePhotoSubjectResponse> FromOldList(IEnumerable<GamePhotoSubject> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
     
-    public static IEnumerable<ApiGamePhotoSubjectResponse> FromOldListWithExtraData(IEnumerable<GamePhotoSubject> oldList, GameDatabaseContext database, IDataStore dataStore) => oldList.Select(old => FromOldWithExtraData(old, database, dataStore)).ToList()!;
+    public static IEnumerable<ApiGamePhotoSubjectResponse> FromOldListWithExtraData(
+        IEnumerable<GamePhotoSubject> oldList, GameDatabaseContext database, IDataStore dataStore,
+        DataContext dataContext) => oldList.Select(old => FromOldWithExtraData(old, database, dataStore, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameReviewResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameReviewResponse.cs
@@ -1,3 +1,4 @@
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Reviews;
 
@@ -12,19 +13,20 @@ public class ApiGameReviewResponse : IApiResponse, IDataConvertableFrom<ApiGameR
     public required DateTimeOffset PostedAt { get; set; }
     public required string Labels { get; set; }
     public required string Text { get; set; }
-    public static ApiGameReviewResponse? FromOld(GameReview? old)
+    public static ApiGameReviewResponse? FromOld(GameReview? old, DataContext dataContext)
     {
         if (old == null) return null;
         return new ApiGameReviewResponse
         {
             ReviewId = old.ReviewId,
-            Level = ApiGameLevelResponse.FromOld(old.Level)!,
-            Publisher = ApiGameUserResponse.FromOld(old.Publisher)!,
+            Level = ApiGameLevelResponse.FromOld(old.Level, dataContext)!,
+            Publisher = ApiGameUserResponse.FromOld(old.Publisher, dataContext)!,
             PostedAt = old.PostedAt,
             Labels = old.Labels,
             Text = old.Content,
         };
     }
 
-    public static IEnumerable<ApiGameReviewResponse> FromOldList(IEnumerable<GameReview> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameReviewResponse> FromOldList(IEnumerable<GameReview> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameRoomPlayerResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameRoomPlayerResponse.cs
@@ -1,3 +1,4 @@
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -8,7 +9,7 @@ public class ApiGameRoomPlayerResponse : IApiResponse, IDataConvertableFrom<ApiG
     public required string Username { get; set; }
     public required string? UserId { get; set; }
     
-    public static ApiGameRoomPlayerResponse? FromOld(GameRoomPlayer? old)
+    public static ApiGameRoomPlayerResponse? FromOld(GameRoomPlayer? old, DataContext dataContext)
     {
         if (old is null) return null;
 
@@ -19,5 +20,6 @@ public class ApiGameRoomPlayerResponse : IApiResponse, IDataConvertableFrom<ApiG
         };
     }
 
-    public static IEnumerable<ApiGameRoomPlayerResponse> FromOldList(IEnumerable<GameRoomPlayer> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameRoomPlayerResponse> FromOldList(IEnumerable<GameRoomPlayer> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameRoomResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameRoomResponse.cs
@@ -1,4 +1,5 @@
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -16,14 +17,14 @@ public class ApiGameRoomResponse : IApiResponse, IDataConvertableFrom<ApiGameRoo
     public required TokenPlatform Platform { get; set; }
     public required TokenGame Game { get; set; }
     
-    public static ApiGameRoomResponse? FromOld(GameRoom? old)
+    public static ApiGameRoomResponse? FromOld(GameRoom? old, DataContext dataContext)
     {
         if (old == null) return null;
 
         return new ApiGameRoomResponse
         {
             RoomId = old.RoomId.ToString()!,
-            PlayerIds = ApiGameRoomPlayerResponse.FromOldList(old.PlayerIds),
+            PlayerIds = ApiGameRoomPlayerResponse.FromOldList(old.PlayerIds, dataContext),
             RoomState = old.RoomState,
             RoomMood = old.RoomMood,
             LevelType = old.LevelType,
@@ -33,5 +34,5 @@ public class ApiGameRoomResponse : IApiResponse, IDataConvertableFrom<ApiGameRoo
         };
     }
 
-    public static IEnumerable<ApiGameRoomResponse> FromOldList(IEnumerable<GameRoom> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameRoomResponse> FromOldList(IEnumerable<GameRoom> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameScoreResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameScoreResponse.cs
@@ -35,25 +35,6 @@ public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameSc
             Platform = old.Platform,
         };
     }
-
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore)
-    {
-        foreach (ApiGameUserResponse player in this.Players)
-        {
-            player.FillInExtraData(database, dataStore);
-        }
-    }
-
-    public static ApiGameScoreResponse? FromOldWithExtraData(GameSubmittedScore? old, GameDatabaseContext database,
-        IDataStore dataStore, DataContext dataContext)
-    {
-        if (old == null) return null;
-
-        ApiGameScoreResponse response = FromOld(old, dataContext)!;
-        response.FillInExtraData(database, dataStore);
-
-        return response;
-    }
     
     public static IEnumerable<ApiGameScoreResponse> FromOldList(IEnumerable<GameSubmittedScore> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameScoreResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameScoreResponse.cs
@@ -1,6 +1,7 @@
 using Bunkum.Core.Storage;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.UserData.Leaderboard;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -18,15 +19,15 @@ public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameSc
     public required TokenGame Game { get; set; }
     public required TokenPlatform Platform { get; set; }
     
-    public static ApiGameScoreResponse? FromOld(GameSubmittedScore? old)
+    public static ApiGameScoreResponse? FromOld(GameSubmittedScore? old, DataContext dataContext)
     {
         if (old == null) return null;
 
         return new ApiGameScoreResponse
         {
             ScoreId = old.ScoreId.ToString()!,
-            Level = ApiGameLevelResponse.FromOld(old.Level)!,
-            Players = ApiGameUserResponse.FromOldList(old.Players),
+            Level = ApiGameLevelResponse.FromOld(old.Level, dataContext)!,
+            Players = ApiGameUserResponse.FromOldList(old.Players, dataContext),
             ScoreSubmitted = old.ScoreSubmitted,
             Score = old.Score,
             ScoreType = old.ScoreType,
@@ -43,15 +44,17 @@ public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameSc
         }
     }
 
-    public static ApiGameScoreResponse? FromOldWithExtraData(GameSubmittedScore? old, GameDatabaseContext database, IDataStore dataStore)
+    public static ApiGameScoreResponse? FromOldWithExtraData(GameSubmittedScore? old, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         if (old == null) return null;
 
-        ApiGameScoreResponse response = FromOld(old)!;
+        ApiGameScoreResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, dataStore);
 
         return response;
     }
     
-    public static IEnumerable<ApiGameScoreResponse> FromOldList(IEnumerable<GameSubmittedScore> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameScoreResponse> FromOldList(IEnumerable<GameSubmittedScore> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameSkillRewardResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameSkillRewardResponse.cs
@@ -1,4 +1,5 @@
-﻿using Refresh.GameServer.Types.Levels.SkillRewards;
+﻿using Refresh.GameServer.Types.Data;
+using Refresh.GameServer.Types.Levels.SkillRewards;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
@@ -11,7 +12,7 @@ public class ApiGameSkillRewardResponse : IApiResponse, IDataConvertableFrom<Api
     public float RequiredAmount { get; set; }
     public GameSkillRewardCondition ConditionType { get; set; }
 
-    public static ApiGameSkillRewardResponse? FromOld(GameSkillReward? old)
+    public static ApiGameSkillRewardResponse? FromOld(GameSkillReward? old, DataContext dataContext)
     {
         if (old == null) return null;
         
@@ -25,5 +26,6 @@ public class ApiGameSkillRewardResponse : IApiResponse, IDataConvertableFrom<Api
         };
     }
 
-    public static IEnumerable<ApiGameSkillRewardResponse> FromOldList(IEnumerable<GameSkillReward> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameSkillRewardResponse> FromOldList(IEnumerable<GameSkillReward> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameUserResponse.cs
@@ -2,6 +2,7 @@ using Bunkum.Core.Storage;
 using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -21,7 +22,7 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
     public required DateTimeOffset LastLoginDate { get; set; }
 
     [ContractAnnotation("null => null; notnull => notnull")]
-    public static ApiGameUserResponse? FromOld(GameUser? user)
+    public static ApiGameUserResponse? FromOld(GameUser? user, DataContext dataContext)
     {
         if (user == null) return null;
         
@@ -42,15 +43,16 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
         this.IconHash = database.GetAssetFromHash(this.IconHash)?.GetAsIcon(TokenGame.Website, database, dataStore) ?? this.IconHash;
     }
     
-    public static ApiGameUserResponse? FromOldWithExtraData(GameUser? old, GameDatabaseContext database, IDataStore dataStore)
+    public static ApiGameUserResponse? FromOldWithExtraData(GameUser? old, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         if (old == null) return null;
 
-        ApiGameUserResponse response = FromOld(old)!;
+        ApiGameUserResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, dataStore);
 
         return response;
     }
 
-    public static IEnumerable<ApiGameUserResponse> FromOldList(IEnumerable<GameUser> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiGameUserResponse> FromOldList(IEnumerable<GameUser> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiGameUserResponse.cs
@@ -30,28 +30,12 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
         {
             UserId = user.UserId.ToString()!,
             Username = user.Username,
-            IconHash = user.IconHash,
+            IconHash = dataContext.Database.GetAssetFromHash(user.IconHash)?.GetAsIcon(TokenGame.Website, dataContext) ?? user.IconHash,
             Description = user.Description,
             Location = ApiGameLocationResponse.FromGameLocation(user.Location)!,
             JoinDate = user.JoinDate,
             LastLoginDate = user.LastLoginDate,
         };
-    }
-
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore)
-    {
-        this.IconHash = database.GetAssetFromHash(this.IconHash)?.GetAsIcon(TokenGame.Website, database, dataStore) ?? this.IconHash;
-    }
-    
-    public static ApiGameUserResponse? FromOldWithExtraData(GameUser? old, GameDatabaseContext database,
-        IDataStore dataStore, DataContext dataContext)
-    {
-        if (old == null) return null;
-
-        ApiGameUserResponse response = FromOld(old, dataContext)!;
-        response.FillInExtraData(database, dataStore);
-
-        return response;
     }
 
     public static IEnumerable<ApiGameUserResponse> FromOldList(IEnumerable<GameUser> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiLevelCategoryResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiLevelCategoryResponse.cs
@@ -40,60 +40,22 @@ public class ApiLevelCategoryResponse : IApiResponse, IDataConvertableFrom<ApiLe
             Hidden = old.Hidden,
         };
     }
-
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore)
-    {
-        this.PreviewLevel?.FillInExtraData(database, dataStore);
-    }
     
-    public static ApiLevelCategoryResponse? FromOldWithExtraData(LevelCategory? old, GameDatabaseContext database,
-        IDataStore dataStore, GameLevel? previewLevel, DataContext dataContext)
-    {
-        if (old == null) return null;
-
-        ApiLevelCategoryResponse response = FromOld(old, previewLevel, dataContext)!;
-        response.FillInExtraData(database, dataStore);
-
-        return response;
-    }
-    
-    public static ApiLevelCategoryResponse? FromOld(LevelCategory? old, DataContext dataContext) => FromOld(old, null);
+    public static ApiLevelCategoryResponse? FromOld(LevelCategory? old, DataContext dataContext) => FromOld(old, dataContext);
 
     public static IEnumerable<ApiLevelCategoryResponse> FromOldList(IEnumerable<LevelCategory> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
-    public static IEnumerable<ApiLevelCategoryResponse> FromOldListWithExtraData(IEnumerable<LevelCategory> oldList,
-        GameDatabaseContext database, IDataStore dataStore, DataContext dataContext) 
-        => oldList.Select(old => FromOldWithExtraData(old, database, dataStore, null, dataContext)).ToList()!;
     
     public static IEnumerable<ApiLevelCategoryResponse> FromOldList(IEnumerable<LevelCategory> oldList,
         RequestContext context,
-        MatchService matchService,
-        GameDatabaseContext database,
-        GameUser? user, DataContext dataContext)
+        DataContext dataContext)
     {
         return oldList.Select(category =>
         {
-            DatabaseList<GameLevel>? list = category.Fetch(context, 0, 1, matchService, database, user, new LevelFilterSettings(context, TokenGame.Website), user);
+            DatabaseList<GameLevel>? list = category.Fetch(context, 0, 1, dataContext.Match, dataContext.Database, dataContext.User, new LevelFilterSettings(context, TokenGame.Website), dataContext.User);
             GameLevel? level = list?.Items.FirstOrDefault();
             
             return FromOld(category, level, dataContext);
         }).ToList()!;
-    }
-
-    public static IEnumerable<ApiLevelCategoryResponse> FromOldListWithExtraData(IEnumerable<LevelCategory> oldList,
-        RequestContext context,
-        MatchService matchService,
-        GameDatabaseContext database,
-        IDataStore dataStore,
-        GameUser? user, DataContext dataContext)
-    {
-        IEnumerable<ApiLevelCategoryResponse> list = FromOldList(oldList, context, matchService, database, user, dataContext).ToList();
-
-        foreach (ApiLevelCategoryResponse category in list)
-        {
-            category.FillInExtraData(database, dataStore);
-        }
-        
-        return list;
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiLevelCategoryResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiLevelCategoryResponse.cs
@@ -41,7 +41,7 @@ public class ApiLevelCategoryResponse : IApiResponse, IDataConvertableFrom<ApiLe
         };
     }
     
-    public static ApiLevelCategoryResponse? FromOld(LevelCategory? old, DataContext dataContext) => FromOld(old, dataContext);
+    public static ApiLevelCategoryResponse? FromOld(LevelCategory? old, DataContext dataContext) => FromOld(old, null, dataContext);
 
     public static IEnumerable<ApiLevelCategoryResponse> FromOldList(IEnumerable<LevelCategory> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiParameterResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiParameterResponse.cs
@@ -1,10 +1,11 @@
 using AttribDoc;
 using Newtonsoft.Json.Converters;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class ApiParameterResponse : IApiResponse, IDataConvertableFrom<ApiParameterResponse, Parameter>
+public class ApiParameterResponse : IApiResponse
 {
     public required string Name { get; set; }
     [JsonConverter(typeof(StringEnumConverter))]

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiRequestStatisticsResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiRequestStatisticsResponse.cs
@@ -1,4 +1,5 @@
 using Refresh.GameServer.Types;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
@@ -9,7 +10,7 @@ public class ApiRequestStatisticsResponse : IApiResponse, IDataConvertableFrom<A
     public required long ApiRequests { get; set; }
     public required long GameRequests { get; set; }
     
-    public static ApiRequestStatisticsResponse? FromOld(RequestStatistics? old)
+    public static ApiRequestStatisticsResponse? FromOld(RequestStatistics? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -21,5 +22,6 @@ public class ApiRequestStatisticsResponse : IApiResponse, IDataConvertableFrom<A
         };
     }
 
-    public static IEnumerable<ApiRequestStatisticsResponse> FromOldList(IEnumerable<RequestStatistics> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiRequestStatisticsResponse> FromOldList(IEnumerable<RequestStatistics> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiRichPresenceConfigurationResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiRichPresenceConfigurationResponse.cs
@@ -1,3 +1,4 @@
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.RichPresence;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
@@ -9,7 +10,7 @@ public class ApiRichPresenceConfigurationResponse : IApiResponse, IDataConvertab
     public required string PartyIdPrefix { get; set; }
     public required RichPresenceAssetConfiguration AssetConfiguration { get; set; }
     
-    public static ApiRichPresenceConfigurationResponse? FromOld(RichPresenceConfiguration? old)
+    public static ApiRichPresenceConfigurationResponse? FromOld(RichPresenceConfiguration? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -21,7 +22,8 @@ public class ApiRichPresenceConfigurationResponse : IApiResponse, IDataConvertab
         };
     }
 
-    public static IEnumerable<ApiRichPresenceConfigurationResponse> FromOldList(IEnumerable<RichPresenceConfiguration> oldList)
+    public static IEnumerable<ApiRichPresenceConfigurationResponse> FromOldList(
+        IEnumerable<RichPresenceConfiguration> oldList, DataContext dataContext)
     {
         throw new NotImplementedException();
     }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiRouteResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiRouteResponse.cs
@@ -1,10 +1,11 @@
 using AttribDoc;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class ApiRouteResponse : IApiResponse, IDataConvertableFrom<ApiRouteResponse, Route>
+public class ApiRouteResponse : IApiResponse
 {
     public required string Method { get; set; }
     public required string RouteUri { get; set; }
@@ -30,5 +31,5 @@ public class ApiRouteResponse : IApiResponse, IDataConvertableFrom<ApiRouteRespo
         };
     }
 
-    public static IEnumerable<ApiRouteResponse> FromOldList(IEnumerable<Route> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<ApiRouteResponse> FromOldList(IEnumerable<Route> oldList) => oldList.Select(old => FromOld(old)).ToList()!;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Assets;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 using Refresh.GameServer.Types.RichPresence;
 
@@ -16,9 +17,10 @@ public class InstanceApiEndpoints : EndpointGroup
 {
     [ApiV3Endpoint("statistics"), Authentication(false)]
     [DocSummary("Retrieves various statistics about the Refresh instance.")]
-    public ApiResponse<ApiStatisticsResponse> GetStatistics(RequestContext context, GameDatabaseContext database, MatchService match, GameServerConfig config)
+    public ApiResponse<ApiStatisticsResponse> GetStatistics(RequestContext context, GameDatabaseContext database,
+        MatchService match, GameServerConfig config, DataContext dataContext)
     {
-        ApiRequestStatisticsResponse requestStatistics = ApiRequestStatisticsResponse.FromOld(database.GetRequestStatistics())!;
+        ApiRequestStatisticsResponse requestStatistics = ApiRequestStatisticsResponse.FromOld(database.GetRequestStatistics(), dataContext)!;
 
         RoomStatistics statistics = match.RoomAccessor.GetStatistics();
         
@@ -43,7 +45,8 @@ public class InstanceApiEndpoints : EndpointGroup
         RichPresenceConfig richConfig,
         IntegrationConfig integrationConfig,
         ContactInfoConfig contactInfoConfig,
-        GameDatabaseContext database) 
+        GameDatabaseContext database,
+        DataContext dataContext) 
         => new ApiInstanceResponse
         {
             InstanceName = gameConfig.InstanceName,
@@ -56,11 +59,11 @@ public class InstanceApiEndpoints : EndpointGroup
             SoftwareLicenseUrl = "https://www.gnu.org/licenses/agpl-3.0.txt",
             MaximumAssetSafetyLevel = gameConfig.MaximumAssetSafetyLevel,
             MaximumAssetSafetyLevelForTrustedUsers = gameConfig.MaximumAssetSafetyLevelForTrustedUsers,
-            Announcements = ApiGameAnnouncementResponse.FromOldList(database.GetAnnouncements()),
+            Announcements = ApiGameAnnouncementResponse.FromOldList(database.GetAnnouncements(), dataContext),
             MaintenanceModeEnabled = gameConfig.MaintenanceMode,
             RichPresenceConfiguration = ApiRichPresenceConfigurationResponse.FromOld(RichPresenceConfiguration.Create(
                 gameConfig,
-                richConfig))!,
+                richConfig), dataContext)!,
             GrafanaDashboardUrl = integrationConfig.GrafanaDashboardUrl,
             
             ContactInfo = new ApiContactInfoResponse
@@ -71,7 +74,7 @@ public class InstanceApiEndpoints : EndpointGroup
                 AdminDiscordUsername = contactInfoConfig.AdminDiscordUsername,
             },
             
-            ActiveContest = ApiContestResponse.FromOld(database.GetNewestActiveContest()),
+            ActiveContest = ApiContestResponse.FromOld(database.GetNewestActiveContest(), dataContext),
 #if DEBUG
             SoftwareType = "Debug",
 #else

--- a/Refresh.GameServer/Endpoints/ApiV3/LeaderboardApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LeaderboardApiEndpoints.cs
@@ -38,7 +38,6 @@ public class LeaderboardApiEndpoints : EndpointGroup
 
         DatabaseList<GameSubmittedScore> scores = database.GetTopScoresForLevel(level, count, skip, (byte)mode, showAll);
         DatabaseList<ApiGameScoreResponse> ret = DatabaseList<ApiGameScoreResponse>.FromOldList<ApiGameScoreResponse, GameSubmittedScore>(scores, dataContext);
-        foreach (ApiGameScoreResponse score in ret.Items) score.FillInExtraData(database, dataStore);
         return ret;
     }
 
@@ -52,6 +51,6 @@ public class LeaderboardApiEndpoints : EndpointGroup
         GameSubmittedScore? score = database.GetScoreByUuid(uuid);
         if (score == null) return ApiNotFoundError.Instance;
         
-        return ApiGameScoreResponse.FromOldWithExtraData(score, database, dataStore, dataContext);
+        return ApiGameScoreResponse.FromOld(score, dataContext);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
@@ -38,8 +38,8 @@ public class LevelApiEndpoints : EndpointGroup
         IEnumerable<ApiLevelCategoryResponse> resp;
 
         // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
-        if (includePreviews)resp = ApiLevelCategoryResponse.FromOldListWithExtraData(categories.Categories, context, matchService, database, dataStore, user, dataContext);
-        else resp = ApiLevelCategoryResponse.FromOldListWithExtraData(categories.Categories, database, dataStore, dataContext);
+        if (includePreviews) resp = ApiLevelCategoryResponse.FromOldList(categories.Categories, context, dataContext);
+        else resp = ApiLevelCategoryResponse.FromOldList(categories.Categories, dataContext);
         
         return new ApiListResponse<ApiLevelCategoryResponse>(resp);
     }
@@ -72,10 +72,6 @@ public class LevelApiEndpoints : EndpointGroup
         if (list == null) return ApiNotFoundError.Instance;
 
         DatabaseList<ApiGameLevelResponse> levels = DatabaseList<ApiGameLevelResponse>.FromOldList<ApiGameLevelResponse, GameLevel>(list, dataContext);
-        foreach (ApiGameLevelResponse level in levels.Items)
-        {
-            level.FillInExtraData(database, dataStore);
-        }
         return levels;
     }
 
@@ -89,7 +85,7 @@ public class LevelApiEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
         
-        return ApiGameLevelResponse.FromOldWithExtraData(level, database, dataStore, dataContext);
+        return ApiGameLevelResponse.FromOld(level, dataContext);
     }
     
     [ApiV3Endpoint("levels/id/{id}", HttpMethods.Patch)]
@@ -108,7 +104,7 @@ public class LevelApiEndpoints : EndpointGroup
 
         level = database.UpdateLevel(body, level);
 
-        return ApiGameLevelResponse.FromOldWithExtraData(level, database, dataStore, dataContext);
+        return ApiGameLevelResponse.FromOld(level, dataContext);
     }
 
     [ApiV3Endpoint("levels/id/{id}", HttpMethods.Delete)]

--- a/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
@@ -13,6 +13,7 @@ using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Levels.Categories;
 using Refresh.GameServer.Types.UserData;
@@ -27,7 +28,9 @@ public class LevelApiEndpoints : EndpointGroup
     [DocSummary("Retrieves a list of categories you can use to search levels")]
     [DocQueryParam("includePreviews", "If true, a single level will be added to each category representing a level from that category. False by default.")]
     [DocError(typeof(ApiValidationError), "The boolean 'includePreviews' could not be parsed by the server.")]
-    public ApiListResponse<ApiLevelCategoryResponse> GetCategories(RequestContext context, CategoryService categories, MatchService matchService, GameDatabaseContext database, GameUser? user, IDataStore dataStore)
+    public ApiListResponse<ApiLevelCategoryResponse> GetCategories(RequestContext context, CategoryService categories,
+        MatchService matchService, GameDatabaseContext database, GameUser? user, IDataStore dataStore,
+        DataContext dataContext)
     {
         bool result = bool.TryParse(context.QueryString.Get("includePreviews") ?? "false", out bool includePreviews);
         if (!result) return ApiValidationError.BooleanParseError;
@@ -35,8 +38,8 @@ public class LevelApiEndpoints : EndpointGroup
         IEnumerable<ApiLevelCategoryResponse> resp;
 
         // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
-        if (includePreviews)resp = ApiLevelCategoryResponse.FromOldListWithExtraData(categories.Categories, context, matchService, database, dataStore, user);
-        else resp = ApiLevelCategoryResponse.FromOldListWithExtraData(categories.Categories, database, dataStore);
+        if (includePreviews)resp = ApiLevelCategoryResponse.FromOldListWithExtraData(categories.Categories, context, matchService, database, dataStore, user, dataContext);
+        else resp = ApiLevelCategoryResponse.FromOldListWithExtraData(categories.Categories, database, dataStore, dataContext);
         
         return new ApiListResponse<ApiLevelCategoryResponse>(resp);
     }
@@ -48,9 +51,11 @@ public class LevelApiEndpoints : EndpointGroup
     [DocQueryParam("game", "Filters levels to a specific game version. Allowed values: lbp1-3, vita, psp, beta")]
     [DocQueryParam("seed", "The random seed to use for randomization. Uses 0 if not specified.")]
     [DocQueryParam("players", "Filters levels to those accommodating the specified number of players.")]
-    public ApiListResponse<ApiGameLevelResponse> GetLevels(RequestContext context, GameDatabaseContext database, MatchService matchService, CategoryService categories, GameUser? user, IDataStore dataStore,
+    public ApiListResponse<ApiGameLevelResponse> GetLevels(RequestContext context, GameDatabaseContext database,
+        MatchService matchService, CategoryService categories, GameUser? user, IDataStore dataStore,
         [DocSummary("The name of the category you'd like to retrieve levels from. " +
-                    "Make a request to /levels to see a list of available categories")] string route)
+                    "Make a request to /levels to see a list of available categories")]
+        string route, DataContext dataContext)
     {
         if (string.IsNullOrWhiteSpace(route))
         {
@@ -66,7 +71,7 @@ public class LevelApiEndpoints : EndpointGroup
 
         if (list == null) return ApiNotFoundError.Instance;
 
-        DatabaseList<ApiGameLevelResponse> levels = DatabaseList<ApiGameLevelResponse>.FromOldList<ApiGameLevelResponse, GameLevel>(list);
+        DatabaseList<ApiGameLevelResponse> levels = DatabaseList<ApiGameLevelResponse>.FromOldList<ApiGameLevelResponse, GameLevel>(list, dataContext);
         foreach (ApiGameLevelResponse level in levels.Items)
         {
             level.FillInExtraData(database, dataStore);
@@ -77,21 +82,23 @@ public class LevelApiEndpoints : EndpointGroup
     [ApiV3Endpoint("levels/id/{id}"), Authentication(false)]
     [DocSummary("Gets an individual level by a numerical ID")]
     [DocError(typeof(ApiNotFoundError), "The level cannot be found")]
-    public ApiResponse<ApiGameLevelResponse> GetLevelById(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The ID of the level")] int id)
+    public ApiResponse<ApiGameLevelResponse> GetLevelById(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore,
+        [DocSummary("The ID of the level")] int id, DataContext dataContext)
     {
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
         
-        return ApiGameLevelResponse.FromOldWithExtraData(level, database, dataStore);
+        return ApiGameLevelResponse.FromOldWithExtraData(level, database, dataStore, dataContext);
     }
     
     [ApiV3Endpoint("levels/id/{id}", HttpMethods.Patch)]
     [DocSummary("Edits a level by the level's numerical ID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     [DocError(typeof(ApiAuthenticationError), ApiAuthenticationError.NoPermissionsForObjectWhen)]
-    public ApiResponse<ApiGameLevelResponse> EditLevelById(RequestContext context, GameDatabaseContext database, GameUser user, IDataStore dataStore,
-        [DocSummary("The ID of the level")] int id, ApiEditLevelRequest body)
+    public ApiResponse<ApiGameLevelResponse> EditLevelById(RequestContext context, GameDatabaseContext database,
+        GameUser user, IDataStore dataStore,
+        [DocSummary("The ID of the level")] int id, ApiEditLevelRequest body, DataContext dataContext)
     {
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
@@ -101,7 +108,7 @@ public class LevelApiEndpoints : EndpointGroup
 
         level = database.UpdateLevel(body, level);
 
-        return ApiGameLevelResponse.FromOldWithExtraData(level, database, dataStore);
+        return ApiGameLevelResponse.FromOldWithExtraData(level, database, dataStore, dataContext);
     }
 
     [ApiV3Endpoint("levels/id/{id}", HttpMethods.Delete)]

--- a/Refresh.GameServer/Endpoints/ApiV3/MatchingApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/MatchingApiEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 using Refresh.GameServer.Types.UserData;
 
@@ -20,8 +21,10 @@ public class MatchingApiEndpoints : EndpointGroup
     [DocSummary("Finds a room by a player's username")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     [DocError(typeof(ApiNotFoundError), "The room could not be found")]
-    public ApiResponse<ApiGameRoomResponse> GetRoomByUsername(RequestContext context, MatchService service, GameDatabaseContext database,
-        [DocSummary("The username of the player")] string username)
+    public ApiResponse<ApiGameRoomResponse> GetRoomByUsername(RequestContext context, MatchService service,
+        GameDatabaseContext database,
+        [DocSummary("The username of the player")]
+        string username, DataContext dataContext)
     {
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return ApiNotFoundError.UserMissingError;
@@ -29,15 +32,16 @@ public class MatchingApiEndpoints : EndpointGroup
         GameRoom? room = service.RoomAccessor.GetRoomByUser(user);
         if(room == null) return ApiNotFoundError.Instance;
         
-        return ApiGameRoomResponse.FromOld(room);
+        return ApiGameRoomResponse.FromOld(room, dataContext);
     }
     
     [ApiV3Endpoint("rooms/uuid/{uuid}"), Authentication(false)]
     [DocSummary("Finds a room by a player's UUID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     [DocError(typeof(ApiNotFoundError), "The room could not be found")]
-    public ApiResponse<ApiGameRoomResponse> GetRoomByUserUuid(RequestContext context, MatchService service, GameDatabaseContext database,
-        [DocSummary("The UUID of the player")] string uuid)
+    public ApiResponse<ApiGameRoomResponse> GetRoomByUserUuid(RequestContext context, MatchService service,
+        GameDatabaseContext database,
+        [DocSummary("The UUID of the player")] string uuid, DataContext dataContext)
     {
         GameUser? user = database.GetUserByUuid(uuid);
         if (user == null) return ApiNotFoundError.UserMissingError;
@@ -45,7 +49,7 @@ public class MatchingApiEndpoints : EndpointGroup
         GameRoom? room = service.RoomAccessor.GetRoomByUser(user);
         if(room == null) return ApiNotFoundError.Instance;
         
-        return ApiGameRoomResponse.FromOld(room);
+        return ApiGameRoomResponse.FromOld(room, dataContext);
     }
     
     [ApiV3Endpoint("rooms/{uuid}"), Authentication(false)]
@@ -53,7 +57,7 @@ public class MatchingApiEndpoints : EndpointGroup
     [DocError(typeof(ApiValidationError), ApiValidationError.ObjectIdParseErrorWhen)]
     [DocError(typeof(ApiNotFoundError), "The room could not be found")]
     public ApiResponse<ApiGameRoomResponse> GetRoomByUuid(RequestContext context, MatchService service,
-        [DocSummary("The UUID of the room")] string uuid)
+        [DocSummary("The UUID of the room")] string uuid, DataContext dataContext)
     {
         bool parsed = ObjectId.TryParse(uuid, out ObjectId objectId);
         if (!parsed) return ApiValidationError.ObjectIdParseError;
@@ -61,14 +65,15 @@ public class MatchingApiEndpoints : EndpointGroup
         GameRoom? room = service.RoomAccessor.GetRoomByUuid(objectId);
         if(room == null) return ApiNotFoundError.Instance;
         
-        return ApiGameRoomResponse.FromOld(room);
+        return ApiGameRoomResponse.FromOld(room, dataContext);
     }
     
     [ApiV3Endpoint("rooms"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets all rooms on the server")]
-    public ApiListResponse<ApiGameRoomResponse> GetRooms(RequestContext context, MatchService service)
+    public ApiListResponse<ApiGameRoomResponse> GetRooms(RequestContext context, MatchService service,
+        DataContext dataContext)
     {
         (int skip, int count) = context.GetPageData();
-        return new DatabaseList<ApiGameRoomResponse>(ApiGameRoomResponse.FromOldList(service.RoomAccessor.GetAllRooms()), skip, count);
+        return new DatabaseList<ApiGameRoomResponse>(ApiGameRoomResponse.FromOldList(service.RoomAccessor.GetAllRooms(), dataContext), skip, count);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/NotificationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/NotificationApiEndpoints.cs
@@ -10,6 +10,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Extensions;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Notifications;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -20,19 +21,22 @@ public class NotificationApiEndpoints : EndpointGroup
 {
     [ApiV3Endpoint("notifications"), MinimumRole(GameUserRole.Restricted)]
     [DocUsesPageData, DocSummary("Gets a list of notifications stored for the user")]
-    public ApiListResponse<ApiGameNotificationResponse> GetNotifications(RequestContext context, GameUser user, GameDatabaseContext database)
+    public ApiListResponse<ApiGameNotificationResponse> GetNotifications(RequestContext context, GameUser user,
+        GameDatabaseContext database, DataContext dataContext)
     {
         (int skip, int count) = context.GetPageData();
         DatabaseList<GameNotification> notifications = database.GetNotificationsByUser(user, count, skip);
-        return DatabaseList<ApiGameNotificationResponse>.FromOldList<ApiGameNotificationResponse, GameNotification>(notifications);
+        return DatabaseList<ApiGameNotificationResponse>.FromOldList<ApiGameNotificationResponse, GameNotification>(notifications, dataContext);
     }
 
     [ApiV3Endpoint("notifications/{uuid}"), MinimumRole(GameUserRole.Restricted)]
     [DocSummary("Gets a specific notification for a user")]
     [DocError(typeof(ApiValidationError), ApiValidationError.ObjectIdParseErrorWhen)]
     [DocError(typeof(ApiNotFoundError), "The notification cannot be found")]
-    public ApiResponse<ApiGameNotificationResponse> GetNotificationByUuid(RequestContext context, GameUser user, GameDatabaseContext database,
-        [DocSummary("The UUID of the notification")] string uuid)
+    public ApiResponse<ApiGameNotificationResponse> GetNotificationByUuid(RequestContext context, GameUser user,
+        GameDatabaseContext database,
+        [DocSummary("The UUID of the notification")]
+        string uuid, DataContext dataContext)
     {
         bool parsed = ObjectId.TryParse(uuid, out ObjectId objectId);
         if (!parsed) return ApiValidationError.ObjectIdParseError;
@@ -40,7 +44,7 @@ public class NotificationApiEndpoints : EndpointGroup
         GameNotification? notification = database.GetNotificationByUuid(user, objectId);
         if (notification == null) return ApiNotFoundError.Instance;
         
-        return ApiGameNotificationResponse.FromOld(notification);
+        return ApiGameNotificationResponse.FromOld(notification, dataContext);
     }
     
     [ApiV3Endpoint("notifications/{uuid}", HttpMethods.Delete), MinimumRole(GameUserRole.Restricted)]

--- a/Refresh.GameServer/Endpoints/ApiV3/PhotoApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/PhotoApiEndpoints.cs
@@ -42,7 +42,6 @@ public class PhotoApiEndpoints : EndpointGroup
 
         DatabaseList<GamePhoto> photos = database.GetPhotosByUser(user, count, skip);
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
-        foreach (ApiGamePhotoResponse photo in photosResponse.Items) photo.FillInExtraData(database, dataStore);
         return photosResponse;
     }
     
@@ -54,7 +53,6 @@ public class PhotoApiEndpoints : EndpointGroup
 
         DatabaseList<GamePhoto> photos = database.GetPhotosWithUser(user, count, skip);
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
-        foreach (ApiGamePhotoResponse photo in photosResponse.Items) photo.FillInExtraData(database, dataStore);
         return photosResponse;
     }
     
@@ -66,10 +64,6 @@ public class PhotoApiEndpoints : EndpointGroup
 
         DatabaseList<GamePhoto> photos = database.GetPhotosInLevel(level, count, skip);
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
-        foreach (ApiGamePhotoResponse photo in photosResponse.Items)
-        {
-            photo.FillInExtraData(database, dataStore);
-        }
         return photosResponse;
     }
     
@@ -124,7 +118,6 @@ public class PhotoApiEndpoints : EndpointGroup
         DatabaseList<GamePhoto> photos = database.GetRecentPhotos(count, skip);
 
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
-        foreach (ApiGamePhotoResponse photo in photosResponse.Items) photo.FillInExtraData(database, dataStore);
         return photosResponse;
     }
     
@@ -137,6 +130,6 @@ public class PhotoApiEndpoints : EndpointGroup
         GamePhoto? photo = database.GetPhotoById(id);
         if (photo == null) return ApiNotFoundError.Instance;
         
-        return ApiGamePhotoResponse.FromOldWithExtraData(photo, database, dataStore, dataContext);
+        return ApiGamePhotoResponse.FromOld(photo, dataContext);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/PhotoApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/PhotoApiEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Extensions;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Photos;
 using Refresh.GameServer.Types.UserData;
@@ -33,35 +34,38 @@ public class PhotoApiEndpoints : EndpointGroup
         return new ApiOkResponse();
     }
     
-    private static ApiListResponse<ApiGamePhotoResponse> PhotosByUser(RequestContext context, GameDatabaseContext database, GameUser? user, IDataStore dataStore)
+    private static ApiListResponse<ApiGamePhotoResponse> PhotosByUser(RequestContext context,
+        GameDatabaseContext database, GameUser? user, IDataStore dataStore, DataContext dataContext)
     {
         if (user == null) return ApiNotFoundError.Instance;
         (int skip, int count) = context.GetPageData();
 
         DatabaseList<GamePhoto> photos = database.GetPhotosByUser(user, count, skip);
-        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos);
+        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
         foreach (ApiGamePhotoResponse photo in photosResponse.Items) photo.FillInExtraData(database, dataStore);
         return photosResponse;
     }
     
-    private static ApiListResponse<ApiGamePhotoResponse> PhotosWithUser(RequestContext context, GameDatabaseContext database, GameUser? user, IDataStore dataStore)
+    private static ApiListResponse<ApiGamePhotoResponse> PhotosWithUser(RequestContext context,
+        GameDatabaseContext database, GameUser? user, IDataStore dataStore, DataContext dataContext)
     {
         if (user == null) return ApiNotFoundError.Instance;
         (int skip, int count) = context.GetPageData();
 
         DatabaseList<GamePhoto> photos = database.GetPhotosWithUser(user, count, skip);
-        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos);
+        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
         foreach (ApiGamePhotoResponse photo in photosResponse.Items) photo.FillInExtraData(database, dataStore);
         return photosResponse;
     }
     
-    private static ApiListResponse<ApiGamePhotoResponse> PhotosInLevel(RequestContext context, GameDatabaseContext database, GameLevel? level, IDataStore dataStore)
+    private static ApiListResponse<ApiGamePhotoResponse> PhotosInLevel(RequestContext context,
+        GameDatabaseContext database, GameLevel? level, IDataStore dataStore, DataContext dataContext)
     {
         if (level == null) return ApiNotFoundError.Instance;
         (int skip, int count) = context.GetPageData();
 
         DatabaseList<GamePhoto> photos = database.GetPhotosInLevel(level, count, skip);
-        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos);
+        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
         foreach (ApiGamePhotoResponse photo in photosResponse.Items)
         {
             photo.FillInExtraData(database, dataStore);
@@ -72,46 +76,54 @@ public class PhotoApiEndpoints : EndpointGroup
     [ApiV3Endpoint("photos/by/username/{username}"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets photos by a user by their username")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosByUsername(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The username of the user")] string username) 
-        => PhotosByUser(context, database, database.GetUserByUsername(username), dataStore);
+    public ApiListResponse<ApiGamePhotoResponse> PhotosByUsername(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore,
+        [DocSummary("The username of the user")]
+        string username, DataContext dataContext) 
+        => PhotosByUser(context, database, database.GetUserByUsername(username), dataStore, dataContext);
     
     [ApiV3Endpoint("photos/with/username/{username}"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets photos including a user by their username")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUsername(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The username of the user")] string username)
-        => PhotosWithUser(context, database, database.GetUserByUsername(username), dataStore);
+    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUsername(RequestContext context,
+        GameDatabaseContext database, IDataStore dataStore,
+        [DocSummary("The username of the user")]
+        string username, DataContext dataContext)
+        => PhotosWithUser(context, database, database.GetUserByUsername(username), dataStore, dataContext);
 
     [ApiV3Endpoint("photos/by/uuid/{uuid}"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets photos by a user by their uuid")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosByUserUuid(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The UUID of the user")] string uuid)
-        => PhotosByUser(context, database, database.GetUserByUuid(uuid), dataStore);
+    public ApiListResponse<ApiGamePhotoResponse> PhotosByUserUuid(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore,
+        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext)
+        => PhotosByUser(context, database, database.GetUserByUuid(uuid), dataStore, dataContext);
 
     [ApiV3Endpoint("photos/with/uuid/{uuid}"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets photos including a user by their uuid")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUserUuid(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The UUID of the user")] string uuid)
-        => PhotosWithUser(context, database, database.GetUserByUuid(uuid), dataStore);
+    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUserUuid(RequestContext context,
+        GameDatabaseContext database, IDataStore dataStore,
+        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext)
+        => PhotosWithUser(context, database, database.GetUserByUuid(uuid), dataStore, dataContext);
 
     [ApiV3Endpoint("levels/id/{id}/photos"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets photos taken in a level by its id")]
     [DocError(typeof(ApiNotFoundError), "The level cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosInLevelById(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The ID of the level")] int id)
-        => PhotosInLevel(context, database, database.GetLevelById(id), dataStore);
+    public ApiListResponse<ApiGamePhotoResponse> PhotosInLevelById(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore,
+        [DocSummary("The ID of the level")] int id, DataContext dataContext)
+        => PhotosInLevel(context, database, database.GetLevelById(id), dataStore, dataContext);
     
     [ApiV3Endpoint("photos"), Authentication(false)]
     [DocUsesPageData, DocSummary("Get all photos taken recently")]
-    public ApiListResponse<ApiGamePhotoResponse> RecentPhotos(RequestContext context, GameDatabaseContext database, IDataStore dataStore)
+    public ApiListResponse<ApiGamePhotoResponse> RecentPhotos(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore, DataContext dataContext)
     {
         (int skip, int count) = context.GetPageData();
         DatabaseList<GamePhoto> photos = database.GetRecentPhotos(count, skip);
 
-        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos);
+        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseList<ApiGamePhotoResponse>.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
         foreach (ApiGamePhotoResponse photo in photosResponse.Items) photo.FillInExtraData(database, dataStore);
         return photosResponse;
     }
@@ -119,11 +131,12 @@ public class PhotoApiEndpoints : EndpointGroup
     [ApiV3Endpoint("photos/id/{id}"), Authentication(false)]
     [DocUsesPageData, DocSummary("Get an individual photo by the photo's id")]
     [DocError(typeof(ApiNotFoundError), "The photo cannot be found")]
-    public ApiResponse<ApiGamePhotoResponse> PhotoById(RequestContext context, GameDatabaseContext database, IDataStore dataStore, [DocSummary("The ID of the photo")] int id)
+    public ApiResponse<ApiGamePhotoResponse> PhotoById(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore, [DocSummary("The ID of the photo")] int id, DataContext dataContext)
     {
         GamePhoto? photo = database.GetPhotoById(id);
         if (photo == null) return ApiNotFoundError.Instance;
         
-        return ApiGamePhotoResponse.FromOldWithExtraData(photo, database, dataStore);
+        return ApiGamePhotoResponse.FromOldWithExtraData(photo, database, dataStore, dataContext);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/ResourceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ResourceApiEndpoints.cs
@@ -133,7 +133,7 @@ public class ResourceApiEndpoints : EndpointGroup
         GameAsset? asset = database.GetAssetFromHash(realHash);
         if (asset == null) return ApiNotFoundError.Instance;
 
-        return ApiGameAssetResponse.FromOldWithExtraData(asset, database, dataStore, dataContext);
+        return ApiGameAssetResponse.FromOld(asset, dataContext);
     }
 
     [ApiV3Endpoint("assets/psp/{hash}"), Authentication(false)]
@@ -176,7 +176,7 @@ public class ResourceApiEndpoints : EndpointGroup
             if (existingAsset == null)
                 return ApiInternalError.HashNotFoundInDatabaseError;
 
-            return ApiGameAssetResponse.FromOldWithExtraData(existingAsset, database, dataStore, dataContext);
+            return ApiGameAssetResponse.FromOld(existingAsset, dataContext);
         }
 
         if (body.Length > 1_048_576 * 2)
@@ -197,6 +197,6 @@ public class ResourceApiEndpoints : EndpointGroup
         gameAsset.OriginalUploader = user;
         database.AddAssetToDatabase(gameAsset);
 
-        return new ApiResponse<ApiGameAssetResponse>(ApiGameAssetResponse.FromOldWithExtraData(gameAsset, database, dataStore, dataContext)!, Created);
+        return new ApiResponse<ApiGameAssetResponse>(ApiGameAssetResponse.FromOld(gameAsset, dataContext)!, Created);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/ResourceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ResourceApiEndpoints.cs
@@ -14,6 +14,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Importing;
 using Refresh.GameServer.Types.Assets;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 using Refresh.GameServer.Verification;
@@ -117,8 +118,10 @@ public class ResourceApiEndpoints : EndpointGroup
     [DocSummary("Gets information from the database about a particular hash. Includes user who uploaded, dependencies, timestamps, etc.")]
     [DocError(typeof(ApiNotFoundError), "The asset could not be found")]
     [DocError(typeof(ApiValidationError), ApiValidationError.HashMissingErrorWhen)]
-    public ApiResponse<ApiGameAssetResponse> GetAssetInfo(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The SHA1 hash of the asset")] string hash)
+    public ApiResponse<ApiGameAssetResponse> GetAssetInfo(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore,
+        [DocSummary("The SHA1 hash of the asset")]
+        string hash, DataContext dataContext)
     {
         bool isPspAsset = hash.StartsWith("psp/");
 
@@ -130,15 +133,17 @@ public class ResourceApiEndpoints : EndpointGroup
         GameAsset? asset = database.GetAssetFromHash(realHash);
         if (asset == null) return ApiNotFoundError.Instance;
 
-        return ApiGameAssetResponse.FromOldWithExtraData(asset, database, dataStore);
+        return ApiGameAssetResponse.FromOldWithExtraData(asset, database, dataStore, dataContext);
     }
 
     [ApiV3Endpoint("assets/psp/{hash}"), Authentication(false)]
     [DocSummary("Gets information from the database about a particular PSP hash. Includes user who uploaded, dependencies, timestamps, etc.")]
     [DocError(typeof(ApiValidationError), ApiValidationError.HashMissingErrorWhen)]
     [DocError(typeof(ApiNotFoundError), "The asset could not be found")]
-    public ApiResponse<ApiGameAssetResponse> GetPspAssetInfo(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The SHA1 hash of the asset")] string hash) => this.GetAssetInfo(context, database, dataStore, $"psp/{hash}");
+    public ApiResponse<ApiGameAssetResponse> GetPspAssetInfo(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore,
+        [DocSummary("The SHA1 hash of the asset")]
+        string hash, DataContext dataContext) => this.GetAssetInfo(context, database, dataStore, $"psp/{hash}", dataContext);
 
     [ApiV3Endpoint("assets/{hash}", HttpMethods.Post)]
     [DocSummary("Uploads an image (PNG/JPEG) asset")]
@@ -147,9 +152,11 @@ public class ResourceApiEndpoints : EndpointGroup
     [DocError(typeof(ApiValidationError), ApiValidationError.CannotReadAssetErrorWhen)]
     [DocError(typeof(ApiValidationError), ApiValidationError.BodyMustBeImageErrorWhen)]
     [DocError(typeof(ApiAuthenticationError), ApiAuthenticationError.NoPermissionsForCreationWhen)]
-    public ApiResponse<ApiGameAssetResponse> UploadImageAsset(RequestContext context, GameDatabaseContext database, IDataStore dataStore, AssetImporter importer, GameServerConfig config,
-        [DocSummary("The SHA1 hash of the asset")] string hash,
-        byte[] body, GameUser user)
+    public ApiResponse<ApiGameAssetResponse> UploadImageAsset(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore, AssetImporter importer, GameServerConfig config,
+        [DocSummary("The SHA1 hash of the asset")]
+        string hash,
+        byte[] body, GameUser user, DataContext dataContext)
     {
         // If we're blocking asset uploads, throw unless the user is an admin.
         // We also have the ability to block asset uploads for trusted users (when they would normally bypass this)
@@ -169,7 +176,7 @@ public class ResourceApiEndpoints : EndpointGroup
             if (existingAsset == null)
                 return ApiInternalError.HashNotFoundInDatabaseError;
 
-            return ApiGameAssetResponse.FromOldWithExtraData(existingAsset, database, dataStore);
+            return ApiGameAssetResponse.FromOldWithExtraData(existingAsset, database, dataStore, dataContext);
         }
 
         if (body.Length > 1_048_576 * 2)
@@ -190,6 +197,6 @@ public class ResourceApiEndpoints : EndpointGroup
         gameAsset.OriginalUploader = user;
         database.AddAssetToDatabase(gameAsset);
 
-        return new ApiResponse<ApiGameAssetResponse>(ApiGameAssetResponse.FromOldWithExtraData(gameAsset, database, dataStore)!, Created);
+        return new ApiResponse<ApiGameAssetResponse>(ApiGameAssetResponse.FromOldWithExtraData(gameAsset, database, dataStore, dataContext)!, Created);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/ReviewApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ReviewApiEndpoints.cs
@@ -8,6 +8,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Extensions;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Reviews;
 
@@ -20,7 +21,7 @@ public class ReviewApiEndpoints : EndpointGroup
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     public ApiListResponse<ApiGameReviewResponse> GetTopScoresForLevel(RequestContext context,
         GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The ID of the level")] int id)
+        [DocSummary("The ID of the level")] int id, DataContext dataContext)
     {
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
@@ -28,7 +29,7 @@ public class ReviewApiEndpoints : EndpointGroup
         (int skip, int count) = context.GetPageData();
         
         DatabaseList<GameReview> reviews = database.GetReviewsForLevel(level, count, skip);
-        DatabaseList<ApiGameReviewResponse> ret = DatabaseList<ApiGameScoreResponse>.FromOldList<ApiGameReviewResponse, GameReview>(reviews);
+        DatabaseList<ApiGameReviewResponse> ret = DatabaseList<ApiGameScoreResponse>.FromOldList<ApiGameReviewResponse, GameReview>(reviews, dataContext);
 
         return ret;
     }

--- a/Refresh.GameServer/Endpoints/ApiV3/UserApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/UserApiEndpoints.cs
@@ -8,6 +8,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
@@ -18,40 +19,45 @@ public class UserApiEndpoints : EndpointGroup
     [ApiV3Endpoint("users/name/{username}"), Authentication(false)]
     [DocSummary("Tries to find a user by the username")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiResponse<ApiGameUserResponse> GetUserByName(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The username of the user")] string username)
+    public ApiResponse<ApiGameUserResponse> GetUserByName(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore,
+        [DocSummary("The username of the user")]
+        string username, DataContext dataContext)
     {
         GameUser? user = database.GetUserByUsername(username);
         if(user == null) return ApiNotFoundError.UserMissingError;
         
-        return ApiGameUserResponse.FromOldWithExtraData(user, database, dataStore);
+        return ApiGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
     }
     
     [ApiV3Endpoint("users/uuid/{uuid}"), Authentication(false)]
     [DocSummary("Tries to find a user by the UUID")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiResponse<ApiGameUserResponse> GetUserByUuid(RequestContext context, GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The UUID of the user")] string uuid)
+    public ApiResponse<ApiGameUserResponse> GetUserByUuid(RequestContext context, GameDatabaseContext database,
+        IDataStore dataStore,
+        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext)
     {
         GameUser? user = database.GetUserByUuid(uuid);
         if(user == null) return ApiNotFoundError.UserMissingError;
         
-        return ApiGameUserResponse.FromOldWithExtraData(user, database, dataStore);
+        return ApiGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
     }
     
     [ApiV3Endpoint("users/me"), MinimumRole(GameUserRole.Restricted)]
     [DocSummary("Returns your own user, provided you are authenticated")]
-    public ApiResponse<ApiExtendedGameUserResponse> GetMyUser(RequestContext context, GameUser user, GameDatabaseContext database, IDataStore dataStore)
-        => ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore);
+    public ApiResponse<ApiExtendedGameUserResponse> GetMyUser(RequestContext context, GameUser user,
+        GameDatabaseContext database, IDataStore dataStore, DataContext dataContext)
+        => ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
     
     [ApiV3Endpoint("users/me", HttpMethods.Patch)]
     [DocSummary("Updates your profile with the given data")]
-    public ApiResponse<ApiExtendedGameUserResponse> UpdateUser(RequestContext context, GameDatabaseContext database, GameUser user, ApiUpdateUserRequest body, IDataStore dataStore)
+    public ApiResponse<ApiExtendedGameUserResponse> UpdateUser(RequestContext context, GameDatabaseContext database,
+        GameUser user, ApiUpdateUserRequest body, IDataStore dataStore, DataContext dataContext)
     {
         if (body.IconHash != null && database.GetAssetFromHash(body.IconHash) == null)
             return ApiNotFoundError.Instance;
 
         database.UpdateUserData(user, body);
-        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore);
+        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/UserApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/UserApiEndpoints.cs
@@ -27,7 +27,7 @@ public class UserApiEndpoints : EndpointGroup
         GameUser? user = database.GetUserByUsername(username);
         if(user == null) return ApiNotFoundError.UserMissingError;
         
-        return ApiGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
+        return ApiGameUserResponse.FromOld(user, dataContext);
     }
     
     [ApiV3Endpoint("users/uuid/{uuid}"), Authentication(false)]
@@ -40,14 +40,14 @@ public class UserApiEndpoints : EndpointGroup
         GameUser? user = database.GetUserByUuid(uuid);
         if(user == null) return ApiNotFoundError.UserMissingError;
         
-        return ApiGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
+        return ApiGameUserResponse.FromOld(user, dataContext);
     }
     
     [ApiV3Endpoint("users/me"), MinimumRole(GameUserRole.Restricted)]
     [DocSummary("Returns your own user, provided you are authenticated")]
     public ApiResponse<ApiExtendedGameUserResponse> GetMyUser(RequestContext context, GameUser user,
         GameDatabaseContext database, IDataStore dataStore, DataContext dataContext)
-        => ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
+        => ApiExtendedGameUserResponse.FromOld(user, dataContext);
     
     [ApiV3Endpoint("users/me", HttpMethods.Patch)]
     [DocSummary("Updates your profile with the given data")]
@@ -58,6 +58,6 @@ public class UserApiEndpoints : EndpointGroup
             return ApiNotFoundError.Instance;
 
         database.UpdateUserData(user, body);
-        return ApiExtendedGameUserResponse.FromOldWithExtraData(user, database, dataStore, dataContext);
+        return ApiExtendedGameUserResponse.FromOld(user, dataContext);
     }
 }

--- a/Refresh.GameServer/Endpoints/Game/ActivityEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ActivityEndpoints.cs
@@ -12,6 +12,7 @@ using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Time;
 using Refresh.GameServer.Types.Activity;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.News;
 using Refresh.GameServer.Types.Roles;
@@ -24,7 +25,8 @@ public class ActivityEndpoints : EndpointGroup
     [GameEndpoint("stream", ContentType.Xml)]
     [NullStatusCode(BadRequest)]
     [MinimumRole(GameUserRole.Restricted)]
-    public ActivityPage? GetRecentActivity(RequestContext context, GameDatabaseContext database, GameUser? user)
+    public ActivityPage? GetRecentActivity(RequestContext context, GameDatabaseContext database, GameUser? user,
+        DataContext dataContext)
     {
         long timestamp = 0;
         long endTimestamp = 0;
@@ -50,13 +52,14 @@ public class ActivityEndpoints : EndpointGroup
             ExcludeFavouriteUsers = excludeFavouriteUsers,
             ExcludeMyself = excludeMyself,
             User = user,
-        });
+        }, dataContext);
     }
 
     [GameEndpoint("stream/slot/{type}/{id}", ContentType.Xml)]
     [NullStatusCode(BadRequest)]
     [MinimumRole(GameUserRole.Restricted)]
-    public Response GetRecentActivityForLevel(RequestContext context, GameDatabaseContext database, GameUser? user, string type, int id)
+    public Response GetRecentActivityForLevel(RequestContext context, GameDatabaseContext database, GameUser? user,
+        string type, int id, DataContext dataContext)
     {
         GameLevel? level = type == "developer" ? database.GetStoryLevelById(id) : database.GetLevelById(id);
         if (level == null) return NotFound;
@@ -85,7 +88,7 @@ public class ActivityEndpoints : EndpointGroup
             ExcludeFavouriteUsers = excludeFavouriteUsers,
             ExcludeMyself = excludeMyself,
             User = user,
-        });
+        }, dataContext);
         
         return new Response(page, ContentType.Xml);
     }
@@ -93,7 +96,8 @@ public class ActivityEndpoints : EndpointGroup
     [GameEndpoint("stream/user2/{username}", ContentType.Xml)]
     [NullStatusCode(BadRequest)]
     [MinimumRole(GameUserRole.Restricted)]
-    public Response GetRecentActivityForUser(RequestContext context, GameDatabaseContext database, string username)
+    public Response GetRecentActivityForUser(RequestContext context, GameDatabaseContext database, string username,
+        DataContext dataContext)
     {
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return NotFound;
@@ -125,7 +129,7 @@ public class ActivityEndpoints : EndpointGroup
             ExcludeFavouriteUsers = excludeFavouriteUsers,
             ExcludeMyself = excludeMyself,
             User = user,
-        }), ContentType.Xml);
+        }, dataContext), ContentType.Xml);
     }
     
     [GameEndpoint("news", ContentType.Xml)]

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types;
 using Refresh.GameServer.Types.Assets;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Levels.SkillRewards;
 using Refresh.GameServer.Types.Matching;
@@ -137,17 +138,18 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         };
     }
     
-    public static GameLevelResponse? FromOldWithExtraData(GameLevel? old, GameDatabaseContext database, MatchService matchService, GameUser user, IDataStore dataStore, TokenGame game)
+    public static GameLevelResponse? FromOldWithExtraData(GameLevel? old, GameDatabaseContext database,
+        MatchService matchService, GameUser user, IDataStore dataStore, TokenGame game, DataContext dataContext)
     {
         if (old == null) return null;
 
-        GameLevelResponse response = FromOld(old)!;
+        GameLevelResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(database, matchService, user, dataStore, game);
 
         return response;
     }
 
-    public static GameLevelResponse? FromOld(GameLevel? old)
+    public static GameLevelResponse? FromOld(GameLevel? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -215,7 +217,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         return response;
     }
 
-    public static IEnumerable<GameLevelResponse> FromOldList(IEnumerable<GameLevel> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<GameLevelResponse> FromOldList(IEnumerable<GameLevel> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 
     private void FillInExtraData(GameDatabaseContext database, MatchService matchService, GameUser user, IDataStore dataStore, TokenGame game)
     {

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -204,14 +204,15 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             };
         }
         
-        Debug.Assert(dataContext.User != null);
-        Debug.Assert(dataContext.Game != null);
+        if (dataContext.User != null)
+        {
+            RatingType? rating = dataContext.Database.GetRatingByUser(old, dataContext.User);
+            
+            response.YourRating = rating?.ToDPad() ?? (int)RatingType.Neutral;
+            response.YourStarRating = rating?.ToLBP1() ?? 0;
+            response.YourLbp2PlayCount = old.AllPlays.Count(p => p.User == dataContext.User);
+        }
         
-        RatingType? rating = dataContext.Database.GetRatingByUser(old, dataContext.User);
-        
-        response.YourRating = rating?.ToDPad() ?? (int)RatingType.Neutral;
-        response.YourStarRating = rating?.ToLBP1() ?? 0;
-        response.YourLbp2PlayCount = old.AllPlays.Count(p => p.User == dataContext.User);
         response.PlayerCount = dataContext.Match.GetPlayerCountForLevel(RoomSlotType.Online, response.LevelId);
         
         GameAsset? rootResourceAsset = dataContext.Database.GetAssetFromHash(response.RootResource);
@@ -224,7 +225,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             });
         }
         
-        response.IconHash = dataContext.Database.GetAssetFromHash(old.IconHash)?.GetAsIcon(dataContext.Game.Value, dataContext) ?? response.IconHash;
+        response.IconHash = dataContext.Database.GetAssetFromHash(old.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? response.IconHash;
         
         response.CommentCount = old.LevelComments.Count;
         

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -74,7 +74,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             Location = old.Location,
             PlanetsHash = "0",
             
-            Handle = SerializedUserHandle.FromUser(old),
+            Handle = SerializedUserHandle.FromUser(old, dataContext),
             CommentCount = old.ProfileComments.Count,
             CommentsEnabled = true,
             FavouriteLevelCount = old.IsManaged ? old.FavouriteLevelRelations.Count() : 0,
@@ -170,7 +170,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
 
                 //Fill out PSP favourite users
                 List<GameUser> users = database.GetUsersFavouritedByUser(old, 20, 0).ToList();
-                this.FavouriteUsers = new SerializedMinimalFavouriteUserList(users.Select(SerializedUserHandle.FromUser).ToList(), users.Count);
+                this.FavouriteUsers = new SerializedMinimalFavouriteUserList(users.Select(u => SerializedUserHandle.FromUser(u, dataContext)).ToList(), users.Count);
 
                 //Fill out PSP favourite levels
                 List<GameMinimalLevelResponse> favouriteLevels = old.FavouriteLevelRelations
@@ -198,7 +198,5 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             default:
                 throw new ArgumentOutOfRangeException(nameof(gameVersion), gameVersion, null);
         }
-        
-        this.Handle.FillInExtraData(database, dataStore, gameVersion);
     }
 }

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -38,7 +38,7 @@ public class LevelEndpoints : EndpointGroup
             List<GameMinimalLevelResponse> overrides = [];
             
             if (overrideService.GetIdOverridesForUser(token, database, out IEnumerable<GameLevel> levelOverrides))
-                overrides.AddRange(levelOverrides.Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame, dataContext))!);
+                overrides.AddRange(levelOverrides.Select(l => GameMinimalLevelResponse.FromOld(l, dataContext))!);
             
             if (overrideService.GetHashOverrideForUser(token, out string hashOverride))
                 overrides.Add(GameMinimalLevelResponse.FromHash(hashOverride, dataContext));
@@ -68,7 +68,7 @@ public class LevelEndpoints : EndpointGroup
         if (levels == null) return null;
         
         IEnumerable<GameMinimalLevelResponse> category = levels.Items
-            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame, dataContext))!;
+            .Select(l => GameMinimalLevelResponse.FromOld(l, dataContext))!;
         
         return new SerializedMinimalLevelList(category, levels.TotalItems, skip + count);
     }
@@ -105,8 +105,7 @@ public class LevelEndpoints : EndpointGroup
             // Return the hashed level info
             return GameLevelResponse.FromHash(hash);
         
-        return GameLevelResponse.FromOldWithExtraData(database.GetLevelByIdAndType(slotType, id), database,
-            matchService, user, dataStore, token.TokenGame, dataContext);
+        return GameLevelResponse.FromOld(database.GetLevelByIdAndType(slotType, id), dataContext);
     }
     
     [GameEndpoint("slotList", ContentType.Xml)]
@@ -127,7 +126,7 @@ public class LevelEndpoints : EndpointGroup
 
             if (level == null) continue;
             
-            levels.Add(GameLevelResponse.FromOldWithExtraData(level, database, matchService, user, dataStore, token.TokenGame, dataContext)!);
+            levels.Add(GameLevelResponse.FromOld(level, dataContext)!);
         }
 
         return new SerializedLevelList
@@ -175,7 +174,7 @@ public class LevelEndpoints : EndpointGroup
             .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame), user);
         
         return new SerializedMinimalLevelResultsList(levels?.Items
-            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame, dataContext))!, levels?.TotalItems ?? 0, skip + count);
+            .Select(l => GameMinimalLevelResponse.FromOld(l, dataContext))!, levels?.TotalItems ?? 0, skip + count);
     }
 
     #region Quirk workarounds

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Levels.Categories;
 using Refresh.GameServer.Types.Lists;
@@ -29,6 +30,7 @@ public class LevelEndpoints : EndpointGroup
         GameUser user,
         Token token,
         IDataStore dataStore,
+        DataContext dataContext,
         string route)
     {
         if (overrideService.UserHasOverrides(user))
@@ -36,10 +38,10 @@ public class LevelEndpoints : EndpointGroup
             List<GameMinimalLevelResponse> overrides = [];
             
             if (overrideService.GetIdOverridesForUser(token, database, out IEnumerable<GameLevel> levelOverrides))
-                overrides.AddRange(levelOverrides.Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame))!);
+                overrides.AddRange(levelOverrides.Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame, dataContext))!);
             
             if (overrideService.GetHashOverrideForUser(token, out string hashOverride))
-                overrides.Add(GameMinimalLevelResponse.FromHash(hashOverride));
+                overrides.Add(GameMinimalLevelResponse.FromHash(hashOverride, dataContext));
             
             return new SerializedMinimalLevelList(overrides, overrides.Count, overrides.Count);
         }
@@ -53,7 +55,7 @@ public class LevelEndpoints : EndpointGroup
             {
                 Total = 1,
                 NextPageStart = 1,
-                Items = [GameMinimalLevelResponse.FromHash(hash)],
+                Items = [GameMinimalLevelResponse.FromHash(hash, dataContext)],
             };
         }
         
@@ -66,7 +68,7 @@ public class LevelEndpoints : EndpointGroup
         if (levels == null) return null;
         
         IEnumerable<GameMinimalLevelResponse> category = levels.Items
-            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame))!;
+            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame, dataContext))!;
         
         return new SerializedMinimalLevelList(category, levels.TotalItems, skip + count);
     }
@@ -81,20 +83,22 @@ public class LevelEndpoints : EndpointGroup
         LevelListOverrideService overrideService,
         Token token,
         IDataStore dataStore,
+        DataContext dataContext,
         string route,
         string username)
     {
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return null;
         
-        return this.GetLevels(context, database, categories, matchService, overrideService, user, token, dataStore, route);
+        return this.GetLevels(context, database, categories, matchService, overrideService, user, token, dataStore, dataContext, route);
     }
 
     [GameEndpoint("s/{slotType}/{id}", ContentType.Xml)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
-    public GameLevelResponse? LevelById(RequestContext context, GameDatabaseContext database, MatchService matchService, 
-        GameUser user, string slotType, int id, IDataStore dataStore, Token token, LevelListOverrideService overrideService)
+    public GameLevelResponse? LevelById(RequestContext context, GameDatabaseContext database, MatchService matchService,
+        GameUser user, string slotType, int id, IDataStore dataStore, Token token,
+        LevelListOverrideService overrideService, DataContext dataContext)
     {
         // If the user has had a hash override in the past, and the level id they requested matches the level ID associated with that hash
         if (overrideService.GetLastHashOverrideForUser(token, out string hash) && GameLevelResponse.LevelIdFromHash(hash) == id)
@@ -102,13 +106,14 @@ public class LevelEndpoints : EndpointGroup
             return GameLevelResponse.FromHash(hash);
         
         return GameLevelResponse.FromOldWithExtraData(database.GetLevelByIdAndType(slotType, id), database,
-            matchService, user, dataStore, token.TokenGame);
+            matchService, user, dataStore, token.TokenGame, dataContext);
     }
     
     [GameEndpoint("slotList", ContentType.Xml)]
     [NullStatusCode(BadRequest)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedLevelList? GetMultipleLevels(RequestContext context, GameDatabaseContext database, MatchService matchService, GameUser user, IDataStore dataStore, Token token)
+    public SerializedLevelList? GetMultipleLevels(RequestContext context, GameDatabaseContext database,
+        MatchService matchService, GameUser user, IDataStore dataStore, Token token, DataContext dataContext)
     {
         string[]? levelIds = context.QueryString.GetValues("s");
         if (levelIds == null) return null;
@@ -122,7 +127,7 @@ public class LevelEndpoints : EndpointGroup
 
             if (level == null) continue;
             
-            levels.Add(GameLevelResponse.FromOldWithExtraData(level, database, matchService, user, dataStore, token.TokenGame)!);
+            levels.Add(GameLevelResponse.FromOldWithExtraData(level, database, matchService, user, dataStore, token.TokenGame, dataContext)!);
         }
 
         return new SerializedLevelList
@@ -136,13 +141,15 @@ public class LevelEndpoints : EndpointGroup
     [GameEndpoint("searches", ContentType.Xml)]
     [GameEndpoint("genres", ContentType.Xml)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedCategoryList GetModernCategories(RequestContext context, GameDatabaseContext database, CategoryService categoryService, MatchService matchService, GameUser user, Token token, IDataStore dataStore)
+    public SerializedCategoryList GetModernCategories(RequestContext context, GameDatabaseContext database,
+        CategoryService categoryService, MatchService matchService, GameUser user, Token token, IDataStore dataStore,
+        DataContext dataContext)
     {
         (int skip, int count) = context.GetPageData();
 
         IEnumerable<SerializedCategory> categories = categoryService.Categories
             .Where(c => !c.Hidden)
-            .Select(c => SerializedCategory.FromLevelCategory(c, context, database, dataStore, user, token, matchService, 0, 1))
+            .Select(c => SerializedCategory.FromLevelCategory(c, context, database, dataStore, user, token, matchService, dataContext, 0, 1))
             .ToList();
 
         int total = categories.Count();
@@ -157,7 +164,9 @@ public class LevelEndpoints : EndpointGroup
 
     [GameEndpoint("searches/{apiRoute}", ContentType.Xml)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedMinimalLevelResultsList GetLevelsFromCategory(RequestContext context, GameDatabaseContext database, CategoryService categories, MatchService matchService, GameUser user, Token token, IDataStore dataStore, string apiRoute)
+    public SerializedMinimalLevelResultsList GetLevelsFromCategory(RequestContext context, GameDatabaseContext database,
+        CategoryService categories, MatchService matchService, GameUser user, Token token, IDataStore dataStore,
+        string apiRoute, DataContext dataContext)
     {
         (int skip, int count) = context.GetPageData();
 
@@ -166,7 +175,7 @@ public class LevelEndpoints : EndpointGroup
             .Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame), user);
         
         return new SerializedMinimalLevelResultsList(levels?.Items
-            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame))!, levels?.TotalItems ?? 0, skip + count);
+            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame, dataContext))!, levels?.TotalItems ?? 0, skip + count);
     }
 
     #region Quirk workarounds
@@ -182,8 +191,9 @@ public class LevelEndpoints : EndpointGroup
         LevelListOverrideService overrideService,
         GameUser user,
         IDataStore dataStore,
-        Token token) 
-        => this.GetLevels(context, database, categories, matchService, overrideService, user, token, dataStore, "newest");
+        Token token,
+        DataContext dataContext) 
+        => this.GetLevels(context, database, categories, matchService, overrideService, user, token, dataStore, dataContext, "newest");
 
     [GameEndpoint("favouriteSlots/{username}", ContentType.Xml)]
     [NullStatusCode(NotFound)]
@@ -195,12 +205,13 @@ public class LevelEndpoints : EndpointGroup
         LevelListOverrideService overrideService,
         Token token,
         IDataStore dataStore,
+        DataContext dataContext,
         string username)
     {
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return null;
         
-        SerializedMinimalLevelList? levels = this.GetLevels(context, database, categories, matchService, overrideService, user, token, dataStore, "favouriteSlots");
+        SerializedMinimalLevelList? levels = this.GetLevels(context, database, categories, matchService, overrideService, user, token, dataStore, dataContext, "favouriteSlots");
         
         return new SerializedMinimalFavouriteLevelList(levels);
     }

--- a/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
@@ -11,6 +11,7 @@ using Refresh.GameServer.Endpoints.Game.DataTypes.Request;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.UserData;
 using Refresh.GameServer.Verification;
@@ -90,7 +91,7 @@ public class PublishEndpoints : EndpointGroup
         GameLevelRequest body,
         CommandService commandService,
         IDataStore dataStore,
-        GuidCheckerService guidChecker)
+        GuidCheckerService guidChecker, DataContext dataContext)
     {
         //If verifying the request fails, return null
         if (!VerifyLevel(body, user, context.Logger, guidChecker, token.TokenGame)) return BadRequest;
@@ -116,7 +117,7 @@ public class PublishEndpoints : EndpointGroup
             // ReSharper disable once InvertIf
             if ((newBody = database.UpdateLevel(level, user)) != null)
             {
-                return new Response(GameLevelResponse.FromOld(newBody)!, ContentType.Xml);
+                return new Response(GameLevelResponse.FromOld(newBody, dataContext)!, ContentType.Xml);
             }
             
             database.AddPublishFailNotification("You may not republish another user's level.", level, user);
@@ -133,7 +134,7 @@ public class PublishEndpoints : EndpointGroup
         
         context.Logger.LogInfo(BunkumCategory.UserContent, "User {0} (id: {1}) uploaded level id {2}", user.Username, user.UserId, level.LevelId);
         
-        return new Response(GameLevelResponse.FromOld(level)!, ContentType.Xml);
+        return new Response(GameLevelResponse.FromOld(level, dataContext)!, ContentType.Xml);
     }
 
     [GameEndpoint("unpublish/{id}", ContentType.Xml, HttpMethods.Post)]

--- a/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
@@ -8,6 +8,7 @@ using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Extensions;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Lists;
 using Refresh.GameServer.Types.Roles;
@@ -80,7 +81,8 @@ public class RelationEndpoints : EndpointGroup
     [GameEndpoint("favouriteUsers/{username}", ContentType.Xml)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedFavouriteUserList? GetFavouriteUsers(RequestContext context, GameDatabaseContext database, string username, Token token, IDataStore dataStore)
+    public SerializedFavouriteUserList? GetFavouriteUsers(RequestContext context, GameDatabaseContext database,
+        string username, Token token, IDataStore dataStore, DataContext dataContext)
     {
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return null;
@@ -89,7 +91,7 @@ public class RelationEndpoints : EndpointGroup
         List<GameUser> users = database.GetUsersFavouritedByUser(user, count, skip)
             .ToList();
 
-        return new SerializedFavouriteUserList(GameUserResponse.FromOldListWithExtraData(users, token.TokenGame, database, dataStore).ToList(), users.Count, skip + count);
+        return new SerializedFavouriteUserList(GameUserResponse.FromOldListWithExtraData(users, token.TokenGame, database, dataStore, dataContext).ToList(), users.Count, skip + count);
     }
 
     [GameEndpoint("lolcatftw/add/{slotType}/{id}", HttpMethods.Post)]

--- a/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
@@ -82,7 +82,7 @@ public class RelationEndpoints : EndpointGroup
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
     public SerializedFavouriteUserList? GetFavouriteUsers(RequestContext context, GameDatabaseContext database,
-        string username, Token token, IDataStore dataStore, DataContext dataContext)
+        string username, DataContext dataContext)
     {
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return null;
@@ -91,7 +91,7 @@ public class RelationEndpoints : EndpointGroup
         List<GameUser> users = database.GetUsersFavouritedByUser(user, count, skip)
             .ToList();
 
-        return new SerializedFavouriteUserList(GameUserResponse.FromOldListWithExtraData(users, token.TokenGame, database, dataStore, dataContext).ToList(), users.Count, skip + count);
+        return new SerializedFavouriteUserList(GameUserResponse.FromOldList(users, dataContext).ToList(), users.Count, skip + count);
     }
 
     [GameEndpoint("lolcatftw/add/{slotType}/{id}", HttpMethods.Post)]

--- a/Refresh.GameServer/Endpoints/Game/ReviewEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ReviewEndpoints.cs
@@ -7,6 +7,7 @@ using Bunkum.Protocols.Http;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Time;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Reviews;
 using Refresh.GameServer.Types.UserData;
@@ -63,7 +64,8 @@ public class ReviewEndpoints : EndpointGroup
 
     [GameEndpoint("reviewsFor/{slotType}/{id}", ContentType.Xml)]
     [AllowEmptyBody]
-    public Response GetReviewsForLevel(RequestContext context, GameDatabaseContext database, string slotType, int id)
+    public Response GetReviewsForLevel(RequestContext context, GameDatabaseContext database, string slotType, int id,
+        DataContext dataContext)
     {
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
 
@@ -72,12 +74,13 @@ public class ReviewEndpoints : EndpointGroup
 
         (int skip, int count) =  context.GetPageData();
         
-        return new Response(new SerializedGameReviewResponse(items: SerializedGameReview.FromOldList(database.GetReviewsForLevel(level, count, skip).Items).ToList()), ContentType.Xml);
+        return new Response(new SerializedGameReviewResponse(items: SerializedGameReview.FromOldList(database.GetReviewsForLevel(level, count, skip).Items, dataContext).ToList()), ContentType.Xml);
     }
     
     [GameEndpoint("reviewsBy/{username}", ContentType.Xml)]
     [AllowEmptyBody]
-    public Response GetReviewsForLevel(RequestContext context, GameDatabaseContext database, string username)
+    public Response GetReviewsForLevel(RequestContext context, GameDatabaseContext database, string username,
+        DataContext dataContext)
     {
         GameUser? user = database.GetUserByUsername(username);
         
@@ -86,7 +89,7 @@ public class ReviewEndpoints : EndpointGroup
 
         (int skip, int count) =  context.GetPageData();
         
-        return new Response(new SerializedGameReviewResponse(SerializedGameReview.FromOldList(database.GetReviewsByUser(user, count, skip).Items).ToList()), ContentType.Xml);
+        return new Response(new SerializedGameReviewResponse(SerializedGameReview.FromOldList(database.GetReviewsByUser(user, count, skip).Items, dataContext).ToList()), ContentType.Xml);
     }
 
     [GameEndpoint("postReview/{slotType}/{id}", ContentType.Xml, HttpMethods.Post)]

--- a/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
@@ -21,7 +21,7 @@ public class UserEndpoints : EndpointGroup
     [MinimumRole(GameUserRole.Restricted)]
     public GameUserResponse? GetUser(RequestContext context, GameDatabaseContext database, string name, Token token,
         IDataStore dataStore, DataContext dataContext) 
-        => GameUserResponse.FromOldWithExtraData(database.GetUserByUsername(name), token.TokenGame, database, dataStore, dataContext);
+        => GameUserResponse.FromOld(database.GetUserByUsername(name), dataContext);
 
     [GameEndpoint("users", HttpMethods.Get, ContentType.Xml)]
     [MinimumRole(GameUserRole.Restricted)]
@@ -38,7 +38,7 @@ public class UserEndpoints : EndpointGroup
             GameUser? user = database.GetUserByUsername(username);
             if (user == null) continue;
             
-            users.Add(GameUserResponse.FromOldWithExtraData(user, token.TokenGame, database, dataStore, dataContext)!);
+            users.Add(GameUserResponse.FromOld(user, dataContext)!);
         }
 
         return new SerializedUserList
@@ -50,11 +50,11 @@ public class UserEndpoints : EndpointGroup
     [GameEndpoint("myFriends", HttpMethods.Get, ContentType.Xml)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedFriendsList? GetFriends(RequestContext context, GameDatabaseContext database,
-        GameUser user, Token token, IDataStore dataStore, DataContext dataContext)
+    public SerializedFriendsList GetFriends(RequestContext context, GameDatabaseContext database,
+        GameUser user, DataContext dataContext)
     {
         List<GameUser> friends = database.GetUsersMutuals(user).ToList();
-        return new SerializedFriendsList(GameUserResponse.FromOldListWithExtraData(friends, token.TokenGame, database, dataStore, dataContext).ToList());
+        return new SerializedFriendsList(GameUserResponse.FromOldList(friends, dataContext).ToList());
     }
 
     [GameEndpoint("updateUser", HttpMethods.Post, ContentType.Xml)]

--- a/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
@@ -8,6 +8,7 @@ using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Lists;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -18,12 +19,14 @@ public class UserEndpoints : EndpointGroup
 {
     [GameEndpoint("user/{name}", HttpMethods.Get, ContentType.Xml)]
     [MinimumRole(GameUserRole.Restricted)]
-    public GameUserResponse? GetUser(RequestContext context, GameDatabaseContext database, string name, Token token, IDataStore dataStore) 
-        => GameUserResponse.FromOldWithExtraData(database.GetUserByUsername(name), token.TokenGame, database, dataStore);
+    public GameUserResponse? GetUser(RequestContext context, GameDatabaseContext database, string name, Token token,
+        IDataStore dataStore, DataContext dataContext) 
+        => GameUserResponse.FromOldWithExtraData(database.GetUserByUsername(name), token.TokenGame, database, dataStore, dataContext);
 
     [GameEndpoint("users", HttpMethods.Get, ContentType.Xml)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedUserList GetMultipleUsers(RequestContext context, GameDatabaseContext database, Token token, IDataStore dataStore)
+    public SerializedUserList GetMultipleUsers(RequestContext context, GameDatabaseContext database, Token token,
+        IDataStore dataStore, DataContext dataContext)
     {
         string[]? usernames = context.QueryString.GetValues("u");
         if (usernames == null) return new SerializedUserList();
@@ -35,7 +38,7 @@ public class UserEndpoints : EndpointGroup
             GameUser? user = database.GetUserByUsername(username);
             if (user == null) continue;
             
-            users.Add(GameUserResponse.FromOldWithExtraData(user, token.TokenGame, database, dataStore)!);
+            users.Add(GameUserResponse.FromOldWithExtraData(user, token.TokenGame, database, dataStore, dataContext)!);
         }
 
         return new SerializedUserList
@@ -48,10 +51,10 @@ public class UserEndpoints : EndpointGroup
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
     public SerializedFriendsList? GetFriends(RequestContext context, GameDatabaseContext database,
-        GameUser user, Token token, IDataStore dataStore)
+        GameUser user, Token token, IDataStore dataStore, DataContext dataContext)
     {
         List<GameUser> friends = database.GetUsersMutuals(user).ToList();
-        return new SerializedFriendsList(GameUserResponse.FromOldListWithExtraData(friends, token.TokenGame, database, dataStore).ToList());
+        return new SerializedFriendsList(GameUserResponse.FromOldListWithExtraData(friends, token.TokenGame, database, dataStore, dataContext).ToList());
     }
 
     [GameEndpoint("updateUser", HttpMethods.Post, ContentType.Xml)]

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -21,6 +21,7 @@ using Refresh.GameServer.Middlewares;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Storage;
 using Refresh.GameServer.Time;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels.Categories;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -129,16 +130,18 @@ public class RefreshGameServer : RefreshServer
         
         this.Server.AddService<RoleService>();
         this.Server.AddService<SmtpService>();
-
         this.Server.AddService<RequestStatisticTrackingService>();
-        
         this.Server.AddService<LevelListOverrideService>();
-        
         this.Server.AddService<CommandService>();
         
         #if DEBUG
         this.Server.AddService<DebugService>();
         #endif
+        
+        // !!! HEY! !!!
+        // This service depends on most services that come before it.
+        // This should always be added last.
+        this.Server.AddService<DataContextService>();
     }
 
     protected virtual void SetupWorkers()

--- a/Refresh.GameServer/Types/Activity/ActivityPage.cs
+++ b/Refresh.GameServer/Types/Activity/ActivityPage.cs
@@ -4,6 +4,7 @@ using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Activity.Groups;
 using Refresh.GameServer.Types.Activity.SerializedEvents;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Lists;
 using Refresh.GameServer.Types.UserData;
@@ -53,7 +54,8 @@ public class ActivityPage
         this.Scores = new List<GameSubmittedScore>();
     }
 
-    private void FillInInfo(GameDatabaseContext database, bool generateGroups, ActivityQueryParameters parameters)
+    private void FillInInfo(GameDatabaseContext database, bool generateGroups, ActivityQueryParameters parameters,
+        DataContext dataContext)
     {
         List<GameUser> users = this.Events
             .Select(e => e.User)
@@ -66,7 +68,7 @@ public class ActivityPage
 
         this.SerializedUsers = new SerializedUserList
         {
-            Users = GameUserResponse.FromOldList(users).ToList(),
+            Users = GameUserResponse.FromOldList(users, dataContext).ToList(),
         };
 
         this.Users = users;
@@ -79,7 +81,7 @@ public class ActivityPage
 
         this.SerializedLevels = new SerializedLevelList
         {
-            Items = GameLevelResponse.FromOldList(levels).ToList(),
+            Items = GameLevelResponse.FromOldList(levels, dataContext).ToList(),
         };
 
         this.Levels = levels;
@@ -105,11 +107,9 @@ public class ActivityPage
         } 
     }
 
-    public static ActivityPage GameLevelActivity(
-        GameDatabaseContext database,
+    public static ActivityPage GameLevelActivity(GameDatabaseContext database,
         GameLevel level,
-        ActivityQueryParameters parameters
-    )
+        ActivityQueryParameters parameters, DataContext dataContext)
     {
         DatabaseList<Event> events = database.GetRecentActivityForLevel(level, parameters);
 
@@ -118,19 +118,18 @@ public class ActivityPage
             Events = events.Items,
         };
         
-        page.FillInInfo(database, true, parameters);
+        page.FillInInfo(database, true, parameters, dataContext);
         
         page.Groups.Groups = page.Groups.Groups.SelectMany(group => group.Subgroups?.Items ?? []).ToList();
         
         return page;
     }
     
-    public static ActivityPage ApiLevelActivity(
-        GameDatabaseContext database,
+    public static ActivityPage ApiLevelActivity(GameDatabaseContext database,
         GameLevel level,
         ActivityQueryParameters parameters,
-        bool generateGroups = true
-    )
+        DataContext dataContext,
+        bool generateGroups = true)
     {
         DatabaseList<Event> events = database.GetRecentActivityForLevel(level, parameters);
 
@@ -139,16 +138,15 @@ public class ActivityPage
             Events = events.Items,
         };
         
-        page.FillInInfo(database, generateGroups, parameters);
+        page.FillInInfo(database, generateGroups, parameters, dataContext);
         
         return page;
     }
     
-    public static ActivityPage UserActivity(
-        GameDatabaseContext database,
+    public static ActivityPage UserActivity(GameDatabaseContext database,
         ActivityQueryParameters parameters,
-        bool generateGroups = true
-    )
+        DataContext dataContext,
+        bool generateGroups = true)
     {
         DatabaseList<Event> events = database.GetUserRecentActivity(parameters);
 
@@ -157,16 +155,15 @@ public class ActivityPage
             Events = events.Items,
         };
         
-        page.FillInInfo(database, generateGroups, parameters);
+        page.FillInInfo(database, generateGroups, parameters, dataContext);
         
         return page;
     }
     
-    public static ActivityPage GlobalActivity(
-        GameDatabaseContext database,
+    public static ActivityPage GlobalActivity(GameDatabaseContext database,
         ActivityQueryParameters parameters,
-        bool generateGroups = true
-    )
+        DataContext dataContext,
+        bool generateGroups = true)
     {
         DatabaseList<Event> events = database.GetGlobalRecentActivity(parameters);
 
@@ -175,7 +172,7 @@ public class ActivityPage
             Events = events.Items,
         };
         
-        page.FillInInfo(database, generateGroups, parameters);
+        page.FillInInfo(database, generateGroups, parameters, dataContext);
         
         return page;
     }

--- a/Refresh.GameServer/Types/Assets/GameAsset.Conversion.cs
+++ b/Refresh.GameServer/Types/Assets/GameAsset.Conversion.cs
@@ -5,6 +5,7 @@ using Refresh.GameServer.Database;
 using Refresh.GameServer.Importing;
 using Refresh.GameServer.Importing.Mip;
 using Refresh.GameServer.Resources;
+using Refresh.GameServer.Types.Data;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
@@ -162,17 +163,17 @@ public partial class GameAsset
     /// <param name="database">The database</param>
     /// <param name="dataStore">The data store</param>
     /// <returns>The new hash of the converted asset, or null if no conversion has taken place</returns>
-    public string? GetAsIcon(TokenGame game, GameDatabaseContext database, IDataStore dataStore)
+    public string? GetAsIcon(TokenGame game, DataContext dataContext)
     {
         return this.GetAsGeneric(
             game,
-            database,
-            dataStore,
+            dataContext.Database,
+            dataContext.DataStore,
             this.CropToIcon,
             () => this.AsMainlineIconHash,
-            hash => database.SetMainlineIconHash(this, hash),
+            hash => dataContext.Database.SetMainlineIconHash(this, hash),
             () => this.AsMipIconHash,
-            hash => database.SetMipIconHash(this, hash)
+            hash => dataContext.Database.SetMipIconHash(this, hash)
         );
     }
     

--- a/Refresh.GameServer/Types/Assets/GameAsset.Conversion.cs
+++ b/Refresh.GameServer/Types/Assets/GameAsset.Conversion.cs
@@ -142,15 +142,15 @@ public partial class GameAsset
     /// <param name="database">The database</param>
     /// <param name="dataStore">The data store</param>
     /// <returns>The new hash of the converted asset, or null if no conversion has taken place</returns>
-    public string? GetAsPhoto(TokenGame game, GameDatabaseContext database, IDataStore dataStore)
+    public string? GetAsPhoto(TokenGame game, DataContext dataContext)
     {
         return this.GetAsGeneric(
             game,
-            database,
-            dataStore,
+            dataContext.Database,
+            dataContext.DataStore,
             _ => null,
             () => this.AsMainlinePhotoHash,
-            hash => database.SetMainlinePhotoHash(this, hash),
+            hash => dataContext.Database.SetMainlinePhotoHash(this, hash),
             () => throw new NotSupportedException(),
             _ => throw new NotSupportedException()
         );

--- a/Refresh.GameServer/Types/Data/DataContext.cs
+++ b/Refresh.GameServer/Types/Data/DataContext.cs
@@ -1,0 +1,12 @@
+using Bunkum.Core.Storage;
+using NotEnoughLogs;
+using Refresh.GameServer.Database;
+
+namespace Refresh.GameServer.Types.Data;
+
+public class DataContext
+{
+    public required GameDatabaseContext Database;
+    public required Logger Logger;
+    public required IDataStore DataStore;
+}

--- a/Refresh.GameServer/Types/Data/DataContext.cs
+++ b/Refresh.GameServer/Types/Data/DataContext.cs
@@ -1,6 +1,9 @@
 using Bunkum.Core.Storage;
 using NotEnoughLogs;
+using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Data;
 
@@ -9,4 +12,10 @@ public class DataContext
     public required GameDatabaseContext Database;
     public required Logger Logger;
     public required IDataStore DataStore;
+    public required MatchService Match;
+    
+    public required Token? Token;
+    public GameUser? User => this.Token?.User;
+    public TokenGame? Game => this.Token?.TokenGame;
+    public TokenPlatform? Platform => this.Token?.TokenPlatform;
 }

--- a/Refresh.GameServer/Types/Data/DataContext.cs
+++ b/Refresh.GameServer/Types/Data/DataContext.cs
@@ -16,6 +16,6 @@ public class DataContext
     
     public required Token? Token;
     public GameUser? User => this.Token?.User;
-    public TokenGame? Game => this.Token?.TokenGame;
-    public TokenPlatform? Platform => this.Token?.TokenPlatform;
+    public TokenGame Game => this.Token?.TokenGame ?? TokenGame.Website;
+    public TokenPlatform Platform => this.Token?.TokenPlatform ?? TokenPlatform.Website;
 }

--- a/Refresh.GameServer/Types/Data/DataContextService.cs
+++ b/Refresh.GameServer/Types/Data/DataContextService.cs
@@ -4,22 +4,28 @@ using Bunkum.Core.Services;
 using Bunkum.Core.Storage;
 using Bunkum.Listener.Request;
 using NotEnoughLogs;
+using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Services;
 
 namespace Refresh.GameServer.Types.Data;
 
 public class DataContextService : Service
 {
     private readonly StorageService _storageService;
+    private readonly MatchService _matchService;
+    private readonly AuthenticationService _authService;
     
-    internal DataContextService(StorageService storage, Logger logger) : base(logger)
+    internal DataContextService(StorageService storage, MatchService match, AuthenticationService auth, Logger logger) : base(logger)
     {
         this._storageService = storage;
+        this._matchService = match;
+        this._authService = auth;
     }
     
-    private static T StealInjection<T>(Service service, string name = "")
+    private static T StealInjection<T>(Service service, ListenerContext? context = null, Lazy<IDatabaseContext>? database = null, string name = "")
     {
-        return (T)service.AddParameterToEndpoint(null!, new BunkumParameterInfo(typeof(T), name), null!)!;
+        return (T)service.AddParameterToEndpoint(context!, new BunkumParameterInfo(typeof(T), name), database!)!;
     }
     
     public override object? AddParameterToEndpoint(ListenerContext context, BunkumParameterInfo parameter, Lazy<IDatabaseContext> database)
@@ -31,6 +37,8 @@ public class DataContextService : Service
                 Database = (GameDatabaseContext)database.Value,
                 Logger = this.Logger,
                 DataStore = StealInjection<IDataStore>(this._storageService),
+                Match = this._matchService,
+                Token = StealInjection<Token>(this._authService, context, database),
             };
         }
         

--- a/Refresh.GameServer/Types/Data/DataContextService.cs
+++ b/Refresh.GameServer/Types/Data/DataContextService.cs
@@ -1,0 +1,39 @@
+using Bunkum.Core;
+using Bunkum.Core.Database;
+using Bunkum.Core.Services;
+using Bunkum.Core.Storage;
+using Bunkum.Listener.Request;
+using NotEnoughLogs;
+using Refresh.GameServer.Database;
+
+namespace Refresh.GameServer.Types.Data;
+
+public class DataContextService : Service
+{
+    private readonly StorageService _storageService;
+    
+    internal DataContextService(StorageService storage, Logger logger) : base(logger)
+    {
+        this._storageService = storage;
+    }
+    
+    private static T StealInjection<T>(Service service, string name = "")
+    {
+        return (T)service.AddParameterToEndpoint(null!, new BunkumParameterInfo(typeof(T), name), null!)!;
+    }
+    
+    public override object? AddParameterToEndpoint(ListenerContext context, BunkumParameterInfo parameter, Lazy<IDatabaseContext> database)
+    {
+        if (ParameterEqualTo<DataContext>(parameter))
+        {
+            return new DataContext
+            {
+                Database = (GameDatabaseContext)database.Value,
+                Logger = this.Logger,
+                DataStore = StealInjection<IDataStore>(this._storageService),
+            };
+        }
+        
+        return null;
+    }
+}

--- a/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
@@ -5,6 +5,7 @@ using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Lists;
 using Refresh.GameServer.Types.UserData;
 
@@ -50,6 +51,7 @@ public class SerializedCategory
         GameUser user,
         Token token,
         MatchService matchService,
+        DataContext dataContext,
         int skip = 0,
         int count = 20)
     {
@@ -58,7 +60,7 @@ public class SerializedCategory
         DatabaseList<GameLevel> categoryLevels = levelCategory.Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame), user);
         
         IEnumerable<GameMinimalLevelResponse> levels = categoryLevels?.Items
-            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame)) ?? Array.Empty<GameMinimalLevelResponse>();
+            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame, dataContext)) ?? Array.Empty<GameMinimalLevelResponse>();
 
         category.Levels = new SerializedMinimalLevelList(levels, categoryLevels?.TotalItems ?? 0, skip + count);
 

--- a/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
@@ -60,7 +60,7 @@ public class SerializedCategory
         DatabaseList<GameLevel> categoryLevels = levelCategory.Fetch(context, skip, count, matchService, database, user, new LevelFilterSettings(context, token.TokenGame), user);
         
         IEnumerable<GameMinimalLevelResponse> levels = categoryLevels?.Items
-            .Select(l => GameMinimalLevelResponse.FromOldWithExtraData(l, matchService, database, dataStore, token.TokenGame, dataContext)) ?? Array.Empty<GameMinimalLevelResponse>();
+            .Select(l => GameMinimalLevelResponse.FromOld(l, dataContext)) ?? Array.Empty<GameMinimalLevelResponse>();
 
         category.Levels = new SerializedMinimalLevelList(levels, categoryLevels?.TotalItems ?? 0, skip + count);
 

--- a/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
@@ -5,6 +5,7 @@ using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 using Refresh.GameServer.Types.UserData;
 
@@ -52,40 +53,43 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     /// Constructs a placeholder level response from a root level hash
     /// </summary>
     /// <param name="hash"></param>
+    /// <param name="dataContext"></param>
     /// <returns></returns>
-    public static GameMinimalLevelResponse FromHash(string hash)
+    public static GameMinimalLevelResponse FromHash(string hash, DataContext dataContext)
     {
-        return FromOld(GameLevelResponse.FromHash(hash))!;
+        return FromOld(GameLevelResponse.FromHash(hash), dataContext)!;
     }
     
-    public static GameMinimalLevelResponse? FromOldWithExtraData(GameLevelResponse? old, MatchService matchService, GameDatabaseContext database, IDataStore dataStore, TokenGame game)
+    public static GameMinimalLevelResponse? FromOldWithExtraData(GameLevelResponse? old, MatchService matchService,
+        GameDatabaseContext database, IDataStore dataStore, TokenGame game, DataContext dataContext)
     {
         if (old == null) return null;
 
-        GameMinimalLevelResponse response = FromOld(old)!;
+        GameMinimalLevelResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(matchService, database, dataStore, game);
 
         return response;
     }
     
-    public static GameMinimalLevelResponse? FromOldWithExtraData(GameLevel? old, MatchService matchService, GameDatabaseContext database, IDataStore dataStore, TokenGame game)
+    public static GameMinimalLevelResponse? FromOldWithExtraData(GameLevel? old, MatchService matchService,
+        GameDatabaseContext database, IDataStore dataStore, TokenGame game, DataContext dataContext)
     {
         if (old == null) return null;
 
-        GameMinimalLevelResponse response = FromOld(old)!;
+        GameMinimalLevelResponse response = FromOld(old, dataContext)!;
         response.FillInExtraData(matchService, database, dataStore, game);
 
         return response;
     }
 
-    public static GameMinimalLevelResponse? FromOld(GameLevel? level)
+    public static GameMinimalLevelResponse? FromOld(GameLevel? level, DataContext dataContext)
     {
         if(level == null) return null;
-        return FromOld(GameLevelResponse.FromOld(level));
+        return FromOld(GameLevelResponse.FromOld(level, dataContext), dataContext);
     }
 
 
-    public static GameMinimalLevelResponse? FromOld(GameLevelResponse? level)
+    public static GameMinimalLevelResponse? FromOld(GameLevelResponse? level, DataContext dataContext)
     {
         if(level == null) return null;
 
@@ -124,6 +128,8 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
         this.IconHash = database.GetAssetFromHash(this.IconHash)?.GetAsIcon(game, database, dataStore) ?? this.IconHash;
     }
 
-    public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GameLevel> oldList) => oldList.Select(FromOld).ToList()!;
-    public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GameLevelResponse> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GameLevel> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
+    public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GameLevelResponse> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
@@ -71,13 +71,11 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     public static GameMinimalLevelResponse? FromOld(GameLevelResponse? level, DataContext dataContext)
     {
         if(level == null) return null;
-        
-        Debug.Assert(dataContext.Game != null);
 
         return new GameMinimalLevelResponse
         {
             Title = level.Title,
-            IconHash = dataContext.Database.GetAssetFromHash(level.IconHash)?.GetAsIcon(dataContext.Game.Value, dataContext) ?? level.IconHash,
+            IconHash = dataContext.Database.GetAssetFromHash(level.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? level.IconHash,
             GameVersion = level.GameVersion,
             RootResource = level.RootResource,
             Description = level.Description,

--- a/Refresh.GameServer/Types/Reviews/SerializedGameReview.cs
+++ b/Refresh.GameServer/Types/Reviews/SerializedGameReview.cs
@@ -55,6 +55,7 @@ public class SerializedGameReview : IDataConvertableFrom<SerializedGameReview, G
         if (review == null) 
             return null;
         
+        // TODO: fill in review.YourThumb
         return new SerializedGameReview
         {
             Id = review.ReviewId,
@@ -74,11 +75,6 @@ public class SerializedGameReview : IDataConvertableFrom<SerializedGameReview, G
             ThumbsDown = 0,
             YourThumb = 0,
         };
-    }
-
-    public void FillInExtraData(GameDatabaseContext database, GameUser user)
-    {
-        //TODO: fill in this.YourThumb
     }
     
     public static IEnumerable<SerializedGameReview> FromOldList(IEnumerable<GameReview> oldList,

--- a/Refresh.GameServer/Types/Reviews/SerializedGameReview.cs
+++ b/Refresh.GameServer/Types/Reviews/SerializedGameReview.cs
@@ -1,6 +1,7 @@
 using System.Xml.Serialization;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.UserData;
 
@@ -49,7 +50,7 @@ public class SerializedGameReview : IDataConvertableFrom<SerializedGameReview, G
     [XmlElement("yourthumb")]
     public RatingType YourThumb { get; set; }
 
-    public static SerializedGameReview? FromOld(GameReview? review)
+    public static SerializedGameReview? FromOld(GameReview? review, DataContext dataContext)
     {
         if (review == null) 
             return null;
@@ -80,5 +81,6 @@ public class SerializedGameReview : IDataConvertableFrom<SerializedGameReview, G
         //TODO: fill in this.YourThumb
     }
     
-    public static IEnumerable<SerializedGameReview> FromOldList(IEnumerable<GameReview> oldList) => oldList.Select(FromOld).ToList()!;
+    public static IEnumerable<SerializedGameReview> FromOldList(IEnumerable<GameReview> oldList,
+        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.GameServer/Types/UserData/SerializedUserHandle.cs
+++ b/Refresh.GameServer/Types/UserData/SerializedUserHandle.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics;
 using System.Xml.Serialization;
 using Bunkum.Core.Storage;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Types.UserData;
 
@@ -13,18 +15,14 @@ public class SerializedUserHandle
 
     [XmlAttribute("icon")] public string IconHash { get; set; } = "0";
 
-    public static SerializedUserHandle FromUser(GameUser user) =>
-        new()
+    public static SerializedUserHandle FromUser(GameUser user, DataContext dataContext)
+    {
+        TokenGame game = dataContext.Game ?? TokenGame.Website;
+        
+        return new SerializedUserHandle
         {
             Username = user.Username,
-            IconHash = user.IconHash,
+            IconHash = dataContext.Database.GetAssetFromHash(user.IconHash)?.GetAsIcon(game, dataContext) ?? user.IconHash,
         };
-
-    public void FillInExtraData(GameDatabaseContext database, IDataStore dataStore, TokenGame game)
-    {
-        //If the icon is a remote asset
-        if(!this.IconHash.StartsWith('g'))
-            //Get the icon form of that remote asset
-            this.IconHash = database.GetAssetFromHash(this.IconHash)?.GetAsIcon(game, database, dataStore) ?? this.IconHash;
     }
 }

--- a/Refresh.GameServer/Types/UserData/SerializedUserHandle.cs
+++ b/Refresh.GameServer/Types/UserData/SerializedUserHandle.cs
@@ -17,12 +17,10 @@ public class SerializedUserHandle
 
     public static SerializedUserHandle FromUser(GameUser user, DataContext dataContext)
     {
-        TokenGame game = dataContext.Game ?? TokenGame.Website;
-        
         return new SerializedUserHandle
         {
             Username = user.Username,
-            IconHash = dataContext.Database.GetAssetFromHash(user.IconHash)?.GetAsIcon(game, dataContext) ?? user.IconHash,
+            IconHash = dataContext.Database.GetAssetFromHash(user.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? user.IconHash,
         };
     }
 }

--- a/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
+++ b/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
@@ -12,6 +12,7 @@ using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Time;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels.Categories;
 using RefreshTests.GameServer.Logging;
 using RefreshTests.GameServer.Time;
@@ -73,6 +74,9 @@ public class TestRefreshGameServer : RefreshGameServer
         this.Server.AddService<LevelListOverrideService>();
         this.Server.AddService<CommandService>();
         this.Server.AddService<GuidCheckerService>();
+        
+        // Must always be last, see comment in RefreshGameServer
+        this.Server.AddService<DataContextService>();
     }
     
     [Pure]


### PR DESCRIPTION
This PR modifies a significant chunk of the codebase for endpoints, so for an easier review I recommend just looking at only the files regarding the `DataContext` itself and the service for it.

Key things to consider:
- A change to `GameDatabaseContext.GetAssetFromHash` to return null for assets that will never be stored in the database. Simplifies some code and makes it faster.
- Since the `DataContext` service depends on most services, it must be added as the last service, always.
- `DataContext.Game` and `DataContext.Platform` both assume `Website` if a token is not present. This shouldn't ever be hit in Game API code but it's something to be aware of.
- To simplify code when making a new `DataContext`, `DataContextService.StealInjection` does some illegal things by passing `null` for some parameters. This should be okay for the services that are already there, but I recommend looking at the services `AddParameterToEndpoint` function when doing this just to make sure.
- Most of this refactor was done automatically with Rider's refactoring tools. Unused parameters in endpoints are not considered, and ordering of parameters in endpoints are also not considered. I'm not willing to manually give each little endpoint a correction of this, because it doesn't matter in the long run.