### PR TITLE
Ability to delete scores via the API

### DIFF
--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLeaderboardApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLeaderboardApiEndpoints.cs
@@ -1,0 +1,55 @@
+using AttribDoc.Attributes;
+using Bunkum.Core;
+using Bunkum.Core.Endpoints;
+using Bunkum.Protocols.Http;
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
+using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
+using Refresh.GameServer.Types.Roles;
+using Refresh.GameServer.Types.UserData;
+using Refresh.GameServer.Types.UserData.Leaderboard;
+
+namespace Refresh.GameServer.Endpoints.ApiV3.Admin;
+
+public class AdminLeaderboardApiEndpoints : EndpointGroup
+{
+    [ApiV3Endpoint("admin/scores/{uuid}", HttpMethods.Delete), MinimumRole(GameUserRole.Admin)]
+    [DocSummary("Removes a score by the score's UUID.")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ScoreMissingErrorWhen)]
+    public ApiOkResponse DeleteScore(RequestContext context, GameDatabaseContext database,
+        [DocSummary("The UUID of the score")] string uuid)
+    {
+        GameSubmittedScore? score = database.GetScoreByUuid(uuid);
+        if (score == null) return ApiNotFoundError.Instance;
+        
+        database.DeleteScore(score);
+        
+        return new ApiOkResponse();
+    }
+    
+    [ApiV3Endpoint("admin/users/uuid/{uuid}/scores", HttpMethods.Delete), MinimumRole(GameUserRole.Admin)]
+    [DocSummary("Deletes all scores set by a user. Gets user by their UUID.")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    public ApiOkResponse DeleteScoresSetByUuid(RequestContext context, GameDatabaseContext database,
+        [DocSummary("The UUID of the user")] string uuid)
+    {
+        GameUser? user = database.GetUserByUuid(uuid);
+        if (user == null) return ApiNotFoundError.UserMissingError;
+        
+        database.DeleteScoresSetByUser(user);
+        return new ApiOkResponse();
+    }
+    
+    [ApiV3Endpoint("admin/users/name/{username}/scores", HttpMethods.Delete), MinimumRole(GameUserRole.Admin)]
+    [DocSummary("Deletes all scores set by a user. Gets user by their username.")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    public ApiOkResponse DeleteScoresSetByUsername(RequestContext context, GameDatabaseContext database,
+        [DocSummary("The username of the user")] string username)
+    {
+        GameUser? user = database.GetUserByUsername(username);
+        if (user == null) return ApiNotFoundError.UserMissingError;
+        
+        database.DeleteScoresSetByUser(user);
+        return new ApiOkResponse();
+    }
+}

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
@@ -22,7 +22,7 @@ public class AdminLevelApiEndpoints : EndpointGroup
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     public ApiOkResponse AddTeamPickToLevel(RequestContext context, GameDatabaseContext database, GameUser user, int id)
     {
-        GameLevel? level = database.GetLevelById(id);
+        GameLevel? level = database.GetLevelById(id); 
         if (level == null) return ApiNotFoundError.LevelMissingError;
         
         database.AddTeamPickToLevel(level);

--- a/Refresh.GameServer/Endpoints/ApiV3/LeaderboardApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/LeaderboardApiEndpoints.cs
@@ -46,8 +46,8 @@ public class LeaderboardApiEndpoints : EndpointGroup
     [DocSummary("Gets an individual score by a UUID")]
     [DocError(typeof(ApiNotFoundError), "The score could not be found")]
     public ApiResponse<ApiGameScoreResponse> GetScoreByUuid(RequestContext context, GameDatabaseContext database,
-        IDataStore dataStore,
-        [DocSummary("The UUID of the score")] string uuid, DataContext dataContext)
+        DataContext dataContext,
+        [DocSummary("The UUID of the score")] string uuid)
     {
         GameSubmittedScore? score = database.GetScoreByUuid(uuid);
         if (score == null) return ApiNotFoundError.Instance;

--- a/RefreshTests.GameServer/Tests/Levels/ScoreModerationTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ScoreModerationTests.cs
@@ -1,0 +1,96 @@
+using MongoDB.Bson;
+using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.Roles;
+using Refresh.GameServer.Types.UserData;
+using Refresh.GameServer.Types.UserData.Leaderboard;
+
+namespace RefreshTests.GameServer.Tests.Levels;
+
+public class ScoreModerationTests : GameServerTest
+{
+    [Test]
+    public void DeletesIndividualScore()
+    {
+        // Arrange
+        using TestContext context = this.GetServer();
+        
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user);
+        
+        GameSubmittedScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        string uuid = score.ScoreId.ToString();
+        
+        // Act
+        context.Database.DeleteScore(context.Database.GetScoreByUuid(uuid)!);
+        
+        // Assert
+        Assert.That(context.Database.GetScoreByUuid(uuid), Is.Null);
+    }
+    
+    [Test]
+    public async Task AnonymousCannotDeleteIndividualScoreViaApi()
+    {
+        // Arrange
+        using TestContext context = this.GetServer();
+        
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user);
+        
+        GameSubmittedScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        string uuid = score.ScoreId.ToString();
+        
+        // Act
+        HttpResponseMessage response = await context.Http.DeleteAsync($"/api/v3/admin/scores/{uuid}");
+        
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(Forbidden));
+        Assert.That(context.Database.GetScoreByUuid(uuid), Is.Not.Null);
+    }
+    
+    [Test]
+    public async Task DeletesIndividualScoreViaApi()
+    {
+        // Arrange
+        using TestContext context = this.GetServer();
+        
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user);
+        context.Database.SetUserRole(user, GameUserRole.Admin);
+        
+        GameSubmittedScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        string uuid = score.ScoreId.ToString();
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+        
+        // Act
+        HttpResponseMessage response = await client.DeleteAsync($"/api/v3/admin/scores/{uuid}");
+        
+        // Assert
+        Assert.That(response.StatusCode, Is.EqualTo(OK));
+        Assert.That(context.Database.GetScoreByUuid(uuid), Is.Null);
+    }
+    
+    [Test]
+    public void DeletesAllScoresByUser()
+    {
+        // Arrange
+        using TestContext context = this.GetServer();
+        
+        GameUser user = context.CreateUser();
+        GameLevel level1 = context.CreateLevel(user);
+        GameLevel level2 = context.CreateLevel(user);
+        
+        GameSubmittedScore score1 = context.SubmitScore(1, 1, level1, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameSubmittedScore score2 = context.SubmitScore(1, 1, level2, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        string uuid1 = score1.ScoreId.ToString();
+        string uuid2 = score2.ScoreId.ToString();
+        
+        // Act
+        context.Database.DeleteScoresSetByUser(user);
+        
+        // Assert
+        Assert.That(context.Database.GetScoreByUuid(uuid1), Is.Null);
+        Assert.That(context.Database.GetScoreByUuid(uuid2), Is.Null);
+    }
+}


### PR DESCRIPTION
Also allows quickly wiping every score set by a user in an incredibly inefficient way thanks to Realm.

Closes #145.