### PR TITLE
Up rate limit for registrations

### DIFF
--- a/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
@@ -223,7 +223,7 @@ public class AuthenticationApiEndpoints : EndpointGroup
     [DocSummary("Registers a new user.")]
     [DocRequestBody(typeof(ApiRegisterRequest))]
     #if !DEBUG
-    [RateLimitSettings(86400, 1, 86400 / 2, "register")]
+    [RateLimitSettings(3600, 5, 3600 / 2, "register")]
     #endif
     public ApiResponse<IApiAuthenticationResponse> Register(RequestContext context,
         GameDatabaseContext database,


### PR DESCRIPTION
1 per day is *way* too strict, we need at least 2, so people actually hit the "account already registered" flag

So i thought 5 per hour is a reasonable count