### PR TITLE
Implement various API extensions

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Comments.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Comments.cs
@@ -27,6 +27,8 @@ public partial class GameDatabaseContext // Comments
             .AsEnumerable()
             .Skip(skip)
             .Take(count);
+    
+    public int GetTotalCommentsForProfile(GameUser profile) => profile.ProfileComments.Count;
 
     public void DeleteProfileComment(GameComment comment, GameUser profile)
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Comments.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Comments.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using Refresh.GameServer.Types.Comments;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.UserData;
@@ -28,6 +29,7 @@ public partial class GameDatabaseContext // Comments
             .Skip(skip)
             .Take(count);
     
+    [Pure]
     public int GetTotalCommentsForProfile(GameUser profile) => profile.ProfileComments.Count;
 
     public void DeleteProfileComment(GameComment comment, GameUser profile)
@@ -57,6 +59,9 @@ public partial class GameDatabaseContext // Comments
              .AsEnumerable()
              .Skip(skip)
              .Take(count);
+    
+    [Pure]
+    public int GetTotalCommentsForLevel(GameLevel level) => level.LevelComments.Count;
 
     public void DeleteLevelComment(GameComment comment, GameLevel level)
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -191,7 +191,9 @@ public partial class GameDatabaseContext // Levels
         
         return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.Publisher == user), skip, count);
     }
-
+    
+    public int GetTotalLevelsByUser(GameUser user) => this._realm.All<GameLevel>().Count(l => l.Publisher == user);
+    
     [Pure]
     public DatabaseList<GameLevel> GetUserLevelsChunk(int skip, int count)
         => new(this._realm.All<GameLevel>().Where(l => l._Source == (int)GameLevelSource.User), skip, count);

--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -101,4 +101,8 @@ public partial class GameDatabaseContext // Photos
     [Pure]
     public DatabaseList<GamePhoto> GetPhotosInLevel(GameLevel level, int count, int skip) =>
         new(this._realm.All<GamePhoto>().Where(p => p.LevelId == level.LevelId), skip, count);
+    
+    [Pure]
+    public int GetTotalPhotosInLevel(GameLevel level)
+        => this._realm.All<GamePhoto>().Count(p => p.LevelId == level.LevelId);
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -280,6 +280,9 @@ public partial class GameDatabaseContext // Relations
         return new DatabaseList<GameReview>(this._realm.All<GameReview>()
             .Where(r => r.Level == level), skip, count);
     }
+    
+    public int GetTotalReviewsForLevel(GameLevel level)
+        => this._realm.All<GameReview>().Count(r => r.Level == level);
 
     #endregion
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
@@ -37,6 +37,10 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
     public required int YayRatings { get; set; }
     public required int BooRatings { get; set; }
     public required int Hearts { get; set; }
+    public required int PhotosTaken { get; set; }
+    public required int LevelComments { get; set; }
+    public required int Reviews { get; set; }
+    
     public required int UniquePlays { get; set; }
     public required bool TeamPicked { get; set; }
     public required GameLevelType LevelType { get; set; }
@@ -78,6 +82,9 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
             IsLocked = level.IsLocked,
             IsSubLevel = level.IsSubLevel,
             Score = level.Score,
+            PhotosTaken = dataContext.Database.GetTotalPhotosInLevel(level),
+            LevelComments = dataContext.Database.GetTotalCommentsForLevel(level),
+            Reviews = dataContext.Database.GetTotalReviewsForLevel(level),
         };
     }
     

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
@@ -20,8 +20,6 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     public required ApiGameLocationResponse Location { get; set; }
     public required DateTimeOffset JoinDate { get; set; }
     public required DateTimeOffset LastLoginDate { get; set; }
-    
-    public required bool AllowIpAuthentication { get; set; }
     public required GameUserRole Role { get; set; }
     
     public required string? BanReason { get; set; }
@@ -36,6 +34,7 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     public required string? EmailAddress { get; set; }
     public required bool EmailAddressVerified { get; set; }
     public required bool ShouldResetPassword { get; set; }
+    public required bool AllowIpAuthentication { get; set; }
     
     public required int FilesizeQuotaUsage { get; set; }
     

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Rooms;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -38,6 +39,9 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     
     public required int FilesizeQuotaUsage { get; set; }
     
+    public required ApiGameUserStatisticsResponse Statistics { get; set; }
+    public required ApiGameRoomResponse? ActiveRoom { get; set; }
+    
     [ContractAnnotation("null => null; notnull => notnull")]
     public static ApiExtendedGameUserResponse? FromOld(GameUser? user, DataContext dataContext)
     {
@@ -64,6 +68,8 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
             RedirectGriefReportsToPhotos = user.RedirectGriefReportsToPhotos,
             UnescapeXmlSequences = user.UnescapeXmlSequences,
             FilesizeQuotaUsage = user.FilesizeQuotaUsage,
+            Statistics = ApiGameUserStatisticsResponse.FromOld(user, dataContext)!,
+            ActiveRoom = ApiGameRoomResponse.FromOld(dataContext.Match.RoomAccessor.GetRoomByUser(user), dataContext),
         };
     }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
@@ -30,12 +30,14 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     public required bool RpcnAuthenticationAllowed { get; set; }
     public required bool PsnAuthenticationAllowed { get; set; }
     
-    public bool RedirectGriefReportsToPhotos { get; set; } 
-    public bool UnescapeXmlSequences { get; set; } 
+    public required bool RedirectGriefReportsToPhotos { get; set; } 
+    public required bool UnescapeXmlSequences { get; set; } 
     
     public required string? EmailAddress { get; set; }
     public required bool EmailAddressVerified { get; set; }
     public required bool ShouldResetPassword { get; set; }
+    
+    public required int FilesizeQuotaUsage { get; set; }
     
     [ContractAnnotation("null => null; notnull => notnull")]
     public static ApiExtendedGameUserResponse? FromOld(GameUser? user, DataContext dataContext)
@@ -62,6 +64,7 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
             ShouldResetPassword = user.ShouldResetPassword,
             RedirectGriefReportsToPhotos = user.RedirectGriefReportsToPhotos,
             UnescapeXmlSequences = user.UnescapeXmlSequences,
+            FilesizeQuotaUsage = user.FilesizeQuotaUsage,
         };
     }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserResponse.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
+using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Rooms;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -23,6 +24,7 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
     public required GameUserRole Role { get; set; }
     
     public required ApiGameUserStatisticsResponse Statistics { get; set; }
+    public required ApiGameRoomResponse? ActiveRoom { get; set; }
 
     [ContractAnnotation("null => null; notnull => notnull")]
     public static ApiGameUserResponse? FromOld(GameUser? user, DataContext dataContext)
@@ -40,6 +42,7 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
             LastLoginDate = user.LastLoginDate,
             Role = user.Role,
             Statistics = ApiGameUserStatisticsResponse.FromOld(user, dataContext)!,
+            ActiveRoom = ApiGameRoomResponse.FromOld(dataContext.Match.RoomAccessor.GetRoomByUser(user), dataContext),
         };
     }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserResponse.cs
@@ -19,6 +19,8 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
     public required ApiGameLocationResponse Location { get; set; }
     public required DateTimeOffset JoinDate { get; set; }
     public required DateTimeOffset LastLoginDate { get; set; }
+    
+    public required ApiGameUserStatisticsResponse Statistics { get; set; }
 
     [ContractAnnotation("null => null; notnull => notnull")]
     public static ApiGameUserResponse? FromOld(GameUser? user, DataContext dataContext)
@@ -34,6 +36,7 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
             Location = ApiGameLocationResponse.FromGameLocation(user.Location)!,
             JoinDate = user.JoinDate,
             LastLoginDate = user.LastLoginDate,
+            Statistics = ApiGameUserStatisticsResponse.FromOld(user, dataContext)!,
         };
     }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserResponse.cs
@@ -2,6 +2,7 @@ using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 using Refresh.GameServer.Types.Data;
+using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
@@ -19,6 +20,7 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
     public required ApiGameLocationResponse Location { get; set; }
     public required DateTimeOffset JoinDate { get; set; }
     public required DateTimeOffset LastLoginDate { get; set; }
+    public required GameUserRole Role { get; set; }
     
     public required ApiGameUserStatisticsResponse Statistics { get; set; }
 
@@ -36,6 +38,7 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
             Location = ApiGameLocationResponse.FromGameLocation(user.Location)!,
             JoinDate = user.JoinDate,
             LastLoginDate = user.LastLoginDate,
+            Role = user.Role,
             Statistics = ApiGameUserStatisticsResponse.FromOld(user, dataContext)!,
         };
     }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserStatisticsResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiGameUserStatisticsResponse.cs
@@ -1,0 +1,28 @@
+using Refresh.GameServer.Types.Data;
+using Refresh.GameServer.Types.UserData;
+
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiGameUserStatisticsResponse: IApiResponse, IDataConvertableFrom<ApiGameUserStatisticsResponse, GameUser>
+{
+    public required int Favourites { get; set; }
+    public required int ProfileComments { get; set; }
+    public required int PublishedLevels { get; set; }
+    public required int PhotosTaken { get; set; }
+    
+    public static ApiGameUserStatisticsResponse? FromOld(GameUser? user, DataContext dataContext)
+    {
+        if (user == null) return null;
+        
+        return new ApiGameUserStatisticsResponse
+        {
+            Favourites = dataContext.Database.GetTotalUsersFavouritingUser(user),
+            ProfileComments = dataContext.Database.GetTotalCommentsForProfile(user),
+            PublishedLevels = dataContext.Database.GetTotalLevelsByUser(user),
+            PhotosTaken = dataContext.Database.GetTotalPhotosByUser(user),
+        };
+    }
+    
+    public static IEnumerable<ApiGameUserStatisticsResponse> FromOldList(IEnumerable<GameUser> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
+}


### PR DESCRIPTION
Closes #515.

Ideally I would have included level statistics in a new Statistics object like I've done for users for organization purposes, but there are already statistics present in ApiGameLevelResponse and I don't want to have them split up.

Something to consider for APIv4 if we ever consider jumping from v3.