### PR TITLE
Organize API responses

### DIFF
--- a/Refresh.GameServer/Documentation/DocumentationService.cs
+++ b/Refresh.GameServer/Documentation/DocumentationService.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Bunkum.Core.Services;
 using NotEnoughLogs;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 
 namespace Refresh.GameServer.Documentation;
 

--- a/Refresh.GameServer/Endpoints/ApiV3/ActivityApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ActivityApiEndpoints.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Documentation.Attributes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Activity;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Activity;

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Roles;

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminUserApiEndpoints.cs
@@ -11,6 +11,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Admin;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;

--- a/Refresh.GameServer/Endpoints/ApiV3/ApiTypes/ApiEmptyResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ApiTypes/ApiEmptyResponse.cs
@@ -1,4 +1,6 @@
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes;
+
+namespace Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiEmptyResponse : IApiResponse

--- a/Refresh.GameServer/Endpoints/ApiV3/ApiTypes/ApiErrorResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ApiTypes/ApiErrorResponse.cs
@@ -1,7 +1,7 @@
 using AttribDoc;
-using Refresh.GameServer.Types.Data;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiErrorResponse : IApiResponse

--- a/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
@@ -13,6 +13,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Data;

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Activity/ApiActivityPageResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Activity/ApiActivityPageResponse.cs
@@ -1,9 +1,9 @@
-using Bunkum.Core.Storage;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.Activity;
 using Refresh.GameServer.Types.Data;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Activity;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiActivityPageResponse : IApiResponse, IDataConvertableFrom<ApiActivityPageResponse, ActivityPage>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Activity/ApiEventResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Activity/ApiEventResponse.cs
@@ -1,7 +1,7 @@
 using Refresh.GameServer.Types.Activity;
 using Refresh.GameServer.Types.Data;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Activity;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiEventResponse : IApiResponse, IDataConvertableFrom<ApiEventResponse, Event>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiContestResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiContestResponse.cs
@@ -1,4 +1,6 @@
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.Contests;
 using Refresh.GameServer.Types.Data;
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiGameAssetResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiGameAssetResponse.cs
@@ -1,9 +1,8 @@
-using Bunkum.Core.Storage;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.Assets;
 using Refresh.GameServer.Types.Data;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameAssetResponse : IApiResponse, IDataConvertableFrom<ApiGameAssetResponse, GameAsset>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiGameLocationResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiGameLocationResponse.cs
@@ -1,7 +1,7 @@
 using JetBrains.Annotations;
 using Refresh.GameServer.Types;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameLocationResponse : IApiResponse

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiParameterResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiParameterResponse.cs
@@ -1,8 +1,7 @@
 using AttribDoc;
 using Newtonsoft.Json.Converters;
-using Refresh.GameServer.Types.Data;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiParameterResponse : IApiResponse

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiRouteResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiRouteResponse.cs
@@ -1,8 +1,8 @@
 using AttribDoc;
-using Refresh.GameServer.Types.Data;
+using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Types.Roles;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiRouteResponse : IApiResponse

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
@@ -1,11 +1,11 @@
-using Bunkum.Core.Storage;
 using Refresh.GameServer.Authentication;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Reviews;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLevelResponse, GameLevel>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameReviewResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameReviewResponse.cs
@@ -1,8 +1,8 @@
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.Data;
-using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Reviews;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameReviewResponse : IApiResponse, IDataConvertableFrom<ApiGameReviewResponse, GameReview>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameScoreResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameScoreResponse.cs
@@ -1,10 +1,9 @@
-using Bunkum.Core.Storage;
 using Refresh.GameServer.Authentication;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.UserData.Leaderboard;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameScoreResponse, GameSubmittedScore>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameSkillRewardResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameSkillRewardResponse.cs
@@ -1,7 +1,7 @@
 ﻿using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels.SkillRewards;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameSkillRewardResponse : IApiResponse, IDataConvertableFrom<ApiGameSkillRewardResponse, GameSkillReward>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiLevelCategoryResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiLevelCategoryResponse.cs
@@ -1,15 +1,12 @@
 using Bunkum.Core;
-using Bunkum.Core.Storage;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
-using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Levels.Categories;
-using Refresh.GameServer.Types.UserData;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiLevelCategoryResponse : IApiResponse, IDataConvertableFrom<ApiLevelCategoryResponse, LevelCategory>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiAuthenticationResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiAuthenticationResponse.cs
@@ -1,7 +1,7 @@
 #nullable disable
 using JetBrains.Annotations;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy), ItemNullValueHandling = NullValueHandling.Ignore)]
 public class ApiAuthenticationResponse : IApiAuthenticationResponse

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
@@ -1,12 +1,11 @@
-using Bunkum.Core.Storage;
 using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 
 /// <summary>
 /// A user with full information, like current role, ban status, etc.

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameIpVerificationRequestResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameIpVerificationRequestResponse.cs
@@ -1,7 +1,7 @@
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.UserData;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameIpVerificationRequestResponse : IApiResponse, IDataConvertableFrom<ApiGameIpVerificationRequestResponse, GameIpVerificationRequest>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameNotificationResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameNotificationResponse.cs
@@ -1,7 +1,7 @@
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Notifications;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameNotificationResponse : IApiResponse, IDataConvertableFrom<ApiGameNotificationResponse, GameNotification>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserResponse.cs
@@ -1,11 +1,10 @@
-using Bunkum.Core.Storage;
 using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.UserData;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUserResponse, GameUser>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiResetPasswordResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiResetPasswordResponse.cs
@@ -1,5 +1,5 @@
 #nullable disable
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiResetPasswordResponse : IApiAuthenticationResponse

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/Photos/ApiGamePhotoResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/Photos/ApiGamePhotoResponse.cs
@@ -1,9 +1,8 @@
-using Bunkum.Core.Storage;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Photos;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Photos;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGamePhotoResponse : IApiResponse, IDataConvertableFrom<ApiGamePhotoResponse, GamePhoto>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/Photos/ApiGamePhotoSubjectResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/Photos/ApiGamePhotoSubjectResponse.cs
@@ -1,9 +1,7 @@
-using Bunkum.Core.Storage;
-using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Photos;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Photos;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGamePhotoSubjectResponse : IApiResponse,IDataConvertableFrom<ApiGamePhotoSubjectResponse, GamePhotoSubject>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/Rooms/ApiGameRoomPlayerResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/Rooms/ApiGameRoomPlayerResponse.cs
@@ -1,7 +1,7 @@
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Rooms;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameRoomPlayerResponse : IApiResponse, IDataConvertableFrom<ApiGameRoomPlayerResponse, GameRoomPlayer>

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/Rooms/ApiGameRoomResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/Rooms/ApiGameRoomResponse.cs
@@ -2,7 +2,7 @@ using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 
-namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Rooms;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public class ApiGameRoomResponse : IApiResponse, IDataConvertableFrom<ApiGameRoomResponse, GameRoom>

--- a/Refresh.GameServer/Endpoints/ApiV3/DocumentationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DocumentationApiEndpoints.cs
@@ -4,6 +4,7 @@ using Bunkum.Core.Endpoints;
 using Refresh.GameServer.Documentation;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 
 namespace Refresh.GameServer.Endpoints.ApiV3;
 

--- a/Refresh.GameServer/Endpoints/ApiV3/LeaderboardApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LeaderboardApiEndpoints.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Documentation.Attributes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;

--- a/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LevelApiEndpoints.cs
@@ -10,6 +10,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;

--- a/Refresh.GameServer/Endpoints/ApiV3/MatchingApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/MatchingApiEndpoints.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Documentation.Attributes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Rooms;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Data;

--- a/Refresh.GameServer/Endpoints/ApiV3/NotificationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/NotificationApiEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.GameServer.Documentation.Attributes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Notifications;

--- a/Refresh.GameServer/Endpoints/ApiV3/PhotoApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/PhotoApiEndpoints.cs
@@ -8,6 +8,7 @@ using Refresh.GameServer.Documentation.Attributes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Photos;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;

--- a/Refresh.GameServer/Endpoints/ApiV3/ResourceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ResourceApiEndpoints.cs
@@ -12,6 +12,7 @@ using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 using Refresh.GameServer.Importing;
 using Refresh.GameServer.Types.Assets;
 using Refresh.GameServer.Types.Data;

--- a/Refresh.GameServer/Endpoints/ApiV3/ReviewApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/ReviewApiEndpoints.cs
@@ -7,6 +7,7 @@ using Refresh.GameServer.Documentation.Attributes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;

--- a/Refresh.GameServer/Endpoints/ApiV3/UserApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/UserApiEndpoints.cs
@@ -8,6 +8,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;

--- a/RefreshTests.GameServer/Tests/ApiV3/LevelApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/LevelApiTests.cs
@@ -2,6 +2,7 @@ using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Levels.Categories;
 using Refresh.GameServer.Types.UserData;

--- a/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
@@ -3,6 +3,7 @@ using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.UserData;
 using RefreshTests.GameServer.Extensions;
 

--- a/RefreshTests.GameServer/Tests/Authentication/AuthenticationIntegrationTests.cs
+++ b/RefreshTests.GameServer/Tests/Authentication/AuthenticationIntegrationTests.cs
@@ -6,6 +6,7 @@ using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
 using Refresh.GameServer.Types.UserData;
 
 namespace RefreshTests.GameServer.Tests.Authentication;


### PR DESCRIPTION
We have too many of these classes for us to not organize them.

This commit does a basic pass to split them up into a few basic categories. It improves things substantially.