### PR TITLE
Shorten time frame required to be considered 'active' to 7 days

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -190,8 +190,8 @@ public partial class GameDatabaseContext // Users
     [Pure]
     public int GetActiveUserCount()
     {
-        DateTimeOffset lastMonth = this._time.Now.Subtract(TimeSpan.FromDays(30));
-        return this._realm.All<GameUser>().Count(u => u.LastLoginDate > lastMonth);
+        DateTimeOffset timeFrame = this._time.Now.Subtract(TimeSpan.FromDays(7));
+        return this._realm.All<GameUser>().Count(u => u.LastLoginDate > timeFrame);
     }
 
     public void UpdateUserPins(GameUser user, UserPins pinsUpdate) 


### PR DESCRIPTION
30 days seems to be too long; our server is [reporting 1043 active users](https://lbp.littlebigrefresh.com/api/v3/statistics) which is simply not even close to how many people are actually playing.

We'll see how well a week works.