### PR TITLE
Remove backlinks from GameUser and GameComment

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Activity.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Activity.cs
@@ -17,7 +17,7 @@ public partial class GameDatabaseContext // Activity
 
         if (parameters.User != null)
         {
-            List<ObjectId?> favouriteUsers = parameters.User.UsersFavourited.AsEnumerable().Select(f => (ObjectId?)f.UserToFavourite.UserId).ToList();
+            List<ObjectId?> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User, 1000, 0).Select(f => (ObjectId?)f.UserId).ToList();
             List<ObjectId?> userFriends = this.GetUsersMutuals(parameters.User).Select(u => (ObjectId?)u.UserId).ToList();
 
             query = query.Where(e =>
@@ -61,9 +61,9 @@ public partial class GameDatabaseContext // Activity
 
         if (parameters is { ExcludeFavouriteUsers: true, User: not null })
         {
-            List<FavouriteUserRelation> favouriteUsers = parameters.User.UsersFavourited.ToList();
+            List<GameUser> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User, 1000, 0).ToList();
             
-            query = query.Where(e => favouriteUsers.All(r => r.UserToFavourite.UserId != e.User.UserId && r.UserToFavourite.UserId != e.StoredObjectId)); 
+            query = query.Where(e => favouriteUsers.All(r => r.UserId != e.User.UserId && r.UserId != e.StoredObjectId)); 
         }
 
         if (parameters is { ExcludeMyself: true, User: not null })

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -363,6 +363,14 @@ public partial class GameDatabaseContext // Levels
     [Pure]
     public int GetTotalLevelCount() => this._realm.All<GameLevel>().Count(l => l._Source == (int)GameLevelSource.User);
     
+    public int GetTotalLevelsPublishedByUser(GameUser user)
+        => this._realm.All<GameLevel>()
+            .Count(r => r.Publisher == user);
+    
+    public int GetTotalLevelsPublishedByUser(GameUser user, TokenGame game)
+        => this._realm.All<GameLevel>()
+            .Count(r => r._GameVersion == (int)game);
+    
     [Pure]
     public int GetTotalTeamPickCount(TokenGame game) => this._realm.All<GameLevel>().FilterByGameVersion(game).Count(l => l.TeamPicked);
 

--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -75,16 +75,28 @@ public partial class GameDatabaseContext // Photos
     public DatabaseList<GamePhoto> GetPhotosByUser(GameUser user, int count, int skip) =>
         new(this._realm.All<GamePhoto>().Where(p => p.Publisher == user)
             .OrderByDescending(p => p.TakenAt), skip, count);
+    
+    [Pure]
+    public int GetTotalPhotosByUser(GameUser user)
+        => this._realm.All<GamePhoto>()
+            .Count(p => p.Publisher == user);
 
     [Pure]
     public DatabaseList<GamePhoto> GetPhotosWithUser(GameUser user, int count, int skip) =>
         new(this._realm.All<GamePhoto>()
-            .AsEnumerable()
             // FIXME: client-side enumeration
+            .AsEnumerable()
             .Where(p => p.Subjects.FirstOrDefault(s => Equals(s.User, user)) != null)
             .OrderByDescending(p => p.TakenAt)
             .Skip(skip)
             .Take(count));
+    
+    [Pure]
+    public int GetTotalPhotosWithUser(GameUser user)
+        => this._realm.All<GamePhoto>()
+            // FIXME: client-side enumeration
+            .AsEnumerable()
+            .Count(p => p.Subjects.FirstOrDefault(s => Equals(s.User, user)) != null);
 
     [Pure]
     public DatabaseList<GamePhoto> GetPhotosInLevel(GameLevel level, int count, int skip) =>

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -26,6 +26,10 @@ public partial class GameDatabaseContext // Relations
         .FilterByLevelFilterSettings(accessor, levelFilterSettings)
         .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     
+    public int GetTotalLevelsFavouritedByUser(GameUser user) 
+        => this._realm.All<FavouriteLevelRelation>()
+            .Count(r => r.User == user);
+    
     public bool FavouriteLevel(GameLevel level, GameUser user)
     {
         if (this.IsLevelFavouritedByUser(level, user)) return false;
@@ -84,6 +88,10 @@ public partial class GameDatabaseContext // Relations
         .Select(r => r.UserToFavourite)
         .Skip(skip)
         .Take(count);
+    
+    public int GetTotalUsersFavouritedByUser(GameUser user)
+        => this._realm.All<FavouriteLevelRelation>()
+            .Count(r => r.User == user);
 
     public bool FavouriteUser(GameUser userToFavourite, GameUser userFavouriting)
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -336,6 +336,9 @@ public partial class GameDatabaseContext // Relations
     public RatingType? GetRatingByUser(GameComment comment, GameUser user) 
         => this.GetCommentRelationByUser(comment, user)?.RatingType;
     
+    public int GetTotalRatingsForComment(GameComment comment, RatingType type) =>
+        this._realm.All<CommentRelation>().Count(r => r.Comment == comment && r._RatingType == (int)type);
+    
     public bool RateComment(GameUser user, GameComment comment, RatingType ratingType)
     {
         if (ratingType == RatingType.Neutral)

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -73,12 +73,8 @@ public partial class GameDatabaseContext // Relations
     [Pure]
     public IEnumerable<GameUser> GetUsersMutuals(GameUser user)
     {
-        // this might be the shittiest query i've ever written.
-        return user.UsersFavourited.AsEnumerable()
-            .Select(relation => relation.UserToFavourite)
-            .Where(f => f.UsersFavourited.AsEnumerable()
-                .Select(otherUserRelation => otherUserRelation.UserToFavourite).AsEnumerable()
-                .Contains(user));
+        return this.GetUsersFavouritedByUser(user, 1000, 0).AsEnumerable()
+            .Where(u => this.IsUserFavouritedByUser(user, u));
     }
     
     [Pure]
@@ -90,8 +86,12 @@ public partial class GameDatabaseContext // Relations
         .Take(count);
     
     public int GetTotalUsersFavouritedByUser(GameUser user)
-        => this._realm.All<FavouriteLevelRelation>()
-            .Count(r => r.User == user);
+        => this._realm.All<FavouriteUserRelation>()
+            .Count(r => r.UserFavouriting == user);
+    
+    public int GetTotalUsersFavouritingUser(GameUser user)
+        => this._realm.All<FavouriteUserRelation>()
+            .Count(r => r.UserToFavourite == user);
 
     public bool FavouriteUser(GameUser userToFavourite, GameUser userFavouriting)
     {
@@ -148,6 +148,11 @@ public partial class GameDatabaseContext // Relations
         .FilterByLevelFilterSettings(accessor, levelFilterSettings)
         .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     
+    [Pure]
+    public int GetTotalLevelsQueuedByUser(GameUser user) 
+        => this._realm.All<QueueLevelRelation>()
+            .Count(r => r.User == user);
+    
     public bool QueueLevel(GameLevel level, GameUser user)
     {
         if (this.IsLevelQueuedByUser(level, user)) return false;
@@ -176,7 +181,7 @@ public partial class GameDatabaseContext // Relations
 
     public void ClearQueue(GameUser user)
     {
-        this._realm.Write(() => this._realm.RemoveRange(user.QueueLevelRelations));
+        this._realm.Write(() => this._realm.RemoveRange(this._realm.All<QueueLevelRelation>().Where(r => r.User == user)));
     }
 
     #endregion

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -298,8 +298,10 @@ public partial class GameDatabaseContext // Users
             user.PsnAuthenticationAllowed = false;
             user.RpcnAuthenticationAllowed = false;
 
-            foreach (GamePhotoSubject subject in user.PhotosWithMe)
-                subject.User = null;
+            // TODO: unit tests for this
+            foreach (GamePhoto photo in this.GetPhotosWithUser(user, int.MaxValue, 0).Items)
+                foreach (GamePhotoSubject subject in photo.Subjects.Where(s => s.User?.UserId == user.UserId))
+                    subject.User = null;
             
             this._realm.RemoveRange(this._realm.All<FavouriteLevelRelation>().Where(r => r.User == user));
             this._realm.RemoveRange(this._realm.All<FavouriteUserRelation>().Where(r => r.UserToFavourite == user));

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -297,8 +297,7 @@ public partial class GameDatabaseContext // Users
             user.CurrentVerifiedIp = null;
             user.PsnAuthenticationAllowed = false;
             user.RpcnAuthenticationAllowed = false;
-
-            // TODO: unit tests for this
+            
             foreach (GamePhoto photo in this.GetPhotosWithUser(user, int.MaxValue, 0).Items)
                 foreach (GamePhotoSubject subject in photo.Subjects.Where(s => s.User?.UserId == user.UserId))
                     subject.User = null;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Types;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Photos;
+using Refresh.GameServer.Types.Relations;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
@@ -300,11 +301,11 @@ public partial class GameDatabaseContext // Users
             foreach (GamePhotoSubject subject in user.PhotosWithMe)
                 subject.User = null;
             
-            this._realm.RemoveRange(user.FavouriteLevelRelations);
-            this._realm.RemoveRange(user.UsersFavourited);
-            this._realm.RemoveRange(user.UsersFavouritingMe);
-            this._realm.RemoveRange(user.QueueLevelRelations);
-            this._realm.RemoveRange(user.PhotosByMe);
+            this._realm.RemoveRange(this._realm.All<FavouriteLevelRelation>().Where(r => r.User == user));
+            this._realm.RemoveRange(this._realm.All<FavouriteUserRelation>().Where(r => r.UserToFavourite == user));
+            this._realm.RemoveRange(this._realm.All<FavouriteUserRelation>().Where(r => r.UserFavouriting == user));
+            this._realm.RemoveRange(this._realm.All<QueueLevelRelation>().Where(r => r.User == user));
+            this._realm.RemoveRange(this._realm.All<GamePhoto>().Where(p => p.Publisher == user));
 
             foreach (GameLevel level in this._realm.All<GameLevel>().Where(l => l.Publisher == user))
             {

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -173,8 +173,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
             if (oldVersion < 100) newUser.EmailAddress = oldUser.EmailAddress?.ToLowerInvariant();
 
             // Version was bumped here to delete invalid favourite level relations
-            // TODO: fix this migration
-            // if (oldVersion < 101) migration.NewRealm.RemoveRange(newUser.FavouriteLevelRelations.Where(r => r.Level == null));
+            if (oldVersion < 101) migration.NewRealm.RemoveRange(migration.OldRealm.All<FavouriteLevelRelation>().Where(r => r.User.UserId == newUser.UserId && r.Level == null));
 
             // In version 102 we split the Vita icon hash from the PS3 icon hash
             if (oldVersion < 102) newUser.VitaIconHash = "0";

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -173,7 +173,8 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
             if (oldVersion < 100) newUser.EmailAddress = oldUser.EmailAddress?.ToLowerInvariant();
 
             // Version was bumped here to delete invalid favourite level relations
-            if (oldVersion < 101) migration.NewRealm.RemoveRange(newUser.FavouriteLevelRelations.Where(r => r.Level == null));
+            // TODO: fix this migration
+            // if (oldVersion < 101) migration.NewRealm.RemoveRange(newUser.FavouriteLevelRelations.Where(r => r.Level == null));
 
             // In version 102 we split the Vita icon hash from the PS3 icon hash
             if (oldVersion < 102) newUser.VitaIconHash = "0";

--- a/Refresh.GameServer/Endpoints/Game/CommentEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/CommentEndpoints.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Database;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Time;
 using Refresh.GameServer.Types.Comments;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Lists;
 using Refresh.GameServer.Types.Reviews;
@@ -35,7 +36,7 @@ public class CommentEndpoints : EndpointGroup
     [GameEndpoint("userComments/{username}", ContentType.Xml)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedCommentList? GetProfileComments(RequestContext context, GameDatabaseContext database, GameUser user, string username)
+    public SerializedCommentList? GetProfileComments(RequestContext context, GameDatabaseContext database, GameUser user, DataContext dataContext, string username)
     {
         GameUser? profile = database.GetUserByUsername(username);
         if (profile == null) return null;
@@ -43,7 +44,7 @@ public class CommentEndpoints : EndpointGroup
         (int skip, int count) = context.GetPageData();
 
         List<GameComment> comments = database.GetProfileComments(profile, count, skip).ToList();
-        foreach (GameComment comment in comments) comment.PrepareForSerialization(user);
+        foreach (GameComment comment in comments) comment.PrepareForSerialization(user, dataContext);
 
         return new SerializedCommentList(comments);
     }
@@ -89,7 +90,8 @@ public class CommentEndpoints : EndpointGroup
     [GameEndpoint("comments/{slotType}/{id}", ContentType.Xml)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedCommentList? GetLevelComments(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id)
+    public SerializedCommentList? GetLevelComments(RequestContext context, GameDatabaseContext database, GameUser user, DataContext dataContext,
+        string slotType, int id)
     {
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return null;
@@ -97,7 +99,7 @@ public class CommentEndpoints : EndpointGroup
         (int skip, int count) = context.GetPageData();
 
         List<GameComment> comments = database.GetLevelComments(level, count, skip).ToList();
-        foreach(GameComment comment in comments) comment.PrepareForSerialization(user);
+        foreach(GameComment comment in comments) comment.PrepareForSerialization(user, dataContext);
 
         return new SerializedCommentList(comments);
     }

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -109,21 +109,21 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
         {
             case TokenGame.LittleBigPlanet3: {
                 //Match all LBP3 levels
-                response.UsedSlotsLBP3 = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.LittleBigPlanet3);
+                response.UsedSlotsLBP3 = dataContext.Database.GetTotalLevelsPublishedByUser(old, TokenGame.LittleBigPlanet3);
                 response.FreeSlotsLBP3 = MaximumLevels - response.UsedSlotsLBP3;
                 //Fill out LBP2/LBP1 levels
                 goto case TokenGame.LittleBigPlanet2;
             }
             case TokenGame.LittleBigPlanet2: {
                 //Match all LBP2 levels
-                response.UsedSlotsLBP2 = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.LittleBigPlanet2);
+                response.UsedSlotsLBP2 = dataContext.Database.GetTotalLevelsPublishedByUser(old, TokenGame.LittleBigPlanet2);
                 response.FreeSlotsLBP2 = MaximumLevels - response.UsedSlotsLBP2;
                 //Fill out LBP1 levels
                 goto case TokenGame.LittleBigPlanet1;
             }
             case TokenGame.LittleBigPlanetVita: { 
                 //Match all LBP Vita levels
-                response.UsedSlotsLBP2 = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.LittleBigPlanetVita);
+                response.UsedSlotsLBP2 = dataContext.Database.GetTotalLevelsPublishedByUser(old, TokenGame.LittleBigPlanetVita);
                 response.FreeSlotsLBP2 = MaximumLevels - response.UsedSlotsLBP2;
 
                 //Apply Vita-specific icon hash
@@ -132,13 +132,13 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             }
             case TokenGame.LittleBigPlanet1: {
                 //Match all LBP1 levels
-                response.UsedSlots = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.LittleBigPlanet1);
+                response.UsedSlots = dataContext.Database.GetTotalLevelsPublishedByUser(old, TokenGame.LittleBigPlanet1);
                 response.FreeSlots = MaximumLevels - response.UsedSlots;
                 break;
             }
             case TokenGame.LittleBigPlanetPSP: {
                 //Match all LBP PSP levels
-                response.UsedSlots = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.LittleBigPlanetPSP);
+                response.UsedSlots = dataContext.Database.GetTotalLevelsPublishedByUser(old, TokenGame.LittleBigPlanetPSP);
                 response.FreeSlots = MaximumLevels - response.UsedSlots;
                 
                 // Apply PSP-specific icon hash
@@ -160,7 +160,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             case TokenGame.BetaBuild:
             {
                 // only beta levels
-                response.UsedSlots = old.PublishedLevels.Count(x => x._GameVersion == (int)TokenGame.BetaBuild);
+                response.UsedSlots = dataContext.Database.GetTotalLevelsPublishedByUser(old, TokenGame.BetaBuild);
                 response.FreeSlots = MaximumLevels - response.UsedSlotsLBP2;
                 
                 // use the same values for LBP3 and LBP2 since they're all shared under one count

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -69,8 +69,8 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             FavouriteUserCount = old.IsManaged ? dataContext.Database.GetTotalUsersFavouritedByUser(old) : 0,
             QueuedLevelCount = old.IsManaged ? dataContext.Database.GetTotalLevelsQueuedByUser(old) : 0,
             HeartCount = old.IsManaged ? dataContext.Database.GetTotalUsersFavouritingUser(old) : 0,
-            PhotosByMeCount = old.IsManaged ? old.PhotosByMe.Count() : 0,
-            PhotosWithMeCount = old.IsManaged ? old.PhotosWithMe.Count() : 0,
+            PhotosByMeCount = old.IsManaged ? dataContext.Database.GetTotalPhotosByUser(old) : 0,
+            PhotosWithMeCount = old.IsManaged ? dataContext.Database.GetTotalPhotosWithUser(old) : 0,
             
             EntitledSlots = MaximumLevels,
             EntitledSlotsLBP2 = MaximumLevels,

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -1,7 +1,5 @@
 using System.Xml.Serialization;
-using Bunkum.Core.Storage;
 using Refresh.GameServer.Authentication;
-using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Types;
@@ -68,9 +66,9 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             CommentCount = old.ProfileComments.Count,
             CommentsEnabled = true,
             FavouriteLevelCount = old.IsManaged ? dataContext.Database.GetTotalLevelsFavouritedByUser(old) : 0,
-            FavouriteUserCount = old.IsManaged ? old.UsersFavourited.Count() : 0,
-            QueuedLevelCount = old.IsManaged ? old.QueueLevelRelations.Count() : 0,
-            HeartCount = old.IsManaged ? old.UsersFavouritingMe.Count() : 0,
+            FavouriteUserCount = old.IsManaged ? dataContext.Database.GetTotalUsersFavouritedByUser(old) : 0,
+            QueuedLevelCount = old.IsManaged ? dataContext.Database.GetTotalLevelsQueuedByUser(old) : 0,
+            HeartCount = old.IsManaged ? dataContext.Database.GetTotalUsersFavouritingUser(old) : 0,
             PhotosByMeCount = old.IsManaged ? old.PhotosByMe.Count() : 0,
             PhotosWithMeCount = old.IsManaged ? old.PhotosWithMe.Count() : 0,
             

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -62,15 +62,6 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     
     #nullable disable
     public IList<GameComment> ProfileComments { get; }
-    
-    [Backlink(nameof(QueueLevelRelation.User))]
-    public IQueryable<QueueLevelRelation> QueueLevelRelations { get; }
-    
-    [Backlink(nameof(FavouriteUserRelation.UserToFavourite))]
-    public IQueryable<FavouriteUserRelation> UsersFavouritingMe { get; }
-    
-    [Backlink(nameof(FavouriteUserRelation.UserFavouriting))]
-    public IQueryable<FavouriteUserRelation> UsersFavourited { get; }
 
     [Backlink(nameof(GameLevel.Publisher))]
     public IQueryable<GameLevel> PublishedLevels { get; }
@@ -80,8 +71,8 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     
     [Backlink(nameof(GamePhotoSubject.User))]
     public IQueryable<GamePhotoSubject> PhotosWithMe { get; }
-    [Backlink(nameof(GameNotification.User))]
     
+    [Backlink(nameof(GameNotification.User))]
     public IQueryable<GameNotification> Notifications { get; }
     
     public IList<GameIpVerificationRequest> IpVerificationRequests { get; }

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -63,9 +63,6 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     #nullable disable
     public IList<GameComment> ProfileComments { get; }
     
-    [Backlink(nameof(FavouriteLevelRelation.User))]
-    public IQueryable<FavouriteLevelRelation> FavouriteLevelRelations { get; }
-    
     [Backlink(nameof(QueueLevelRelation.User))]
     public IQueryable<QueueLevelRelation> QueueLevelRelations { get; }
     

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -71,10 +71,7 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     
     [Backlink(nameof(GamePhotoSubject.User))]
     public IQueryable<GamePhotoSubject> PhotosWithMe { get; }
-    
-    [Backlink(nameof(GameNotification.User))]
-    public IQueryable<GameNotification> Notifications { get; }
-    
+
     public IList<GameIpVerificationRequest> IpVerificationRequests { get; }
     #nullable restore
 

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -63,9 +63,6 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     #nullable disable
     public IList<GameComment> ProfileComments { get; }
 
-    [Backlink(nameof(GameLevel.Publisher))]
-    public IQueryable<GameLevel> PublishedLevels { get; }
-    
     public IList<GameIpVerificationRequest> IpVerificationRequests { get; }
     #nullable restore
 

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -66,12 +66,6 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     [Backlink(nameof(GameLevel.Publisher))]
     public IQueryable<GameLevel> PublishedLevels { get; }
     
-    [Backlink(nameof(GamePhoto.Publisher))]
-    public IQueryable<GamePhoto> PhotosByMe { get; }
-    
-    [Backlink(nameof(GamePhotoSubject.User))]
-    public IQueryable<GamePhotoSubject> PhotosWithMe { get; }
-
     public IList<GameIpVerificationRequest> IpVerificationRequests { get; }
     #nullable restore
 

--- a/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
@@ -425,7 +425,7 @@ public class ScoreLeaderboardTests : GameServerTest
             if (lastBestScore == null) continue;
 
             GameUser notificationRecipient = lastBestScore.Players.First();
-            GameNotification? notification = notificationRecipient.Notifications.FirstOrDefault();
+            GameNotification? notification = context.Database.GetNotificationsByUser(notificationRecipient, 1, 0).Items.FirstOrDefault();
 
             if (lastBestScore.Score <= 0)
             {
@@ -443,7 +443,7 @@ public class ScoreLeaderboardTests : GameServerTest
             if (level.Scores.Count() <= 2) continue;
             
             notificationRecipient = users[i - 2];
-            Assert.That(notificationRecipient.Notifications.Any(), Is.False);
+            Assert.That(context.Database.GetNotificationCountByUser(notificationRecipient), Is.Zero);
         }
         
         Assert.That(testedSent && testedNotSent, Is.True);


### PR DESCRIPTION
This PR replaces all the backlinks in GameUser with equivalents using `GameDatabaseContext`. Doing this does not require any migrations, it seems.

Tested with unit tests and API, but the game hasn't been tested. I'd recommend doing so.

It's worth noting that these are all cherry-picked from the postgres branch.