### PR TITLE
Matching + Metadata fixes

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -177,6 +177,12 @@ public partial class GameDatabaseContext // Users
 
             if (data.EmailAddress != null)
                 user.EmailAddress = data.EmailAddress;
+            
+            if (data.LevelVisibility != null)
+                user.LevelVisibility = data.LevelVisibility.Value;
+            
+            if (data.ProfileVisibility != null)
+                user.ProfileVisibility = data.ProfileVisibility.Value;
         });
     }
 
@@ -378,6 +384,22 @@ public partial class GameDatabaseContext // Users
         this._realm.Write(() =>
         {
             user.FilesizeQuotaUsage += amount;
+        });
+    }
+    
+    public void SetProfileVisibility(GameUser user, Visibility visibility)
+    {
+        this._realm.Write(() =>
+        {
+            user.ProfileVisibility = visibility;
+        });
+    }
+    
+    public void SetLevelVisibility(GameUser user, Visibility visibility)
+    {
+        this._realm.Write(() =>
+        {
+            user.LevelVisibility = visibility;
         });
     }
 }

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -34,7 +34,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 124;
+    protected override ulong SchemaVersion => 125;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiUpdateUserRequest.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiUpdateUserRequest.cs
@@ -1,3 +1,5 @@
+using Refresh.GameServer.Types;
+
 namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
@@ -14,4 +16,7 @@ public class ApiUpdateUserRequest
     public bool? UnescapeXmlSequences { get; set; }
     
     public string? EmailAddress { get; set; }
+    
+    public Visibility? LevelVisibility { get; set; }
+    public Visibility? ProfileVisibility { get; set; }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
@@ -2,6 +2,7 @@ using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Users.Rooms;
+using Refresh.GameServer.Types;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -37,6 +38,9 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     public required bool ShouldResetPassword { get; set; }
     public required bool AllowIpAuthentication { get; set; }
     
+    public required Visibility LevelVisibility { get; set; }
+    public required Visibility ProfileVisibility { get; set; }
+    
     public required int FilesizeQuotaUsage { get; set; }
     
     public required ApiGameUserStatisticsResponse Statistics { get; set; }
@@ -70,6 +74,8 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
             FilesizeQuotaUsage = user.FilesizeQuotaUsage,
             Statistics = ApiGameUserStatisticsResponse.FromOld(user, dataContext)!,
             ActiveRoom = ApiGameRoomResponse.FromOld(dataContext.Match.RoomAccessor.GetRoomByUser(user), dataContext),
+            LevelVisibility = user.LevelVisibility,
+            ProfileVisibility = user.ProfileVisibility,
         };
     }
 

--- a/Refresh.GameServer/Endpoints/Game/MatchingEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/MatchingEndpoints.cs
@@ -45,7 +45,7 @@ public class MatchingEndpoints : EndpointGroup
     [GameEndpoint("enterLevel/{slotType}/{id}", HttpMethods.Post)]
     public Response EnterLevel(RequestContext context, Token token, MatchService matchService, string slotType, int id)
     {
-        GameRoom room = matchService.GetOrCreateRoomByPlayer(token.User, token.TokenPlatform, token.TokenGame, NatType.Strict);
+        GameRoom room = matchService.GetOrCreateRoomByPlayer(token.User, token.TokenPlatform, token.TokenGame, NatType.Strict, null, false);
         
         // User slot ID of 0 means pod/moon level
         if (id == 0 && slotType == "user")

--- a/Refresh.GameServer/Services/MatchService.Parsing.cs
+++ b/Refresh.GameServer/Services/MatchService.Parsing.cs
@@ -11,10 +11,6 @@ public partial class MatchService // Parsing
         // skip until after second open bracket, replace with JSON object brackets
         int start = 3 + method.Length;
         body = string.Concat("{", body.AsSpan(start, body.Length - 2 - start), "}");
-        
-        // Fix double arrays
-        body = body.Replace("[[", "[")
-            .Replace("]]", "]");
 
         body = ReplaceHexValuesInStringWithIpAddresses(body);
 
@@ -28,7 +24,7 @@ public partial class MatchService // Parsing
         int hexIndex;
         while ((hexIndex = body.IndexOf("0x", StringComparison.Ordinal)) != -1)
         {
-            string hex = body.Substring(hexIndex, hexValueLength);
+            ReadOnlySpan<char> hex = body.AsSpan().Slice(hexIndex, hexValueLength);
             string ip = ConvertHexadecimalIpAddressToString(hex);
             body = string.Concat(body.AsSpan(0, hexIndex), '\"' + ip + '\"', body.AsSpan(hexIndex + hexValueLength));
         }
@@ -37,7 +33,7 @@ public partial class MatchService // Parsing
     }
 
     // should serialize "0x17257bc9" into "23.39.123.201"
-    public static string ConvertHexadecimalIpAddressToString(string hex)
+    public static string ConvertHexadecimalIpAddressToString(ReadOnlySpan<char> hex)
     {
         // parse hex string as uint, stripping 0x header, if it fails, return 0.0.0.0
         if (!uint.TryParse(hex[2..], NumberStyles.HexNumber, null, out uint ip)) return "0.0.0.0";

--- a/Refresh.GameServer/Services/MatchService.cs
+++ b/Refresh.GameServer/Services/MatchService.cs
@@ -21,30 +21,48 @@ public partial class MatchService(Logger logger) : EndpointService(logger)
 
     public IRoomAccessor RoomAccessor { get; private set; } = null!; //initialized in Initialize()
     
-    public GameRoom GetOrCreateRoomByPlayer(GameUser player, TokenPlatform platform, TokenGame game, NatType natType)
+    public GameRoom GetOrCreateRoomByPlayer(
+        GameUser player, 
+        TokenPlatform platform, 
+        TokenGame game, 
+        NatType natType, 
+        int? buildVersion,
+        bool passedNoJoinPoint)
     {
         GameRoom? room = this.RoomAccessor.GetRoomByUser(player, platform, game);
         
         // ReSharper disable once ConvertIfStatementToNullCoalescingExpression
         if (room == null)
-            room = this.CreateRoomByPlayer(player, platform, game, natType);
+            room = this.CreateRoomByPlayer(player, platform, game, natType, buildVersion, passedNoJoinPoint);
 
         return room;
     }
 
-    public GameRoom CreateRoomByPlayer(GameUser player, TokenPlatform platform, TokenGame game, NatType natType)
+    public GameRoom CreateRoomByPlayer(
+        GameUser player, 
+        TokenPlatform platform, 
+        TokenGame game, 
+        NatType natType, 
+        int? buildVersion,
+        bool passedNoJoinPoint)
     {
-        GameRoom room = new(player, platform, game, natType);
+        GameRoom room = new(player, platform, game, natType, buildVersion, passedNoJoinPoint);
         this.RoomAccessor.AddRoom(room);
         return room;
     }
 
-    public GameRoom SplitUserIntoNewRoom(GameUser player, TokenPlatform platform, TokenGame game, NatType natType)
+    public GameRoom SplitUserIntoNewRoom(
+        GameUser player, 
+        TokenPlatform platform, 
+        TokenGame game, 
+        NatType natType, 
+        int? buildVersion,
+        bool passedNoJoinPoint)
     {
         GameRoom? room = this.RoomAccessor.GetRoomByUser(player, platform, game);
         if (room == null)
         {
-            return this.CreateRoomByPlayer(player, platform, game, natType);
+            return this.CreateRoomByPlayer(player, platform, game, natType, buildVersion, passedNoJoinPoint);
         }
         
         // Remove player from old room
@@ -52,7 +70,7 @@ public partial class MatchService(Logger logger) : EndpointService(logger)
         // Update the room on the room accessor
         this.RoomAccessor.UpdateRoom(room);
         
-        return this.CreateRoomByPlayer(player, platform, game, natType);
+        return this.CreateRoomByPlayer(player, platform, game, natType, buildVersion, passedNoJoinPoint);
     }
     
     public int GetPlayerCountForLevel(RoomSlotType type, int id)

--- a/Refresh.GameServer/Types/Matching/GameRoom.cs
+++ b/Refresh.GameServer/Types/Matching/GameRoom.cs
@@ -8,12 +8,14 @@ namespace Refresh.GameServer.Types.Matching;
 
 public class GameRoom
 {
-    public GameRoom(GameUser host, TokenPlatform platform, TokenGame game, NatType natType)
+    public GameRoom(GameUser host, TokenPlatform platform, TokenGame game, NatType natType, int? buildVersion, bool passedNoJoinPoint)
     {
         this.PlayerIds.Add(new GameRoomPlayer(host.Username, host.UserId));
         this.Platform = platform;
         this.Game = game;
         this.NatType = natType;
+        this.BuildVersion = buildVersion;
+        this.PassedNoJoinPoint = passedNoJoinPoint;
     }
 
     public readonly ObjectId RoomId = ObjectId.GenerateNewId();
@@ -27,6 +29,9 @@ public class GameRoom
     public readonly NatType NatType;
 
     public DateTimeOffset LastContact;
+    
+    public int? BuildVersion;
+    public bool PassedNoJoinPoint;
 
     public List<GameUser?> GetPlayers(GameDatabaseContext database) =>
         this.PlayerIds

--- a/Refresh.GameServer/Types/Matching/IRoomAccessor.cs
+++ b/Refresh.GameServer/Types/Matching/IRoomAccessor.cs
@@ -98,17 +98,17 @@ public interface IRoomAccessor
     /// <param name="platform">The platform to check for</param>
     /// <param name="game">The game to check for</param>
     /// <returns>The found room, or null if not found</returns>
-    public GameRoom? GetRoomByUser(GameUser user, TokenPlatform? platform = null, TokenGame? game = null) => this.GetRoomByUserUuid(user.UserId, platform, game);
+    public GameRoom? GetRoomByUser(GameUser user, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null) => this.GetRoomByUserUuid(user.UserId, platform, game, buildVersion);
     /// <summary>
     /// Gets a room by a user's UUID.
     /// </summary>
     /// <param name="uuid">The user UUID to search for</param>
     /// <returns>The found room, or null if not found</returns>
-    public GameRoom? GetRoomByUserUuid(ObjectId uuid, TokenPlatform? platform = null, TokenGame? game = null);
+    public GameRoom? GetRoomByUserUuid(ObjectId uuid, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null);
     /// <summary>
     /// Gets a room by a user's username.
     /// </summary>
     /// <param name="username">The username to search for</param>
     /// <returns>The found room, or null if not found</returns>
-    public GameRoom? GetRoomByUsername(string username, TokenPlatform? platform = null, TokenGame? game = null);
+    public GameRoom? GetRoomByUsername(string username, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null);
 }

--- a/Refresh.GameServer/Types/Matching/MatchMethods/CreateRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/CreateRoomMethod.cs
@@ -16,25 +16,30 @@ public class CreateRoomMethod : IMatchMethod
         SerializedRoomData body)
     {
         NatType natType = body.NatType == null ? NatType.Open : body.NatType[0];
-        GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, natType);
+        GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, natType, body.BuildVersion, body.PassedNoJoinPoint ?? false);
         if (room.HostId.Id != user.UserId)
         {
-            room = service.SplitUserIntoNewRoom(user, token.TokenPlatform, token.TokenGame, natType);
+            room = service.SplitUserIntoNewRoom(user, token.TokenPlatform, token.TokenGame, natType, body.BuildVersion, body.PassedNoJoinPoint ?? false);
         }
 
         if (body.RoomState != null) room.RoomState = body.RoomState.Value;
-
-        // LBP likes to send both Slot and Slots interchangeably, handle that case here
-        if (body.Slots != null)
+        
+        if (body.Slots.Count > 1)
         {
-            if (body.Slots.Count != 2)
+            logger.LogWarning(BunkumCategory.Matching, "Received create room request with multiple slots, rejecting");
+            return BadRequest;
+        }
+        
+        foreach(List<int> slot in body.Slots)
+        {
+            if (slot.Count != 2)
             {
-                logger.LogWarning(BunkumCategory.Matching, "Received request with invalid amount of slots, rejecting.");
+                logger.LogWarning(BunkumCategory.Matching, "Received request with invalid slot, rejecting.");
                 return BadRequest;
             }
 
-            room.LevelType = (RoomSlotType)body.Slots[0];
-            room.LevelId = body.Slots[1];
+            room.LevelType = (RoomSlotType)slot[0];
+            room.LevelId = slot[1];
         }
 
         byte? mood = body.HostMood ?? body.Mood;

--- a/Refresh.GameServer/Types/Matching/MatchMethods/FindRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/FindRoomMethod.cs
@@ -22,22 +22,30 @@ public class FindRoomMethod : IMatchMethod
     {
         GameRoom? usersRoom = service.RoomAccessor.GetRoomByUser(user, token.TokenPlatform, token.TokenGame);
         if (usersRoom == null) return BadRequest; // user should already have a room.
-
-        int? levelId = null;
-        if (body.Slots != null)
+        
+        List<int> levelIds = new(body.Slots.Count);
+        // Iterate over all sent slots and append their IDs to the list of level IDs to check
+        foreach(List<int> slot in body.Slots)
         {
-            if (body.Slots.Count != 2)
+            if (slot.Count != 2)
             {
-                logger.LogWarning(BunkumCategory.Matching, "Received request with invalid amount of slots, rejecting.");
+                logger.LogWarning(BunkumCategory.Matching, "Received request with invalid slot, rejecting.");
                 return BadRequest;
             }
             
-            levelId = body.Slots[1];
-        } 
+            // 0 means "no level specified"
+            if (slot[1] == 0) 
+                continue;
+            
+            levelIds.Add(slot[1]);
+        }
+        
+        // If we are on vita and the game specified more than one level ID, then its trying to do dive in only to players in a certain category of levels
+        // This is not how most people expect dive in to work, so let's pretend that the game didn't specify any level IDs whatsoever, so they will get matched with all players
+        if (token.TokenGame == TokenGame.LittleBigPlanetVita && levelIds.Count > 1)
+            levelIds = [];
         
         //TODO: Add user option to filter rooms by language
-        //TODO: Deprioritize rooms which have PassedNoJoinPoint set 
-        //TODO: Filter by BuildVersion
         
         IEnumerable<GameRoom> rooms = service.RoomAccessor
             // Get all the available rooms 
@@ -46,15 +54,19 @@ public class FindRoomMethod : IMatchMethod
                 // Make sure we don't match the user into their own room
                 r.RoomId != usersRoom.RoomId &&
                 // If the level id isn't specified, or is 0, then we don't want to try to match against level IDs, else only match the user to people who are playing that level
-                (levelId == null || levelId == 0 || r.LevelId == levelId) &&
+                (levelIds.Count == 0 || levelIds.Contains(r.LevelId)) &&
                 // Make sure that we don't try to match the player into a full room, or a room which won't fit the user's current room
-                usersRoom.PlayerIds.Count + r.PlayerIds.Count <= 4)
+                usersRoom.PlayerIds.Count + r.PlayerIds.Count <= 4 &&
+                // Match the build version of the rooms
+                (r.BuildVersion ?? 0) == body.BuildVersion)
             // Shuffle the rooms around before sorting, this is because the selection is based on a weighted average towards the top of the range,
             // so there would be a bias towards longer lasting rooms without this shuffle
             .OrderBy(r => Random.Shared.Next())
             // Order by descending room mood, so that rooms with higher mood (e.g. allowing more people) get selected more often
             // This is a stable sort, which is why the order needs to be shuffled above
-            .ThenByDescending(r => r.RoomMood);
+            .ThenByDescending(r => r.RoomMood)
+            // Order by "passed no join point" so that people are more likely to be matched into rooms which they can instantly hop into and play
+            .ThenByDescending(r => r.PassedNoJoinPoint ? 0 : 1);
         
         //When a user is behind a Strict NAT layer, we can only connect them to players with Open NAT types
         if (body.NatType != null && body.NatType[0] == NatType.Strict)
@@ -76,7 +88,16 @@ public class FindRoomMethod : IMatchMethod
         
         if (roomList.Count <= 0)
         {
-            //Return a 404 status code if there's no rooms to match them to
+#if DEBUG
+            logger.LogDebug(BunkumCategory.Matching, "Room search by {0} on {1} ({2}) returned no results, dumping list of available rooms.", user.Username, token.TokenGame, token.TokenPlatform);
+            
+            // Dump an "overview" of the global room state, to help debug matching issues
+            rooms = service.RoomAccessor.GetRoomsByGameAndPlatform(token.TokenGame, token.TokenPlatform);
+            foreach (GameRoom logRoom in rooms)
+                logger.LogDebug(BunkumCategory.Matching,"Room {0} has NAT type {1} and is on level {2}", logRoom.RoomId, logRoom.NatType, logRoom.LevelId);
+#endif
+            
+            // Return a 404 status code if there's no rooms to match them to
             return new Response(new List<object> { new SerializedStatusCodeMatchResponse(404), }, ContentType.Json);
         }
 
@@ -88,13 +109,16 @@ public class FindRoomMethod : IMatchMethod
         }
         
         // Generate a weighted random number, this is weighted relatively strongly towards lower numbers,
-        // which makes it more likely to pick rooms with a higher mood, since those are sorted near the start of the array
-        // Graph: https://www.desmos.com/calculator/aagcmlbb08
+        // which makes it more likely to pick rooms with a higher mood and not past a "no join point",
+        // since those are sorted near the start of the list
+        // Curve: https://www.desmos.com/calculator/aagcmlbb08
         double weightedRandom = 1 - Math.Cbrt(1 - Random.Shared.NextDouble());
         
         // Even though NextDouble guarantees the result to be < 1.0, and this mathematically always will check out,
         // rounding errors may cause this to become roomList.Count (which would crash), so we use a Math.Min to make sure it doesn't
         GameRoom room = roomList[Math.Min(roomList.Count - 1, (int)Math.Floor(weightedRandom * roomList.Count))];
+        
+        logger.LogDebug(BunkumCategory.Matching, "Matched user {0} into room {1}.", user.Username, room.RoomId);
 
         SerializedRoomMatchResponse roomMatch = new()
         {

--- a/Refresh.GameServer/Types/Matching/MatchMethods/UpdatePlayersInRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/UpdatePlayersInRoomMethod.cs
@@ -17,7 +17,7 @@ public class UpdatePlayersInRoomMethod : IMatchMethod
         SerializedRoomData body)
     {
         if (body.Players == null) return BadRequest;
-        GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, body.NatType == null ? NatType.Open : body.NatType[0]);
+        GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint ?? false);
         
         foreach (string playerUsername in body.Players)
         {

--- a/Refresh.GameServer/Types/Matching/MatchMethods/UpdateRoomDataMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/UpdateRoomDataMethod.cs
@@ -15,28 +15,39 @@ public class UpdateRoomDataMethod : IMatchMethod
     public Response Execute(MatchService service, Logger logger,
         GameDatabaseContext database, GameUser user, Token token, SerializedRoomData body)
     {
-        GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, body.NatType == null ? NatType.Open : body.NatType[0]);
+        GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint ?? false);
         if (room.HostId.Id != user.UserId) return Unauthorized;
 
         if (body.RoomState != null) room.RoomState = body.RoomState.Value;
-
-        // LBP likes to send both Slot and Slots interchangeably, handle that case here
-        if (body.Slots != null)
+        
+        // Players cannot be in multiple levels at once
+        if (body.Slots.Count > 1)
         {
-            if (body.Slots.Count != 2)
+            logger.LogWarning(BunkumCategory.Matching, "Received update room request with multiple slots, rejecting");
+            return BadRequest;
+        }
+        
+        foreach(List<int> slot in body.Slots)
+        {
+            if (slot.Count != 2)
             {
-                logger.LogWarning(BunkumCategory.Matching, "Received request with invalid amount of slots, rejecting.");
+                logger.LogWarning(BunkumCategory.Matching, "Received request with invalid slot, rejecting.");
                 return BadRequest;
             }
 
-            room.LevelType = (RoomSlotType)body.Slots[0];
-            room.LevelId = body.Slots[1];
+            room.LevelType = (RoomSlotType)slot[0];
+            room.LevelId = slot[1];
         }
-
+        
         byte? mood = body.HostMood ?? body.Mood;
         if (mood != null)
         {
             room.RoomMood = (RoomMood)mood;
+        }
+        
+        if (body.PassedNoJoinPoint != null)
+        {
+            room.PassedNoJoinPoint = body.PassedNoJoinPoint.Value;
         }
         
         service.RoomAccessor.UpdateRoom(room);

--- a/Refresh.GameServer/Types/Matching/RoomAccessors/InMemoryRoomAccessor.cs
+++ b/Refresh.GameServer/Types/Matching/RoomAccessors/InMemoryRoomAccessor.cs
@@ -149,22 +149,30 @@ public class InMemoryRoomAccessor(Logger logger) : IRoomAccessor
     }
 
     /// <inheritdoc/>
-    public GameRoom? GetRoomByUserUuid(ObjectId uuid, TokenPlatform? platform = null, TokenGame? game = null)
+    public GameRoom? GetRoomByUserUuid(ObjectId uuid, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null)
     {
         lock (this._rooms)
         {
             this.RemoveExpiredRooms();
-            return this._rooms.FirstOrDefault(r => r.PlayerIds.Any(p => p.Id == uuid) && (platform == null || r.Platform == platform) && (game == null || r.Game == game));
+            return this._rooms.FirstOrDefault(r =>
+                r.PlayerIds.Any(p => p.Id == uuid) &&
+                (platform == null || r.Platform == platform) &&
+                (game == null || r.Game == game) &&
+                (buildVersion == null || r.BuildVersion == buildVersion));
         }
     }
     
     /// <inheritdoc/>
-    public GameRoom? GetRoomByUsername(string username, TokenPlatform? platform = null, TokenGame? game = null)
+    public GameRoom? GetRoomByUsername(string username, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null)
     {
         lock (this._rooms)
         {
             this.RemoveExpiredRooms();
-            return this._rooms.FirstOrDefault(r => r.PlayerIds.Any(p => p.Username == username) && (platform == null || r.Platform == platform) && (game == null || r.Game == game));
+            return this._rooms.FirstOrDefault(r =>
+                    r.PlayerIds.Any(p => p.Username == username) &&
+                    (platform == null || r.Platform == platform) &&
+                    (game == null || r.Game == game) &&
+                    (buildVersion == null || r.BuildVersion == buildVersion));
         }
     }
 }

--- a/Refresh.GameServer/Types/Matching/SerializedRoomData.cs
+++ b/Refresh.GameServer/Types/Matching/SerializedRoomData.cs
@@ -23,11 +23,11 @@ public class SerializedRoomData
     private List<int>? _Slot { get; set; }
     
     [JsonProperty("Slots")]
-    private List<int>? _Slots { get; set; }
+    private List<List<int>>? _Slots { get; set; }
     // ReSharper restore InconsistentNaming
 
     [JsonIgnore]
-    public List<int>? Slots => this._Slot ?? this._Slots;
+    public List<List<int>> Slots => this._Slot != null ? [this._Slot] : this._Slots ?? [];
     
     [JsonProperty("RoomState")]
     public RoomState? RoomState { get; set; }

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -82,6 +82,29 @@ public partial class GameUser : IRealmObject, IRateLimitUser
     public bool RpcnAuthenticationAllowed { get; set; }
     public bool PsnAuthenticationAllowed { get; set; }
     
+    private int _ProfileVisibility { get; set; } = (int)Visibility.All;
+    private int _LevelVisibility { get; set; } = (int)Visibility.All;
+    
+    /// <summary>
+    /// Whether the user's profile is displayed on the website
+    /// </summary>
+    [Ignored]
+    public Visibility ProfileVisibility
+    {
+        get => (Visibility)this._ProfileVisibility;
+        set => this._ProfileVisibility = (int)value;
+    }
+    
+    /// <summary>
+    /// Whether the user's levels are displayed on the website
+    /// </summary>
+    [Ignored]
+    public Visibility LevelVisibility
+    {
+        get => (Visibility)this._LevelVisibility;
+        set => this._LevelVisibility = (int)value;
+    }
+    
     /// <summary>
     /// If `true`, turn all grief reports into photo uploads
     /// </summary>


### PR DESCRIPTION
Easiest to review by commit

The metadata commit implements the start to the "level/profile visibility" functionality the game exposes, but lacks the actual functionality of hiding the user/levels from the API 

This also adds multiple fixes to matching, making vita dive in work, and implements "passed no join point" 

Closes #373 