### PR TITLE
Minimize calls to `this._realm` for source compatibility with Entity Framework

### DIFF
--- a/Refresh.GameServer/Database/Activity/GameDatabaseContext.Activity.cs
+++ b/Refresh.GameServer/Database/Activity/GameDatabaseContext.Activity.cs
@@ -41,7 +41,7 @@ public partial class GameDatabaseContext // Activity
         if (parameters.Timestamp == 0) 
             parameters.Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         
-        IEnumerable<Event> query = this._realm.All<Event>()
+        IEnumerable<Event> query = this.Events
             .Where(e => e.Timestamp < parameters.Timestamp && e.Timestamp >= parameters.EndTimestamp)
             .AsEnumerable();
 
@@ -91,5 +91,5 @@ public partial class GameDatabaseContext // Activity
             .OrderByDescending(e => e.Timestamp), parameters.Skip, parameters.Count);
     }
 
-    public int GetTotalEventCount() => this._realm.All<Event>().Count();
+    public int GetTotalEventCount() => this.Events.Count();
 }

--- a/Refresh.GameServer/Database/Activity/GameDatabaseContext.ActivityRead.cs
+++ b/Refresh.GameServer/Database/Activity/GameDatabaseContext.ActivityRead.cs
@@ -46,7 +46,7 @@ public partial class GameDatabaseContext // ActivityRead
 
         Debug.Assert(e.StoredObjectId != null);
 
-        return this._realm.All<RateLevelRelation>()
+        return this.RateLevelRelations
             .FirstOrDefault(l => l.RateLevelRelationId == e.StoredObjectId);
     }
 }

--- a/Refresh.GameServer/Database/Activity/GameDatabaseContext.ActivityWrite.cs
+++ b/Refresh.GameServer/Database/Activity/GameDatabaseContext.ActivityWrite.cs
@@ -22,7 +22,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -40,7 +40,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -58,7 +58,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -76,7 +76,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = user.UserId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -94,7 +94,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = user.UserId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -112,7 +112,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -130,7 +130,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -148,7 +148,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -166,7 +166,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = relation.RateLevelRelationId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -184,7 +184,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -202,7 +202,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = score.ScoreId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 
@@ -220,7 +220,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = user.UserId,
         };
 
-        this.Write(() => this._realm.Add(e));
+        this.Write(() => this.Events.Add(e));
         return e;
     }
 }

--- a/Refresh.GameServer/Database/Activity/GameDatabaseContext.ActivityWrite.cs
+++ b/Refresh.GameServer/Database/Activity/GameDatabaseContext.ActivityWrite.cs
@@ -22,7 +22,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -40,7 +40,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -58,7 +58,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -76,7 +76,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = user.UserId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -94,7 +94,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = user.UserId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -112,7 +112,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -130,7 +130,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -148,7 +148,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -166,7 +166,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = relation.RateLevelRelationId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -184,7 +184,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredSequentialId = level.LevelId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -202,7 +202,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = score.ScoreId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 
@@ -220,7 +220,7 @@ public partial class GameDatabaseContext // ActivityWrite
             StoredObjectId = user.UserId,
         };
 
-        this._realm.Write(() => this._realm.Add(e));
+        this.Write(() => this._realm.Add(e));
         return e;
     }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
@@ -8,13 +8,13 @@ public partial class GameDatabaseContext // AssetConfiguration
     {
         if (hash == "0" || hash.StartsWith('g')) return null;
         
-        return this._realm.All<GameAsset>()
+        return this.GameAssets
             .FirstOrDefault(a => a.AssetHash == hash);
     }
     
     public GameAssetType? GetConvertedType(string hash)
     {
-        IQueryable<GameAsset> assets = this._realm.All<GameAsset>();
+        IQueryable<GameAsset> assets = this.GameAssets;
         
         foreach (GameAsset asset in assets)
         {
@@ -32,7 +32,7 @@ public partial class GameDatabaseContext // AssetConfiguration
     }
 
     public IEnumerable<string> GetAssetDependencies(GameAsset asset) 
-        => this._realm.All<AssetDependencyRelation>().Where(a => a.Dependent == asset.AssetHash)
+        => this.AssetDependencyRelations.Where(a => a.Dependent == asset.AssetHash)
             .AsEnumerable()
             .Select(a => a.Dependency);
 
@@ -41,7 +41,7 @@ public partial class GameDatabaseContext // AssetConfiguration
         this.Write(() =>
         {
             // delete all existing relations. ensures duplicates won't exist when reprocessing
-            this._realm.RemoveRange(this._realm.All<AssetDependencyRelation>().Where(a => a.Dependent == dependent));
+            this._realm.RemoveRange(this.AssetDependencyRelations.Where(a => a.Dependent == dependent));
             
             foreach (string dependency in dependencies)
                 this._realm.Add(new AssetDependencyRelation
@@ -53,7 +53,7 @@ public partial class GameDatabaseContext // AssetConfiguration
     }
     
     public IEnumerable<GameAsset> GetAssetsByType(GameAssetType type) =>
-        this._realm.All<GameAsset>()
+        this.GameAssets
             .Where(a => a._AssetType == (int)type);
 
     public void AddAssetToDatabase(GameAsset asset) =>

--- a/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
@@ -38,7 +38,7 @@ public partial class GameDatabaseContext // AssetConfiguration
 
     public void AddOrOverwriteAssetDependencyRelations(string dependent, IEnumerable<string> dependencies)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             // delete all existing relations. ensures duplicates won't exist when reprocessing
             this._realm.RemoveRange(this._realm.All<AssetDependencyRelation>().Where(a => a.Dependent == dependent));
@@ -57,31 +57,31 @@ public partial class GameDatabaseContext // AssetConfiguration
             .Where(a => a._AssetType == (int)type);
 
     public void AddAssetToDatabase(GameAsset asset) =>
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(asset);
         });
 
     public void AddOrUpdateAssetsInDatabase(IEnumerable<GameAsset> assets) =>
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(assets, true);
         });
 
     public void SetMainlineIconHash(GameAsset asset, string hash) =>
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             asset.AsMainlineIconHash = hash;
         });
     
     public void SetMipIconHash(GameAsset asset, string hash) =>
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             asset.AsMipIconHash = hash;
         });
     
     public void SetMainlinePhotoHash(GameAsset asset, string hash) =>
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             asset.AsMainlinePhotoHash = hash;
         });

--- a/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
@@ -44,7 +44,7 @@ public partial class GameDatabaseContext // AssetConfiguration
             this._realm.RemoveRange(this.AssetDependencyRelations.Where(a => a.Dependent == dependent));
             
             foreach (string dependency in dependencies)
-                this._realm.Add(new AssetDependencyRelation
+                this.AssetDependencyRelations.Add(new AssetDependencyRelation
                 {
                     Dependent = dependent,
                     Dependency = dependency,
@@ -59,13 +59,13 @@ public partial class GameDatabaseContext // AssetConfiguration
     public void AddAssetToDatabase(GameAsset asset) =>
         this.Write(() =>
         {
-            this._realm.Add(asset);
+            this.GameAssets.Add(asset);
         });
 
     public void AddOrUpdateAssetsInDatabase(IEnumerable<GameAsset> assets) =>
         this.Write(() =>
         {
-            this._realm.Add(assets, true);
+            this.GameAssets.AddRange(assets, true);
         });
 
     public void SetMainlineIconHash(GameAsset asset, string hash) =>

--- a/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Assets.cs
@@ -41,7 +41,7 @@ public partial class GameDatabaseContext // AssetConfiguration
         this.Write(() =>
         {
             // delete all existing relations. ensures duplicates won't exist when reprocessing
-            this._realm.RemoveRange(this.AssetDependencyRelations.Where(a => a.Dependent == dependent));
+            this.AssetDependencyRelations.RemoveRange(this.AssetDependencyRelations.Where(a => a.Dependent == dependent));
             
             foreach (string dependency in dependencies)
                 this.AssetDependencyRelations.Add(new AssetDependencyRelation

--- a/Refresh.GameServer/Database/GameDatabaseContext.Comments.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Comments.cs
@@ -34,7 +34,7 @@ public partial class GameDatabaseContext // Comments
 
     public void DeleteProfileComment(GameComment comment, GameUser profile)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             profile.ProfileComments.Remove(comment);
         });
@@ -65,7 +65,7 @@ public partial class GameDatabaseContext // Comments
 
     public void DeleteLevelComment(GameComment comment, GameLevel level)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             level.LevelComments.Remove(comment);
         });

--- a/Refresh.GameServer/Database/GameDatabaseContext.Comments.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Comments.cs
@@ -8,7 +8,7 @@ namespace Refresh.GameServer.Database;
 public partial class GameDatabaseContext // Comments
 {
     public GameComment? GetCommentById(int id) =>
-        this._realm.All<GameComment>().FirstOrDefault(c => c.SequentialId == id);
+        this.GameComments.FirstOrDefault(c => c.SequentialId == id);
     public GameComment PostCommentToProfile(GameUser profile, GameUser author, string content)
     {
         GameComment comment = new()

--- a/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
@@ -19,7 +19,7 @@ public partial class GameDatabaseContext // Contests
         this.Write(() =>
         {
             contest.CreationDate = this._time.Now;
-            this._realm.Add(contest);
+            this.GameContests.Add(contest);
         });
     }
     

--- a/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
@@ -34,19 +34,19 @@ public partial class GameDatabaseContext // Contests
     public GameContest? GetContestById(string? id)
     {
         if (id == null) return null;
-        return this._realm.All<GameContest>().FirstOrDefault(c => c.ContestId == id);
+        return this.GameContests.FirstOrDefault(c => c.ContestId == id);
     }
     
     public IEnumerable<GameContest> GetAllContests()
     {
-        return this._realm.All<GameContest>()
+        return this.GameContests
             .OrderBy(c => c.CreationDate);
     }
     
     public GameContest? GetNewestActiveContest()
     {
         DateTimeOffset now = this._time.Now;
-        return this._realm.All<GameContest>()
+        return this.GameContests
             .Where(c => c.StartDate <= now && c.EndDate > now) // Filter active contests
             .OrderByDescending(c => c.CreationDate)
             .FirstOrDefault();

--- a/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
@@ -16,7 +16,7 @@ public partial class GameDatabaseContext // Contests
     {
         if (this.GetContestById(contest.ContestId) != null) throw new InvalidOperationException("Contest already exists.");
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             contest.CreationDate = this._time.Now;
             this._realm.Add(contest);
@@ -25,7 +25,7 @@ public partial class GameDatabaseContext // Contests
     
     public void DeleteContest(GameContest contest)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(contest);
         });
@@ -54,7 +54,7 @@ public partial class GameDatabaseContext // Contests
     
     public GameContest UpdateContest(ApiContestRequest body, GameContest contest, GameUser? newOrganizer = null)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             if (newOrganizer != null)
                 contest.Organizer = newOrganizer;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
@@ -27,7 +27,7 @@ public partial class GameDatabaseContext // Contests
     {
         this.Write(() =>
         {
-            this._realm.Remove(contest);
+            this.GameContests.Remove(contest);
         });
     }
     

--- a/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
@@ -26,7 +26,7 @@ public partial class GameDatabaseContext // Leaderboard
             Platform = platform,
         };
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(newScore);
         });
@@ -116,7 +116,7 @@ public partial class GameDatabaseContext // Leaderboard
         IQueryable<Event> scoreEvents = this._realm.All<Event>()
             .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.RemoveRange(scoreEvents);
             this._realm.Remove(score);
@@ -133,7 +133,7 @@ public partial class GameDatabaseContext // Leaderboard
             .AsEnumerable()
             .Where(s => s.Players.Contains(user));
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             foreach (GameSubmittedScore score in scores)
             {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
@@ -118,8 +118,8 @@ public partial class GameDatabaseContext // Leaderboard
         
         this.Write(() =>
         {
-            this._realm.RemoveRange(scoreEvents);
-            this._realm.Remove(score);
+            this.Events.RemoveRange(scoreEvents);
+            this.GameSubmittedScores.Remove(score);
         });
     }
     
@@ -140,8 +140,8 @@ public partial class GameDatabaseContext // Leaderboard
                 IQueryable<Event> scoreEvents = this.Events
                     .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
                 
-                this._realm.RemoveRange(scoreEvents);
-                this._realm.Remove(score);
+                this.Events.RemoveRange(scoreEvents);
+                this.GameSubmittedScores.Remove(score);
             }
         });
     }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
@@ -64,7 +64,7 @@ public partial class GameDatabaseContext // Leaderboard
 
     public DatabaseList<GameSubmittedScore> GetTopScoresForLevel(GameLevel level, int count, int skip, byte type, bool showDuplicates = false)
     {
-        IEnumerable<GameSubmittedScore> scores = this._realm.All<GameSubmittedScore>()
+        IEnumerable<GameSubmittedScore> scores = this.GameSubmittedScores
             .Where(s => s.ScoreType == type && s.Level == level)
             .OrderByDescending(s => s.Score)
             .AsEnumerable();
@@ -81,7 +81,7 @@ public partial class GameDatabaseContext // Leaderboard
         
         // this is probably REALLY fucking slow, and i probably shouldn't be trusted with LINQ anymore
 
-        List<GameSubmittedScore> scores = this._realm.All<GameSubmittedScore>().Where(s => s.ScoreType == score.ScoreType && s.Level == score.Level)
+        List<GameSubmittedScore> scores = this.GameSubmittedScores.Where(s => s.ScoreType == score.ScoreType && s.Level == score.Level)
             .OrderByDescending(s => s.Score)
             .AsEnumerable()
             .ToList();
@@ -100,7 +100,7 @@ public partial class GameDatabaseContext // Leaderboard
     {
         if (uuid == null) return null;
         if(!ObjectId.TryParse(uuid, out ObjectId objectId)) return null;
-        return this._realm.All<GameSubmittedScore>().FirstOrDefault(u => u.ScoreId == objectId);
+        return this.GameSubmittedScores.FirstOrDefault(u => u.ScoreId == objectId);
     }
     
     [Pure]
@@ -108,12 +108,12 @@ public partial class GameDatabaseContext // Leaderboard
     public GameSubmittedScore? GetScoreByObjectId(ObjectId? id)
     {
         if (id == null) return null;
-        return this._realm.All<GameSubmittedScore>().FirstOrDefault(u => u.ScoreId == id);
+        return this.GameSubmittedScores.FirstOrDefault(u => u.ScoreId == id);
     }
     
     public void DeleteScore(GameSubmittedScore score)
     {
-        IQueryable<Event> scoreEvents = this._realm.All<Event>()
+        IQueryable<Event> scoreEvents = this.Events
             .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
         
         this.Write(() =>
@@ -125,7 +125,7 @@ public partial class GameDatabaseContext // Leaderboard
     
     public void DeleteScoresSetByUser(GameUser user)
     {
-        IEnumerable<GameSubmittedScore> scores = this._realm.All<GameSubmittedScore>()
+        IEnumerable<GameSubmittedScore> scores = this.GameSubmittedScores
             // FIXME: Realm (ahem, I mean the atlas device sdk *rolls eyes*) is a fucking joke.
             // Realm doesn't support .Contains on IList<T>. Yes, really.
             // This means we are forced to iterate over EVERY SCORE.
@@ -137,7 +137,7 @@ public partial class GameDatabaseContext // Leaderboard
         {
             foreach (GameSubmittedScore score in scores)
             {
-                IQueryable<Event> scoreEvents = this._realm.All<Event>()
+                IQueryable<Event> scoreEvents = this.Events
                     .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
                 
                 this._realm.RemoveRange(scoreEvents);

--- a/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Leaderboard.cs
@@ -28,7 +28,7 @@ public partial class GameDatabaseContext // Leaderboard
 
         this.Write(() =>
         {
-            this._realm.Add(newScore);
+            this.GameSubmittedScores.Add(newScore);
         });
 
         this.CreateLevelScoreEvent(user, newScore);

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -125,24 +125,24 @@ public partial class GameDatabaseContext // Levels
             IQueryable<Event> levelEvents = this.Events
                 .Where(e => e._StoredDataType == (int)EventDataType.Level && e.StoredSequentialId == level.LevelId);
             
-            this._realm.RemoveRange(levelEvents);
+            this.Events.RemoveRange(levelEvents);
 
             #region This is so terrible it needs to be hidden away
 
             IQueryable<FavouriteLevelRelation> favouriteLevelRelations = this.FavouriteLevelRelations.Where(r => r.Level == level);
-            this._realm.RemoveRange(favouriteLevelRelations);
+            this.FavouriteLevelRelations.RemoveRange(favouriteLevelRelations);
             
             IQueryable<PlayLevelRelation> playLevelRelations = this.PlayLevelRelations.Where(r => r.Level == level);
-            this._realm.RemoveRange(playLevelRelations);
+            this.PlayLevelRelations.RemoveRange(playLevelRelations);
             
             IQueryable<QueueLevelRelation> queueLevelRelations = this.QueueLevelRelations.Where(r => r.Level == level);
-            this._realm.RemoveRange(queueLevelRelations);
+            this.QueueLevelRelations.RemoveRange(queueLevelRelations);
             
             IQueryable<RateLevelRelation> rateLevelRelations = this.RateLevelRelations.Where(r => r.Level == level);
-            this._realm.RemoveRange(rateLevelRelations);
+            this.RateLevelRelations.RemoveRange(rateLevelRelations);
             
             IQueryable<UniquePlayLevelRelation> uniquePlayLevelRelations = this.UniquePlayLevelRelations.Where(r => r.Level == level);
-            this._realm.RemoveRange(uniquePlayLevelRelations);
+            this.UniquePlayLevelRelations.RemoveRange(uniquePlayLevelRelations);
             
             IQueryable<GameSubmittedScore> scores = this.GameSubmittedScores.Where(r => r.Level == level);
             
@@ -150,10 +150,10 @@ public partial class GameDatabaseContext // Levels
             {
                 IQueryable<Event> scoreEvents = this.Events
                     .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
-                this._realm.RemoveRange(scoreEvents);
+                this.Events.RemoveRange(scoreEvents);
             }
             
-            this._realm.RemoveRange(scores);
+            this.GameSubmittedScores.RemoveRange(scores);
 
             #endregion
             
@@ -162,7 +162,7 @@ public partial class GameDatabaseContext // Levels
         //do in separate transaction in a vain attempt to fix Weirdness with favourite level relations having missing levels
         this.Write(() =>
         {
-            this._realm.Remove(level);
+            this.GameLevels.Remove(level);
         });
     }
 

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -33,7 +33,7 @@ public partial class GameDatabaseContext // Levels
 
     public GameLevel GetStoryLevelById(int id)
     {
-        GameLevel? level = this._realm.All<GameLevel>().FirstOrDefault(l => l.StoryId == id);
+        GameLevel? level = this.GameLevels.FirstOrDefault(l => l.StoryId == id);
 
         if (level != null) return level;
         
@@ -122,33 +122,33 @@ public partial class GameDatabaseContext // Levels
     {
         this.Write(() =>
         {
-            IQueryable<Event> levelEvents = this._realm.All<Event>()
+            IQueryable<Event> levelEvents = this.Events
                 .Where(e => e._StoredDataType == (int)EventDataType.Level && e.StoredSequentialId == level.LevelId);
             
             this._realm.RemoveRange(levelEvents);
 
             #region This is so terrible it needs to be hidden away
 
-            IQueryable<FavouriteLevelRelation> favouriteLevelRelations = this._realm.All<FavouriteLevelRelation>().Where(r => r.Level == level);
+            IQueryable<FavouriteLevelRelation> favouriteLevelRelations = this.FavouriteLevelRelations.Where(r => r.Level == level);
             this._realm.RemoveRange(favouriteLevelRelations);
             
-            IQueryable<PlayLevelRelation> playLevelRelations = this._realm.All<PlayLevelRelation>().Where(r => r.Level == level);
+            IQueryable<PlayLevelRelation> playLevelRelations = this.PlayLevelRelations.Where(r => r.Level == level);
             this._realm.RemoveRange(playLevelRelations);
             
-            IQueryable<QueueLevelRelation> queueLevelRelations = this._realm.All<QueueLevelRelation>().Where(r => r.Level == level);
+            IQueryable<QueueLevelRelation> queueLevelRelations = this.QueueLevelRelations.Where(r => r.Level == level);
             this._realm.RemoveRange(queueLevelRelations);
             
-            IQueryable<RateLevelRelation> rateLevelRelations = this._realm.All<RateLevelRelation>().Where(r => r.Level == level);
+            IQueryable<RateLevelRelation> rateLevelRelations = this.RateLevelRelations.Where(r => r.Level == level);
             this._realm.RemoveRange(rateLevelRelations);
             
-            IQueryable<UniquePlayLevelRelation> uniquePlayLevelRelations = this._realm.All<UniquePlayLevelRelation>().Where(r => r.Level == level);
+            IQueryable<UniquePlayLevelRelation> uniquePlayLevelRelations = this.UniquePlayLevelRelations.Where(r => r.Level == level);
             this._realm.RemoveRange(uniquePlayLevelRelations);
             
-            IQueryable<GameSubmittedScore> scores = this._realm.All<GameSubmittedScore>().Where(r => r.Level == level);
+            IQueryable<GameSubmittedScore> scores = this.GameSubmittedScores.Where(r => r.Level == level);
             
             foreach (GameSubmittedScore score in scores)
             {
-                IQueryable<Event> scoreEvents = this._realm.All<Event>()
+                IQueryable<Event> scoreEvents = this.Events
                     .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
                 this._realm.RemoveRange(scoreEvents);
             }
@@ -167,7 +167,7 @@ public partial class GameDatabaseContext // Levels
     }
 
     private IQueryable<GameLevel> GetLevelsByGameVersion(TokenGame gameVersion) 
-        => this._realm.All<GameLevel>().Where(l => l._Source == (int)GameLevelSource.User).FilterByGameVersion(gameVersion);
+        => this.GameLevels.Where(l => l._Source == (int)GameLevelSource.User).FilterByGameVersion(gameVersion);
 
     [Pure]
     public DatabaseList<GameLevel> GetLevelsByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor)
@@ -191,11 +191,11 @@ public partial class GameDatabaseContext // Levels
         return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.Publisher == user), skip, count);
     }
     
-    public int GetTotalLevelsByUser(GameUser user) => this._realm.All<GameLevel>().Count(l => l.Publisher == user);
+    public int GetTotalLevelsByUser(GameUser user) => this.GameLevels.Count(l => l.Publisher == user);
     
     [Pure]
     public DatabaseList<GameLevel> GetUserLevelsChunk(int skip, int count)
-        => new(this._realm.All<GameLevel>().Where(l => l._Source == (int)GameLevelSource.User), skip, count);
+        => new(this.GameLevels.Where(l => l._Source == (int)GameLevelSource.User), skip, count);
 
     [Pure]
     public DatabaseList<GameLevel> GetNewestLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings) =>
@@ -218,7 +218,7 @@ public partial class GameDatabaseContext // Levels
     [Pure]
     public DatabaseList<GameLevel> GetMostHeartedLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings)
     {
-        IQueryable<FavouriteLevelRelation> favourites = this._realm.All<FavouriteLevelRelation>();
+        IQueryable<FavouriteLevelRelation> favourites = this.FavouriteLevelRelations;
         
         IEnumerable<GameLevel> mostHeartedLevels = favourites
             .AsEnumerable()
@@ -237,7 +237,7 @@ public partial class GameDatabaseContext // Levels
     [Pure]
     public DatabaseList<GameLevel> GetMostUniquelyPlayedLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings)
     {
-        IQueryable<UniquePlayLevelRelation> uniquePlays = this._realm.All<UniquePlayLevelRelation>();
+        IQueryable<UniquePlayLevelRelation> uniquePlays = this.UniquePlayLevelRelations;
         
         IEnumerable<GameLevel> mostPlayed = uniquePlays
             .AsEnumerable()
@@ -256,7 +256,7 @@ public partial class GameDatabaseContext // Levels
     [Pure]
     public DatabaseList<GameLevel> GetMostReplayedLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings)
     {
-        IQueryable<PlayLevelRelation> plays = this._realm.All<PlayLevelRelation>();
+        IQueryable<PlayLevelRelation> plays = this.PlayLevelRelations;
         
         IEnumerable<GameLevel> mostPlayed = plays
             .AsEnumerable()
@@ -274,7 +274,7 @@ public partial class GameDatabaseContext // Levels
     [Pure]
     public DatabaseList<GameLevel> GetHighestRatedLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings)
     {
-        IQueryable<RateLevelRelation> ratings = this._realm.All<RateLevelRelation>();
+        IQueryable<RateLevelRelation> ratings = this.RateLevelRelations;
         
         IEnumerable<GameLevel> highestRated = ratings
             .AsEnumerable()
@@ -299,7 +299,7 @@ public partial class GameDatabaseContext // Levels
 
     [Pure]
     public DatabaseList<GameLevel> GetDeveloperLevels(int count, int skip, LevelFilterSettings levelFilterSettings) =>
-        new(this._realm.All<GameLevel>()
+        new(this.GameLevels
             .Where(l => l._Source == (int)GameLevelSource.Story)
             .FilterByLevelFilterSettings(null, levelFilterSettings)
             .OrderByDescending(l => l.Title), skip, count);
@@ -359,21 +359,21 @@ public partial class GameDatabaseContext // Levels
     }
 
     [Pure]
-    public int GetTotalLevelCount(TokenGame game) => this._realm.All<GameLevel>().FilterByGameVersion(game).Count(l => l._Source == (int)GameLevelSource.User);
+    public int GetTotalLevelCount(TokenGame game) => this.GameLevels.FilterByGameVersion(game).Count(l => l._Source == (int)GameLevelSource.User);
     
     [Pure]
-    public int GetTotalLevelCount() => this._realm.All<GameLevel>().Count(l => l._Source == (int)GameLevelSource.User);
+    public int GetTotalLevelCount() => this.GameLevels.Count(l => l._Source == (int)GameLevelSource.User);
     
     public int GetTotalLevelsPublishedByUser(GameUser user)
-        => this._realm.All<GameLevel>()
+        => this.GameLevels
             .Count(r => r.Publisher == user);
     
     public int GetTotalLevelsPublishedByUser(GameUser user, TokenGame game)
-        => this._realm.All<GameLevel>()
+        => this.GameLevels
             .Count(r => r._GameVersion == (int)game);
     
     [Pure]
-    public int GetTotalTeamPickCount(TokenGame game) => this._realm.All<GameLevel>().FilterByGameVersion(game).Count(l => l.TeamPicked);
+    public int GetTotalTeamPickCount(TokenGame game) => this.GameLevels.FilterByGameVersion(game).Count(l => l.TeamPicked);
 
     [Pure]
     public GameLevel? GetLevelByIdAndType(string slotType, int id)
@@ -393,7 +393,7 @@ public partial class GameDatabaseContext // Levels
     }
     
     [Pure]
-    public GameLevel? GetLevelById(int id) => this._realm.All<GameLevel>().FirstOrDefault(l => l.LevelId == id);
+    public GameLevel? GetLevelById(int id) => this.GameLevels.FirstOrDefault(l => l.LevelId == id);
 
     private void SetLevelPickStatus(GameLevel level, bool status)
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -81,7 +81,7 @@ public partial class GameDatabaseContext // Levels
         // Now newLevel is set up to replace oldLevel.
         // If information is lost here, then that's probably a bug.
         // Update the level's properties in the database
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             PropertyInfo[] userProps = typeof(GameLevel).GetProperties();
             foreach (PropertyInfo prop in userProps)
@@ -96,7 +96,7 @@ public partial class GameDatabaseContext // Levels
 
     public GameLevel UpdateLevel(ApiEditLevelRequest body, GameLevel level)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             PropertyInfo[] userProps = body.GetType().GetProperties();
             foreach (PropertyInfo prop in userProps)
@@ -120,7 +120,7 @@ public partial class GameDatabaseContext // Levels
 
     public void DeleteLevel(GameLevel level)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             IQueryable<Event> levelEvents = this._realm.All<Event>()
                 .Where(e => e._StoredDataType == (int)EventDataType.Level && e.StoredSequentialId == level.LevelId);
@@ -160,7 +160,7 @@ public partial class GameDatabaseContext // Levels
         });
 
         //do in separate transaction in a vain attempt to fix Weirdness with favourite level relations having missing levels
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(level);
         });
@@ -397,7 +397,7 @@ public partial class GameDatabaseContext // Levels
 
     private void SetLevelPickStatus(GameLevel level, bool status)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             level.TeamPicked = status;
         });
@@ -408,7 +408,7 @@ public partial class GameDatabaseContext // Levels
 
     public void SetLevelScores(Dictionary<GameLevel, float> scoresToSet)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             foreach ((GameLevel level, float score) in scoresToSet)
             {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
@@ -21,7 +21,7 @@ public partial class GameDatabaseContext // Notifications
             CreatedAt = this._time.Now,
         };
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(notification);
         });
@@ -59,7 +59,7 @@ public partial class GameDatabaseContext // Notifications
     
     public void DeleteNotificationsByUser(GameUser user)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.RemoveRange(this._realm.All<GameNotification>().Where(n => n.User == user));
         });
@@ -67,7 +67,7 @@ public partial class GameDatabaseContext // Notifications
     
     public void DeleteNotification(GameNotification notification)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(notification);
         });
@@ -87,7 +87,7 @@ public partial class GameDatabaseContext // Notifications
             CreatedAt = this._time.Now,
         };
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(announcement);
         });
@@ -97,7 +97,7 @@ public partial class GameDatabaseContext // Notifications
     
     public void DeleteAnnouncement(GameAnnouncement announcement)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(announcement);
         });

--- a/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
@@ -44,12 +44,12 @@ public partial class GameDatabaseContext // Notifications
 
     [Pure]
     public int GetNotificationCountByUser(GameUser user) => 
-        this._realm.All<GameNotification>()
+        this.GameNotifications
             .Count(n => n.User == user);
     
     [Pure]
     public DatabaseList<GameNotification> GetNotificationsByUser(GameUser user, int count, int skip) =>
-        new(this._realm.All<GameNotification>().Where(n => n.User == user), skip, count);
+        new(this.GameNotifications.Where(n => n.User == user), skip, count);
 
     [Pure]
     public GameNotification? GetNotificationByUuid(GameUser user, ObjectId id) 
@@ -61,7 +61,7 @@ public partial class GameDatabaseContext // Notifications
     {
         this.Write(() =>
         {
-            this._realm.RemoveRange(this._realm.All<GameNotification>().Where(n => n.User == user));
+            this._realm.RemoveRange(this.GameNotifications.Where(n => n.User == user));
         });
     }
     
@@ -73,9 +73,9 @@ public partial class GameDatabaseContext // Notifications
         });
     }
 
-    public IEnumerable<GameAnnouncement> GetAnnouncements() => this._realm.All<GameAnnouncement>();
+    public IEnumerable<GameAnnouncement> GetAnnouncements() => this.GameAnnouncements;
     
-    public GameAnnouncement? GetAnnouncementById(ObjectId id) => this._realm.All<GameAnnouncement>().FirstOrDefault(a => a.AnnouncementId == id);
+    public GameAnnouncement? GetAnnouncementById(ObjectId id) => this.GameAnnouncements.FirstOrDefault(a => a.AnnouncementId == id);
     
     public GameAnnouncement AddAnnouncement(string title, string text)
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
@@ -53,8 +53,7 @@ public partial class GameDatabaseContext // Notifications
 
     [Pure]
     public GameNotification? GetNotificationByUuid(GameUser user, ObjectId id) 
-        => this._realm
-            .All<GameNotification>()
+        => this.GameNotifications
             .FirstOrDefault(n => n.User == user && n.NotificationId == id);
     
     public void DeleteNotificationsByUser(GameUser user)

--- a/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
@@ -60,7 +60,7 @@ public partial class GameDatabaseContext // Notifications
     {
         this.Write(() =>
         {
-            this._realm.RemoveRange(this.GameNotifications.Where(n => n.User == user));
+            this.GameNotifications.RemoveRange(this.GameNotifications.Where(n => n.User == user));
         });
     }
     
@@ -68,7 +68,7 @@ public partial class GameDatabaseContext // Notifications
     {
         this.Write(() =>
         {
-            this._realm.Remove(notification);
+            this.GameNotifications.Remove(notification);
         });
     }
 
@@ -98,7 +98,7 @@ public partial class GameDatabaseContext // Notifications
     {
         this.Write(() =>
         {
-            this._realm.Remove(announcement);
+            this.GameAnnouncements.Remove(announcement);
         });
     }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
@@ -23,7 +23,7 @@ public partial class GameDatabaseContext // Notifications
 
         this.Write(() =>
         {
-            this._realm.Add(notification);
+            this.GameNotifications.Add(notification);
         });
     }
 
@@ -89,7 +89,7 @@ public partial class GameDatabaseContext // Notifications
         
         this.Write(() =>
         {
-            this._realm.Add(announcement);
+            this.GameAnnouncements.Add(announcement);
         });
 
         return announcement;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -56,7 +56,7 @@ public partial class GameDatabaseContext // Photos
     {
         this.Write(() =>
         {
-            this._realm.Remove(photo);
+            this.GamePhotos.Remove(photo);
         });
     }
 

--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -60,30 +60,30 @@ public partial class GameDatabaseContext // Photos
         });
     }
 
-    public int GetTotalPhotoCount() => this._realm.All<GamePhoto>().Count();
+    public int GetTotalPhotoCount() => this.GamePhotos.Count();
     
     [Pure]
     public DatabaseList<GamePhoto> GetRecentPhotos(int count, int skip) =>
-        new(this._realm.All<GamePhoto>()
+        new(this.GamePhotos
             .OrderByDescending(p => p.PublishedAt), skip, count);
 
     [Pure]
     public GamePhoto? GetPhotoById(int id) =>
-        this._realm.All<GamePhoto>().FirstOrDefault(p => p.PhotoId == id);
+        this.GamePhotos.FirstOrDefault(p => p.PhotoId == id);
 
     [Pure]
     public DatabaseList<GamePhoto> GetPhotosByUser(GameUser user, int count, int skip) =>
-        new(this._realm.All<GamePhoto>().Where(p => p.Publisher == user)
+        new(this.GamePhotos.Where(p => p.Publisher == user)
             .OrderByDescending(p => p.TakenAt), skip, count);
     
     [Pure]
     public int GetTotalPhotosByUser(GameUser user)
-        => this._realm.All<GamePhoto>()
+        => this.GamePhotos
             .Count(p => p.Publisher == user);
 
     [Pure]
     public DatabaseList<GamePhoto> GetPhotosWithUser(GameUser user, int count, int skip) =>
-        new(this._realm.All<GamePhoto>()
+        new(this.GamePhotos
             // FIXME: client-side enumeration
             .AsEnumerable()
             .Where(p => p.Subjects.FirstOrDefault(s => Equals(s.User, user)) != null)
@@ -93,16 +93,16 @@ public partial class GameDatabaseContext // Photos
     
     [Pure]
     public int GetTotalPhotosWithUser(GameUser user)
-        => this._realm.All<GamePhoto>()
+        => this.GamePhotos
             // FIXME: client-side enumeration
             .AsEnumerable()
             .Count(p => p.Subjects.FirstOrDefault(s => Equals(s.User, user)) != null);
 
     [Pure]
     public DatabaseList<GamePhoto> GetPhotosInLevel(GameLevel level, int count, int skip) =>
-        new(this._realm.All<GamePhoto>().Where(p => p.LevelId == level.LevelId), skip, count);
+        new(this.GamePhotos.Where(p => p.LevelId == level.LevelId), skip, count);
     
     [Pure]
     public int GetTotalPhotosInLevel(GameLevel level)
-        => this._realm.All<GamePhoto>().Count(p => p.LevelId == level.LevelId);
+        => this.GamePhotos.Count(p => p.LevelId == level.LevelId);
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -54,7 +54,7 @@ public partial class GameDatabaseContext // Photos
 
     public void RemovePhoto(GamePhoto photo)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(photo);
         });

--- a/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
@@ -198,7 +198,7 @@ public partial class GameDatabaseContext // Registration
     
     public bool DisallowUser(string username)
     {
-        if (this._realm.Find<DisallowedUser>(username) != null) 
+        if (this.DisallowedUsers.FirstOrDefault(u => u.Username == username) != null) 
             return false;
         
         this.Write(() =>
@@ -214,7 +214,7 @@ public partial class GameDatabaseContext // Registration
     
     public bool ReallowUser(string username)
     {
-        DisallowedUser? disallowedUser = this._realm.Find<DisallowedUser>(username);
+        DisallowedUser? disallowedUser = this.DisallowedUsers.FirstOrDefault(u => u.Username == username);
         if (disallowedUser == null) 
             return false;
         
@@ -228,6 +228,6 @@ public partial class GameDatabaseContext // Registration
     
     public bool IsUserDisallowed(string username)
     {
-        return this._realm.Find<DisallowedUser>(username) != null;
+        return this.DisallowedUsers.FirstOrDefault(u => u.Username == username) != null;
     }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
@@ -81,14 +81,14 @@ public partial class GameDatabaseContext // Registration
 
     public bool IsUsernameTaken(string username)
     {
-        return this._realm.All<GameUser>().Any(u => u.Username == username) ||
-               this._realm.All<QueuedRegistration>().Any(r => r.Username == username);
+        return this.GameUsers.Any(u => u.Username == username) ||
+               this.QueuedRegistrations.Any(r => r.Username == username);
     }
     
     public bool IsEmailTaken(string emailAddress)
     {
-        return this._realm.All<GameUser>().Any(u => u.EmailAddress == emailAddress) ||
-               this._realm.All<QueuedRegistration>().Any(r => r.EmailAddress == emailAddress);
+        return this.GameUsers.Any(u => u.EmailAddress == emailAddress) ||
+               this.QueuedRegistrations.Any(r => r.EmailAddress == emailAddress);
     }
 
     public void AddRegistrationToQueue(string username, string emailAddress, string passwordBcrypt)
@@ -132,30 +132,30 @@ public partial class GameDatabaseContext // Registration
     public bool IsRegistrationExpired(QueuedRegistration registration) => registration.ExpiryDate < this._time.Now;
 
     public QueuedRegistration? GetQueuedRegistrationByUsername(string username) 
-        => this._realm.All<QueuedRegistration>().FirstOrDefault(q => q.Username == username);
+        => this.QueuedRegistrations.FirstOrDefault(q => q.Username == username);
     
     public QueuedRegistration? GetQueuedRegistrationByObjectId(ObjectId id) 
-        => this._realm.All<QueuedRegistration>().FirstOrDefault(q => q.RegistrationId == id);
+        => this.QueuedRegistrations.FirstOrDefault(q => q.RegistrationId == id);
     
 
     public DatabaseList<QueuedRegistration> GetAllQueuedRegistrations()
-        => new(this._realm.All<QueuedRegistration>());
+        => new(this.QueuedRegistrations);
     
     public DatabaseList<EmailVerificationCode> GetAllVerificationCodes()
-        => new(this._realm.All<EmailVerificationCode>());
+        => new(this.EmailVerificationCodes);
     
     public void VerifyUserEmail(GameUser user)
     {
         this.Write(() =>
         {
             user.EmailAddressVerified = true;
-            this._realm.RemoveRange(this._realm.All<EmailVerificationCode>()
+            this._realm.RemoveRange(this.EmailVerificationCodes
                 .Where(c => c.User == user));
         });
     }
 
     public bool VerificationCodeMatches(GameUser user, string code) => 
-        this._realm.All<EmailVerificationCode>().Any(c => c.User == user && c.Code == code);
+        this.EmailVerificationCodes.Any(c => c.User == user && c.Code == code);
     
     public bool IsVerificationCodeExpired(EmailVerificationCode code) => code.ExpiryDate < this._time.Now;
 

--- a/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
@@ -36,7 +36,7 @@ public partial class GameDatabaseContext // Registration
 
         this.Write(() =>
         {
-            this._realm.Add(user);
+            this.GameUsers.Add(user);
         });
         return user;
     }
@@ -109,7 +109,7 @@ public partial class GameDatabaseContext // Registration
 
         this.Write(() =>
         {
-            this._realm.Add(registration);
+            this.QueuedRegistrations.Add(registration);
         });
     }
 
@@ -188,7 +188,7 @@ public partial class GameDatabaseContext // Registration
 
         this.Write(() =>
         {
-            this._realm.Add(verificationCode);
+            this.EmailVerificationCodes.Add(verificationCode);
         });
 
         return verificationCode;
@@ -209,7 +209,7 @@ public partial class GameDatabaseContext // Registration
         
         this.Write(() =>
         {
-            this._realm.Add(new DisallowedUser
+            this.DisallowedUsers.Add(new DisallowedUser
             {
                 Username = username,
             });

--- a/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
@@ -34,7 +34,7 @@ public partial class GameDatabaseContext // Registration
             JoinDate = this._time.Now,
         };
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(user);
         });
@@ -45,7 +45,7 @@ public partial class GameDatabaseContext // Registration
     {
         QueuedRegistration cloned = (QueuedRegistration)registration.Clone();
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(registration);
         });
@@ -55,7 +55,7 @@ public partial class GameDatabaseContext // Registration
 
         if (platform != null)
         {
-            this._realm.Write(() =>
+            this.Write(() =>
             {
                 // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault
                 switch (platform)
@@ -107,7 +107,7 @@ public partial class GameDatabaseContext // Registration
             ExpiryDate = this._time.Now + TimeSpan.FromHours(1),
         };
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(registration);
         });
@@ -115,7 +115,7 @@ public partial class GameDatabaseContext // Registration
 
     public void RemoveRegistrationFromQueue(QueuedRegistration registration)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(registration);
         });
@@ -123,7 +123,7 @@ public partial class GameDatabaseContext // Registration
     
     public void RemoveAllRegistrationsFromQueue()
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.RemoveAll<QueuedRegistration>();
         });
@@ -146,7 +146,7 @@ public partial class GameDatabaseContext // Registration
     
     public void VerifyUserEmail(GameUser user)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.EmailAddressVerified = true;
             this._realm.RemoveRange(this._realm.All<EmailVerificationCode>()
@@ -186,7 +186,7 @@ public partial class GameDatabaseContext // Registration
             ExpiryDate = this._time.Now + TimeSpan.FromDays(1),
         };
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(verificationCode);
         });
@@ -196,7 +196,7 @@ public partial class GameDatabaseContext // Registration
 
     public void RemoveEmailVerificationCode(EmailVerificationCode code)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(code);
         });
@@ -207,7 +207,7 @@ public partial class GameDatabaseContext // Registration
         if (this._realm.Find<DisallowedUser>(username) != null) 
             return false;
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(new DisallowedUser
             {
@@ -224,7 +224,7 @@ public partial class GameDatabaseContext // Registration
         if (disallowedUser == null) 
             return false;
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(disallowedUser);
         });

--- a/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Registration.cs
@@ -47,7 +47,7 @@ public partial class GameDatabaseContext // Registration
 
         this.Write(() =>
         {
-            this._realm.Remove(registration);
+            this.QueuedRegistrations.Remove(registration);
         });
 
         GameUser user = this.CreateUser(cloned.Username, cloned.EmailAddress);
@@ -117,18 +117,12 @@ public partial class GameDatabaseContext // Registration
     {
         this.Write(() =>
         {
-            this._realm.Remove(registration);
+            this.QueuedRegistrations.Remove(registration);
         });
     }
     
-    public void RemoveAllRegistrationsFromQueue()
-    {
-        this.Write(() =>
-        {
-            this._realm.RemoveAll<QueuedRegistration>();
-        });
-    }
-    
+    public void RemoveAllRegistrationsFromQueue() => this.Write(this.RemoveAll<QueuedRegistration>);
+
     public bool IsRegistrationExpired(QueuedRegistration registration) => registration.ExpiryDate < this._time.Now;
 
     public QueuedRegistration? GetQueuedRegistrationByUsername(string username) 
@@ -149,7 +143,7 @@ public partial class GameDatabaseContext // Registration
         this.Write(() =>
         {
             user.EmailAddressVerified = true;
-            this._realm.RemoveRange(this.EmailVerificationCodes
+            this.EmailVerificationCodes.RemoveRange(this.EmailVerificationCodes
                 .Where(c => c.User == user));
         });
     }
@@ -198,7 +192,7 @@ public partial class GameDatabaseContext // Registration
     {
         this.Write(() =>
         {
-            this._realm.Remove(code);
+            this.EmailVerificationCodes.Remove(code);
         });
     }
     
@@ -226,7 +220,7 @@ public partial class GameDatabaseContext // Registration
         
         this.Write(() =>
         {
-            this._realm.Remove(disallowedUser);
+            this.DisallowedUsers.Remove(disallowedUser);
         });
         
         return true;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -14,12 +14,12 @@ public partial class GameDatabaseContext // Relations
 {
     #region Favouriting Levels
     [Pure]
-    private bool IsLevelFavouritedByUser(GameLevel level, GameUser user) => this._realm.All<FavouriteLevelRelation>()
+    private bool IsLevelFavouritedByUser(GameLevel level, GameUser user) => this.FavouriteLevelRelations
         .FirstOrDefault(r => r.Level == level && r.User == user) != null;
 
     [Pure]
     public DatabaseList<GameLevel> GetLevelsFavouritedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor) 
-        => new(this._realm.All<FavouriteLevelRelation>()
+        => new(this.FavouriteLevelRelations
         .Where(r => r.User == user)
         .AsEnumerable()
         .Select(r => r.Level)
@@ -27,7 +27,7 @@ public partial class GameDatabaseContext // Relations
         .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     
     public int GetTotalLevelsFavouritedByUser(GameUser user) 
-        => this._realm.All<FavouriteLevelRelation>()
+        => this.FavouriteLevelRelations
             .Count(r => r.User == user);
     
     public bool FavouriteLevel(GameLevel level, GameUser user)
@@ -48,7 +48,7 @@ public partial class GameDatabaseContext // Relations
     
     public bool UnfavouriteLevel(GameLevel level, GameUser user)
     {
-        FavouriteLevelRelation? relation = this._realm.All<FavouriteLevelRelation>()
+        FavouriteLevelRelation? relation = this.FavouriteLevelRelations
             .FirstOrDefault(r => r.Level == level && r.User == user);
 
         if (relation == null) return false;
@@ -62,7 +62,7 @@ public partial class GameDatabaseContext // Relations
     #region Favouriting Users
 
     [Pure]
-    private bool IsUserFavouritedByUser(GameUser userToFavourite, GameUser userFavouriting) => this._realm.All<FavouriteUserRelation>()
+    private bool IsUserFavouritedByUser(GameUser userToFavourite, GameUser userFavouriting) => this.FavouriteUserRelations
         .FirstOrDefault(r => r.UserToFavourite == userToFavourite && r.UserFavouriting == userFavouriting) != null;
 
     [Pure]
@@ -78,7 +78,7 @@ public partial class GameDatabaseContext // Relations
     }
     
     [Pure]
-    public IEnumerable<GameUser> GetUsersFavouritedByUser(GameUser user, int count, int skip) => this._realm.All<FavouriteUserRelation>()
+    public IEnumerable<GameUser> GetUsersFavouritedByUser(GameUser user, int count, int skip) => this.FavouriteUserRelations
         .Where(r => r.UserFavouriting == user)
         .AsEnumerable()
         .Select(r => r.UserToFavourite)
@@ -86,11 +86,11 @@ public partial class GameDatabaseContext // Relations
         .Take(count);
     
     public int GetTotalUsersFavouritedByUser(GameUser user)
-        => this._realm.All<FavouriteUserRelation>()
+        => this.FavouriteUserRelations
             .Count(r => r.UserFavouriting == user);
     
     public int GetTotalUsersFavouritingUser(GameUser user)
-        => this._realm.All<FavouriteUserRelation>()
+        => this.FavouriteUserRelations
             .Count(r => r.UserToFavourite == user);
 
     public bool FavouriteUser(GameUser userToFavourite, GameUser userFavouriting)
@@ -122,7 +122,7 @@ public partial class GameDatabaseContext // Relations
 
     public bool UnfavouriteUser(GameUser userToFavourite, GameUser userFavouriting)
     {
-        FavouriteUserRelation? relation = this._realm.All<FavouriteUserRelation>()
+        FavouriteUserRelation? relation = this.FavouriteUserRelations
             .FirstOrDefault(r => r.UserToFavourite == userToFavourite && r.UserFavouriting == userFavouriting);
 
         if (relation == null) return false;
@@ -136,12 +136,12 @@ public partial class GameDatabaseContext // Relations
 
     #region Queueing
     [Pure]
-    private bool IsLevelQueuedByUser(GameLevel level, GameUser user) => this._realm.All<QueueLevelRelation>()
+    private bool IsLevelQueuedByUser(GameLevel level, GameUser user) => this.QueueLevelRelations
         .FirstOrDefault(r => r.Level == level && r.User == user) != null;
 
     [Pure]
     public DatabaseList<GameLevel> GetLevelsQueuedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor)
-        => new(this._realm.All<QueueLevelRelation>()
+        => new(this.QueueLevelRelations
         .Where(r => r.User == user)
         .AsEnumerable()
         .Select(r => r.Level)
@@ -150,7 +150,7 @@ public partial class GameDatabaseContext // Relations
     
     [Pure]
     public int GetTotalLevelsQueuedByUser(GameUser user) 
-        => this._realm.All<QueueLevelRelation>()
+        => this.QueueLevelRelations
             .Count(r => r.User == user);
     
     public bool QueueLevel(GameLevel level, GameUser user)
@@ -169,7 +169,7 @@ public partial class GameDatabaseContext // Relations
 
     public bool DequeueLevel(GameLevel level, GameUser user)
     {
-        QueueLevelRelation? relation = this._realm.All<QueueLevelRelation>()
+        QueueLevelRelation? relation = this.QueueLevelRelations
             .FirstOrDefault(r => r.Level == level && r.User == user);
 
         if (relation == null) return false;
@@ -181,7 +181,7 @@ public partial class GameDatabaseContext // Relations
 
     public void ClearQueue(GameUser user)
     {
-        this.Write(() => this._realm.RemoveRange(this._realm.All<QueueLevelRelation>().Where(r => r.User == user)));
+        this.Write(() => this._realm.RemoveRange(this.QueueLevelRelations.Where(r => r.User == user)));
     }
 
     #endregion
@@ -189,7 +189,7 @@ public partial class GameDatabaseContext // Relations
     #region Rating and Reviewing
 
     private RateLevelRelation? GetRateRelationByUser(GameLevel level, GameUser user)
-        => this._realm.All<RateLevelRelation>().FirstOrDefault(r => r.User == user && r.Level == level);
+        => this.RateLevelRelations.FirstOrDefault(r => r.User == user && r.Level == level);
 
     /// <summary>
     /// Get a user's rating on a particular level.
@@ -258,12 +258,12 @@ public partial class GameDatabaseContext // Relations
 
     public DatabaseList<GameReview> GetReviewsByUser(GameUser user, int count, int skip)
     {
-        return new DatabaseList<GameReview>(this._realm.All<GameReview>()
+        return new DatabaseList<GameReview>(this.GameReviews
             .Where(r => r.Publisher == user), skip, count);
     }
 
     public int GetTotalReviewsByUser(GameUser user)
-        => this._realm.All<GameReview>().Count(r => r.Publisher == user);
+        => this.GameReviews.Count(r => r.Publisher == user);
     
     public void DeleteReview(GameReview review)
     {
@@ -277,12 +277,12 @@ public partial class GameDatabaseContext // Relations
 
     public DatabaseList<GameReview> GetReviewsForLevel(GameLevel level, int count, int skip)
     {
-        return new DatabaseList<GameReview>(this._realm.All<GameReview>()
+        return new DatabaseList<GameReview>(this.GameReviews
             .Where(r => r.Level == level), skip, count);
     }
     
     public int GetTotalReviewsForLevel(GameLevel level)
-        => this._realm.All<GameReview>().Count(r => r.Level == level);
+        => this.GameReviews.Count(r => r.Level == level);
 
     #endregion
 
@@ -298,7 +298,7 @@ public partial class GameDatabaseContext // Relations
             Count = count,
         };
         
-        UniquePlayLevelRelation? uniqueRelation = this._realm.All<UniquePlayLevelRelation>()
+        UniquePlayLevelRelation? uniqueRelation = this.UniquePlayLevelRelations
             .FirstOrDefault(r => r.Level == level && r.User == user);
 
         this.Write(() =>
@@ -318,7 +318,7 @@ public partial class GameDatabaseContext // Relations
     }
 
     public bool HasUserPlayedLevel(GameLevel level, GameUser user) =>
-        this._realm.All<UniquePlayLevelRelation>()
+        this.UniquePlayLevelRelations
             .FirstOrDefault(r => r.Level == level && r.User == user) != null;
 
     #endregion
@@ -340,7 +340,7 @@ public partial class GameDatabaseContext // Relations
         => this.GetCommentRelationByUser(comment, user)?.RatingType;
     
     public int GetTotalRatingsForComment(GameComment comment, RatingType type) =>
-        this._realm.All<CommentRelation>().Count(r => r.Comment == comment && r._RatingType == (int)type);
+        this.CommentRelations.Count(r => r.Comment == comment && r._RatingType == (int)type);
     
     public bool RateComment(GameUser user, GameComment comment, RatingType ratingType)
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -325,8 +325,8 @@ public partial class GameDatabaseContext // Relations
 
     #region Comments
 
-    private CommentRelation? GetCommentRelationByUser(GameComment comment, GameUser user) => this._realm
-        .All<CommentRelation>().FirstOrDefault(r => r.Comment == comment && r.User == user);
+    private CommentRelation? GetCommentRelationByUser(GameComment comment, GameUser user) => this.CommentRelations
+        .FirstOrDefault(r => r.Comment == comment && r.User == user);
     
     /// <summary>
     /// Get a user's rating on a particular comment.

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -39,7 +39,7 @@ public partial class GameDatabaseContext // Relations
             Level = level,
             User = user,
         };
-        this.Write(() => this._realm.Add(relation));
+        this.Write(() => this.FavouriteLevelRelations.Add(relation));
 
         this.CreateLevelFavouriteEvent(user, level);
 
@@ -103,7 +103,7 @@ public partial class GameDatabaseContext // Relations
             UserFavouriting = userFavouriting,
         };
         
-        this.Write(() => this._realm.Add(relation));
+        this.Write(() => this.FavouriteUserRelations.Add(relation));
 
         this.CreateUserFavouriteEvent(userFavouriting, userToFavourite);
 
@@ -162,7 +162,7 @@ public partial class GameDatabaseContext // Relations
             Level = level,
             User = user,
         };
-        this.Write(() => this._realm.Add(relation));
+        this.Write(() => this.QueueLevelRelations.Add(relation));
 
         return true;
     }
@@ -220,7 +220,7 @@ public partial class GameDatabaseContext // Relations
                 Timestamp = this._time.Now,
             };
 
-            this.Write(() => this._realm.Add(rating));
+            this.Write(() => this.RateLevelRelations.Add(rating));
             return true;
         }
 
@@ -303,10 +303,10 @@ public partial class GameDatabaseContext // Relations
 
         this.Write(() =>
         {
-            this._realm.Add(relation);
+            this.PlayLevelRelations.Add(relation);
             
             // If the user hasn't played the level before, then add a unique relation too
-            if (uniqueRelation == null) this._realm.Add(new UniquePlayLevelRelation 
+            if (uniqueRelation == null) this.UniquePlayLevelRelations.Add(new UniquePlayLevelRelation 
             {
                 Level = level,
                 User = user,
@@ -361,7 +361,7 @@ public partial class GameDatabaseContext // Relations
             
             this.Write(() =>
             {
-                this._realm.Add(relation);
+                this.CommentRelations.Add(relation);
             });
         }
         else

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -53,7 +53,7 @@ public partial class GameDatabaseContext // Relations
 
         if (relation == null) return false;
 
-        this.Write(() => this._realm.Remove(relation));
+        this.Write(() => this.FavouriteLevelRelations.Remove(relation));
 
         return true;
     }
@@ -127,7 +127,7 @@ public partial class GameDatabaseContext // Relations
 
         if (relation == null) return false;
 
-        this.Write(() => this._realm.Remove(relation));
+        this.Write(() => this.FavouriteUserRelations.Remove(relation));
 
         return true;
     }
@@ -174,14 +174,14 @@ public partial class GameDatabaseContext // Relations
 
         if (relation == null) return false;
 
-        this.Write(() => this._realm.Remove(relation));
+        this.Write(() => this.QueueLevelRelations.Remove(relation));
 
         return true;
     }
 
     public void ClearQueue(GameUser user)
     {
-        this.Write(() => this._realm.RemoveRange(this.QueueLevelRelations.Where(r => r.User == user)));
+        this.Write(() => this.QueueLevelRelations.RemoveRange(this.QueueLevelRelations.Where(r => r.User == user)));
     }
 
     #endregion
@@ -248,7 +248,7 @@ public partial class GameDatabaseContext // Relations
                 foreach (GameReview reviewToDelete in toRemove)
                 {
                     level.Reviews.Remove(reviewToDelete);
-                    this._realm.Remove(reviewToDelete);
+                    this.GameReviews.Remove(reviewToDelete);
                 }
             });
         }
@@ -267,7 +267,7 @@ public partial class GameDatabaseContext // Relations
     
     public void DeleteReview(GameReview review)
     {
-        this._realm.Remove(review);
+        this.GameReviews.Remove(review);
     }
     
     public GameReview? GetReviewByLevelAndUser(GameLevel level, GameUser user)

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -39,7 +39,7 @@ public partial class GameDatabaseContext // Relations
             Level = level,
             User = user,
         };
-        this._realm.Write(() => this._realm.Add(relation));
+        this.Write(() => this._realm.Add(relation));
 
         this.CreateLevelFavouriteEvent(user, level);
 
@@ -53,7 +53,7 @@ public partial class GameDatabaseContext // Relations
 
         if (relation == null) return false;
 
-        this._realm.Write(() => this._realm.Remove(relation));
+        this.Write(() => this._realm.Remove(relation));
 
         return true;
     }
@@ -103,7 +103,7 @@ public partial class GameDatabaseContext // Relations
             UserFavouriting = userFavouriting,
         };
         
-        this._realm.Write(() => this._realm.Add(relation));
+        this.Write(() => this._realm.Add(relation));
 
         this.CreateUserFavouriteEvent(userFavouriting, userToFavourite);
 
@@ -127,7 +127,7 @@ public partial class GameDatabaseContext // Relations
 
         if (relation == null) return false;
 
-        this._realm.Write(() => this._realm.Remove(relation));
+        this.Write(() => this._realm.Remove(relation));
 
         return true;
     }
@@ -162,7 +162,7 @@ public partial class GameDatabaseContext // Relations
             Level = level,
             User = user,
         };
-        this._realm.Write(() => this._realm.Add(relation));
+        this.Write(() => this._realm.Add(relation));
 
         return true;
     }
@@ -174,14 +174,14 @@ public partial class GameDatabaseContext // Relations
 
         if (relation == null) return false;
 
-        this._realm.Write(() => this._realm.Remove(relation));
+        this.Write(() => this._realm.Remove(relation));
 
         return true;
     }
 
     public void ClearQueue(GameUser user)
     {
-        this._realm.Write(() => this._realm.RemoveRange(this._realm.All<QueueLevelRelation>().Where(r => r.User == user)));
+        this.Write(() => this._realm.RemoveRange(this._realm.All<QueueLevelRelation>().Where(r => r.User == user)));
     }
 
     #endregion
@@ -220,11 +220,11 @@ public partial class GameDatabaseContext // Relations
                 Timestamp = this._time.Now,
             };
 
-            this._realm.Write(() => this._realm.Add(rating));
+            this.Write(() => this._realm.Add(rating));
             return true;
         }
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             rating.RatingType = type;
             rating.Timestamp = this._time.Now;
@@ -243,7 +243,7 @@ public partial class GameDatabaseContext // Relations
         List<GameReview> toRemove = level.Reviews.Where(r => r.Publisher.UserId == review.Publisher.UserId).ToList();
         if (toRemove.Count > 0)
         {
-            this._realm.Write(() =>
+            this.Write(() =>
             {
                 foreach (GameReview reviewToDelete in toRemove)
                 {
@@ -301,7 +301,7 @@ public partial class GameDatabaseContext // Relations
         UniquePlayLevelRelation? uniqueRelation = this._realm.All<UniquePlayLevelRelation>()
             .FirstOrDefault(r => r.Level == level && r.User == user);
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(relation);
             
@@ -359,14 +359,14 @@ public partial class GameDatabaseContext // Relations
                 RatingType = ratingType,
             };
             
-            this._realm.Write(() =>
+            this.Write(() =>
             {
                 this._realm.Add(relation);
             });
         }
         else
         {
-            this._realm.Write(() =>
+            this.Write(() =>
             {
                 relation.Timestamp = this._time.Now;
                 relation.RatingType = ratingType;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Statistics.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Statistics.cs
@@ -10,7 +10,7 @@ public partial class GameDatabaseContext // Statistics
         if (statistics != null) return statistics;
 
         statistics = new RequestStatistics();
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Add(statistics);
         });
@@ -21,7 +21,7 @@ public partial class GameDatabaseContext // Statistics
     public void IncrementApiRequests(int count)
     {
         RequestStatistics statistics = this.GetRequestStatistics();
-        this._realm.Write(() => {
+        this.Write(() => {
             statistics.TotalRequests += count;
             statistics.ApiRequests += count;
         });
@@ -30,7 +30,7 @@ public partial class GameDatabaseContext // Statistics
     public void IncrementGameRequests(int count)
     {
         RequestStatistics statistics = this.GetRequestStatistics();
-        this._realm.Write(() => {
+        this.Write(() => {
             statistics.TotalRequests += count;
             statistics.GameRequests += count;
         });

--- a/Refresh.GameServer/Database/GameDatabaseContext.Statistics.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Statistics.cs
@@ -12,7 +12,7 @@ public partial class GameDatabaseContext // Statistics
         statistics = new RequestStatistics();
         this.Write(() =>
         {
-            this._realm.Add(statistics);
+            this.RequestStatistics.Add(statistics);
         });
 
         return statistics;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Statistics.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Statistics.cs
@@ -6,7 +6,7 @@ public partial class GameDatabaseContext // Statistics
 {
     public RequestStatistics GetRequestStatistics()
     {
-        RequestStatistics? statistics = this._realm.All<RequestStatistics>().FirstOrDefault();
+        RequestStatistics? statistics = this.RequestStatistics.FirstOrDefault();
         if (statistics != null) return statistics;
 
         statistics = new RequestStatistics();

--- a/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
@@ -69,7 +69,7 @@ public partial class GameDatabaseContext // Tokens
     [ContractAnnotation("=> canbenull")]
     public Token? GetTokenFromTokenData(string tokenData, TokenType type)
     {
-        Token? token = this._realm.All<Token>()
+        Token? token = this.Tokens
             .FirstOrDefault(t => t.TokenData == tokenData && t._TokenType == (int)type);
 
         if (token == null) return null;
@@ -102,7 +102,7 @@ public partial class GameDatabaseContext // Tokens
     {
         if (tokenData == null) return false;
 
-        Token? token = this._realm.All<Token>().FirstOrDefault(t => t.TokenData == tokenData && t._TokenType == (int)type);
+        Token? token = this.Tokens.FirstOrDefault(t => t.TokenData == tokenData && t._TokenType == (int)type);
         if (token == null) return false;
 
         this.RevokeToken(token);
@@ -122,7 +122,7 @@ public partial class GameDatabaseContext // Tokens
     {
         this.Write(() =>
         {
-            this._realm.RemoveRange(this._realm.All<Token>().Where(t => t.User == user));
+            this._realm.RemoveRange(this.Tokens.Where(t => t.User == user));
         });
     }
     
@@ -130,14 +130,14 @@ public partial class GameDatabaseContext // Tokens
     {
         this.Write(() =>
         {
-            this._realm.RemoveRange(this._realm.All<Token>().Where(t => t.User == user && t._TokenType == (int)type));
+            this._realm.RemoveRange(this.Tokens.Where(t => t.User == user && t._TokenType == (int)type));
         });
     }
     
     public bool IsTokenExpired(Token token) => token.ExpiresAt < this._time.Now;
     
     public DatabaseList<Token> GetAllTokens()
-        => new(this._realm.All<Token>());
+        => new(this.Tokens);
 
     public void AddIpVerificationRequest(GameUser user, string ipAddress)
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
@@ -59,7 +59,7 @@ public partial class GameDatabaseContext // Tokens
         this.Write(() =>
         {
             user.LastLoginDate = this._time.Now;
-            this._realm.Add(token);
+            this.Tokens.Add(token);
         });
         
         return token;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
@@ -56,7 +56,7 @@ public partial class GameDatabaseContext // Tokens
             this.CreateUserFirstLoginEvent(user, user);
         }
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.LastLoginDate = this._time.Now;
             this._realm.Add(token);
@@ -91,7 +91,7 @@ public partial class GameDatabaseContext // Tokens
 
     public void SetUserPassword(GameUser user, string? passwordBcrypt, bool shouldReset = false)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.PasswordBcrypt = passwordBcrypt;
             user.ShouldResetPassword = shouldReset;
@@ -112,7 +112,7 @@ public partial class GameDatabaseContext // Tokens
 
     public void RevokeToken(Token token)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(token);
         });
@@ -120,7 +120,7 @@ public partial class GameDatabaseContext // Tokens
 
     public void RevokeAllTokensForUser(GameUser user)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.RemoveRange(this._realm.All<Token>().Where(t => t.User == user));
         });
@@ -128,7 +128,7 @@ public partial class GameDatabaseContext // Tokens
     
     public void RevokeAllTokensForUser(GameUser user, TokenType type)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.RemoveRange(this._realm.All<Token>().Where(t => t.User == user && t._TokenType == (int)type));
         });
@@ -147,7 +147,7 @@ public partial class GameDatabaseContext // Tokens
             CreatedAt = this._time.Now,
         };
 
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.IpVerificationRequests.Add(request);
         });
@@ -155,7 +155,7 @@ public partial class GameDatabaseContext // Tokens
 
     public void SetApprovedIp(GameUser user, string ipAddress)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.CurrentVerifiedIp = ipAddress;
             user.IpVerificationRequests.Clear();
@@ -165,7 +165,7 @@ public partial class GameDatabaseContext // Tokens
     public void DenyIpVerificationRequest(GameUser user, string ipAddress)
     {
         IEnumerable<GameIpVerificationRequest> requests = user.IpVerificationRequests.Where(r => r.IpAddress == ipAddress);
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             foreach (GameIpVerificationRequest request in requests)
             {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
@@ -114,7 +114,7 @@ public partial class GameDatabaseContext // Tokens
     {
         this.Write(() =>
         {
-            this._realm.Remove(token);
+            this.Tokens.Remove(token);
         });
     }
 
@@ -122,7 +122,7 @@ public partial class GameDatabaseContext // Tokens
     {
         this.Write(() =>
         {
-            this._realm.RemoveRange(this.Tokens.Where(t => t.User == user));
+            this.Tokens.RemoveRange(this.Tokens.Where(t => t.User == user));
         });
     }
     
@@ -130,7 +130,7 @@ public partial class GameDatabaseContext // Tokens
     {
         this.Write(() =>
         {
-            this._realm.RemoveRange(this.Tokens.Where(t => t.User == user && t._TokenType == (int)type));
+            this.Tokens.RemoveRange(this.Tokens.Where(t => t.User == user && t._TokenType == (int)type));
         });
     }
     

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -72,7 +72,7 @@ public partial class GameDatabaseContext // Users
 
     public void UpdateUserData(GameUser user, SerializedUpdateData data, TokenGame game)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             if (data.Description != null)
                 user.Description = data.Description;
@@ -144,7 +144,7 @@ public partial class GameDatabaseContext // Users
     
     public void UpdateUserData(GameUser user, ApiUpdateUserRequest data)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             if (data.EmailAddress != null && data.EmailAddress != user.EmailAddress)
             {
@@ -194,7 +194,7 @@ public partial class GameDatabaseContext // Users
 
     public void UpdateUserPins(GameUser user, UserPins pinsUpdate) 
     {
-        this._realm.Write(() => {
+        this.Write(() => {
             user.Pins = new UserPins();
 
             foreach (long pinsAward in pinsUpdate.Awards) user.Pins.Awards.Add(pinsAward);
@@ -206,7 +206,7 @@ public partial class GameDatabaseContext // Users
     public void SetUserRole(GameUser user, GameUserRole role)
     {
         if(role == GameUserRole.Banned) throw new InvalidOperationException($"Cannot ban a user with this method. Please use {nameof(this.BanUser)}().");
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             if (user.Role is GameUserRole.Banned or GameUserRole.Restricted)
             {
@@ -220,7 +220,7 @@ public partial class GameDatabaseContext // Users
 
     private void PunishUser(GameUser user, string reason, DateTimeOffset expiryDate, GameUserRole role)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.Role = role;
             user.BanReason = reason;
@@ -260,7 +260,7 @@ public partial class GameDatabaseContext // Users
     {
         string oldUsername = user.Username;
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.Username = newUsername;
         });
@@ -281,7 +281,7 @@ public partial class GameDatabaseContext // Users
         this.RevokeAllTokensForUser(user);
         this.DeleteNotificationsByUser(user);
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.Pins = new UserPins();
             user.LocationX = 0;
@@ -323,7 +323,7 @@ public partial class GameDatabaseContext // Users
         // do an initial cleanup of everything before deleting the row  
         this.DeleteUser(user);
         
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             this._realm.Remove(user);
         });
@@ -331,7 +331,7 @@ public partial class GameDatabaseContext // Users
 
     public void ResetUserPlanets(GameUser user)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.Lbp2PlanetsHash = "0";
             user.Lbp3PlanetsHash = "0";
@@ -341,7 +341,7 @@ public partial class GameDatabaseContext // Users
 
     public void SetUnescapeXmlSequences(GameUser user, bool value)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.UnescapeXmlSequences = value;
         });
@@ -349,7 +349,7 @@ public partial class GameDatabaseContext // Users
 
     public void ClearForceMatch(GameUser user)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.ForceMatch = null;
         });
@@ -357,7 +357,7 @@ public partial class GameDatabaseContext // Users
 
     public void SetForceMatch(GameUser user, GameUser target)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.ForceMatch = target.ForceMatch;
         });
@@ -365,7 +365,7 @@ public partial class GameDatabaseContext // Users
     
     public void ForceUserTokenGame(Token token, TokenGame game)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             token.TokenGame = game;
         });
@@ -373,7 +373,7 @@ public partial class GameDatabaseContext // Users
     
     public void ForceUserTokenPlatform(Token token, TokenPlatform platform)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             token.TokenPlatform = platform;
         });
@@ -381,7 +381,7 @@ public partial class GameDatabaseContext // Users
     
     public void IncrementUserFilesizeQuota(GameUser user, int amount)
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             user.FilesizeQuotaUsage += amount;
         });
@@ -389,7 +389,7 @@ public partial class GameDatabaseContext // Users
     
     public void SetPrivacySettings(GameUser user, SerializedPrivacySettings settings) 
     {
-        this._realm.Write(() =>
+        this.Write(() =>
         {
             if(settings.LevelVisibility != null)
                 user.LevelVisibility = settings.LevelVisibility.Value;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -36,9 +36,9 @@ public partial class GameDatabaseContext // Users
             };
         
         if (!caseSensitive)
-            return this._realm.All<GameUser>().FirstOrDefault(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
+            return this.GameUsers.FirstOrDefault(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
         
-        return this._realm.All<GameUser>().FirstOrDefault(u => u.Username == username);
+        return this.GameUsers.FirstOrDefault(u => u.Username == username);
     }
     
     [Pure]
@@ -47,7 +47,7 @@ public partial class GameDatabaseContext // Users
     {
         if (emailAddress == null) return null;
         emailAddress = emailAddress.ToLowerInvariant();
-        return this._realm.All<GameUser>().FirstOrDefault(u => u.EmailAddress == emailAddress);
+        return this.GameUsers.FirstOrDefault(u => u.EmailAddress == emailAddress);
     }
 
     [Pure]
@@ -55,7 +55,7 @@ public partial class GameDatabaseContext // Users
     public GameUser? GetUserByObjectId(ObjectId? id)
     {
         if (id == null) return null;
-        return this._realm.All<GameUser>().FirstOrDefault(u => u.UserId == id);
+        return this.GameUsers.FirstOrDefault(u => u.UserId == id);
     }
     
     [Pure]
@@ -64,11 +64,11 @@ public partial class GameDatabaseContext // Users
     {
         if (uuid == null) return null;
         if(!ObjectId.TryParse(uuid, out ObjectId objectId)) return null;
-        return this._realm.All<GameUser>().FirstOrDefault(u => u.UserId == objectId);
+        return this.GameUsers.FirstOrDefault(u => u.UserId == objectId);
     }
 
     public DatabaseList<GameUser> GetUsers(int count, int skip)
-        => new(this._realm.All<GameUser>().OrderByDescending(u => u.JoinDate), skip, count);
+        => new(this.GameUsers.OrderByDescending(u => u.JoinDate), skip, count);
 
     public void UpdateUserData(GameUser user, SerializedUpdateData data, TokenGame game)
     {
@@ -183,13 +183,13 @@ public partial class GameDatabaseContext // Users
     }
 
     [Pure]
-    public int GetTotalUserCount() => this._realm.All<GameUser>().Count();
+    public int GetTotalUserCount() => this.GameUsers.Count();
     
     [Pure]
     public int GetActiveUserCount()
     {
         DateTimeOffset timeFrame = this._time.Now.Subtract(TimeSpan.FromDays(7));
-        return this._realm.All<GameUser>().Count(u => u.LastLoginDate > timeFrame);
+        return this.GameUsers.Count(u => u.LastLoginDate > timeFrame);
     }
 
     public void UpdateUserPins(GameUser user, UserPins pinsUpdate) 
@@ -253,7 +253,7 @@ public partial class GameDatabaseContext // Users
         // for some stupid reason, we have to do the byte conversion here or realm won't work correctly.
         byte roleByte = (byte)role;
         
-        return new DatabaseList<GameUser>(this._realm.All<GameUser>().Where(u => u._Role == roleByte));
+        return new DatabaseList<GameUser>(this.GameUsers.Where(u => u._Role == roleByte));
     }
 
     public void RenameUser(GameUser user, string newUsername)
@@ -305,13 +305,13 @@ public partial class GameDatabaseContext // Users
                 foreach (GamePhotoSubject subject in photo.Subjects.Where(s => s.User?.UserId == user.UserId))
                     subject.User = null;
             
-            this._realm.RemoveRange(this._realm.All<FavouriteLevelRelation>().Where(r => r.User == user));
-            this._realm.RemoveRange(this._realm.All<FavouriteUserRelation>().Where(r => r.UserToFavourite == user));
-            this._realm.RemoveRange(this._realm.All<FavouriteUserRelation>().Where(r => r.UserFavouriting == user));
-            this._realm.RemoveRange(this._realm.All<QueueLevelRelation>().Where(r => r.User == user));
-            this._realm.RemoveRange(this._realm.All<GamePhoto>().Where(p => p.Publisher == user));
+            this._realm.RemoveRange(this.FavouriteLevelRelations.Where(r => r.User == user));
+            this._realm.RemoveRange(this.FavouriteUserRelations.Where(r => r.UserToFavourite == user));
+            this._realm.RemoveRange(this.FavouriteUserRelations.Where(r => r.UserFavouriting == user));
+            this._realm.RemoveRange(this.QueueLevelRelations.Where(r => r.User == user));
+            this._realm.RemoveRange(this.GamePhotos.Where(p => p.Publisher == user));
 
-            foreach (GameLevel level in this._realm.All<GameLevel>().Where(l => l.Publisher == user))
+            foreach (GameLevel level in this.GameLevels.Where(l => l.Publisher == user))
             {
                 level.Publisher = null;
             }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -305,11 +305,11 @@ public partial class GameDatabaseContext // Users
                 foreach (GamePhotoSubject subject in photo.Subjects.Where(s => s.User?.UserId == user.UserId))
                     subject.User = null;
             
-            this._realm.RemoveRange(this.FavouriteLevelRelations.Where(r => r.User == user));
-            this._realm.RemoveRange(this.FavouriteUserRelations.Where(r => r.UserToFavourite == user));
-            this._realm.RemoveRange(this.FavouriteUserRelations.Where(r => r.UserFavouriting == user));
-            this._realm.RemoveRange(this.QueueLevelRelations.Where(r => r.User == user));
-            this._realm.RemoveRange(this.GamePhotos.Where(p => p.Publisher == user));
+            this.FavouriteLevelRelations.RemoveRange(this.FavouriteLevelRelations.Where(r => r.User == user));
+            this.FavouriteUserRelations.RemoveRange(this.FavouriteUserRelations.Where(r => r.UserToFavourite == user));
+            this.FavouriteUserRelations.RemoveRange(this.FavouriteUserRelations.Where(r => r.UserFavouriting == user));
+            this.QueueLevelRelations.RemoveRange(this.QueueLevelRelations.Where(r => r.User == user));
+            this.GamePhotos.RemoveRange(this.GamePhotos.Where(p => p.Publisher == user));
 
             foreach (GameLevel level in this.GameLevels.Where(l => l.Publisher == user))
             {
@@ -325,7 +325,7 @@ public partial class GameDatabaseContext // Users
         
         this.Write(() =>
         {
-            this._realm.Remove(user);
+            this.GameUsers.Remove(user);
         });
     }
 

--- a/Refresh.GameServer/Database/GameDatabaseContext.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.cs
@@ -27,31 +27,31 @@ public partial class GameDatabaseContext : RealmDatabaseContext
 
     private readonly IDateTimeProvider _time;
     
-    private IQueryable<GameUser> GameUsers => this._realm.All<GameUser>();
-    private IQueryable<Token> Tokens => this._realm.All<Token>();
-    private IQueryable<GameLevel> GameLevels => this._realm.All<GameLevel>();
-    private IQueryable<GameComment> GameComments => this._realm.All<GameComment>();
-    private IQueryable<CommentRelation> CommentRelations => this._realm.All<CommentRelation>();
-    private IQueryable<FavouriteLevelRelation> FavouriteLevelRelations => this._realm.All<FavouriteLevelRelation>();
-    private IQueryable<QueueLevelRelation> QueueLevelRelations => this._realm.All<QueueLevelRelation>();
-    private IQueryable<FavouriteUserRelation> FavouriteUserRelations => this._realm.All<FavouriteUserRelation>();
-    private IQueryable<PlayLevelRelation> PlayLevelRelations => this._realm.All<PlayLevelRelation>();
-    private IQueryable<UniquePlayLevelRelation> UniquePlayLevelRelations => this._realm.All<UniquePlayLevelRelation>();
-    private IQueryable<RateLevelRelation> RateLevelRelations => this._realm.All<RateLevelRelation>();
-    private IQueryable<Event> Events => this._realm.All<Event>();
-    private IQueryable<GameSubmittedScore> GameSubmittedScores => this._realm.All<GameSubmittedScore>();
-    private IQueryable<GameAsset> GameAssets => this._realm.All<GameAsset>();
-    private IQueryable<GameNotification> GameNotifications => this._realm.All<GameNotification>();
-    private IQueryable<GamePhoto> GamePhotos => this._realm.All<GamePhoto>();
-    private IQueryable<GameAnnouncement> GameAnnouncements => this._realm.All<GameAnnouncement>();
-    private IQueryable<QueuedRegistration> QueuedRegistrations => this._realm.All<QueuedRegistration>();
-    private IQueryable<EmailVerificationCode> EmailVerificationCodes => this._realm.All<EmailVerificationCode>();
-    private IQueryable<RequestStatistics> RequestStatistics => this._realm.All<RequestStatistics>();
-    private IQueryable<SequentialIdStorage> SequentialIdStorage => this._realm.All<SequentialIdStorage>();
-    private IQueryable<GameContest> GameContests => this._realm.All<GameContest>();
-    private IQueryable<AssetDependencyRelation> AssetDependencyRelations => this._realm.All<AssetDependencyRelation>();
-    private IQueryable<GameReview> GameReviews => this._realm.All<GameReview>();
-    private IQueryable<DisallowedUser> DisallowedUsers => this._realm.All<DisallowedUser>();
+    private RealmDbSet<GameUser> GameUsers => new(this._realm);
+    private RealmDbSet<Token> Tokens => new(this._realm);
+    private RealmDbSet<GameLevel> GameLevels => new(this._realm);
+    private RealmDbSet<GameComment> GameComments => new(this._realm);
+    private RealmDbSet<CommentRelation> CommentRelations => new(this._realm);
+    private RealmDbSet<FavouriteLevelRelation> FavouriteLevelRelations => new(this._realm);
+    private RealmDbSet<QueueLevelRelation> QueueLevelRelations => new(this._realm);
+    private RealmDbSet<FavouriteUserRelation> FavouriteUserRelations => new(this._realm);
+    private RealmDbSet<PlayLevelRelation> PlayLevelRelations => new(this._realm);
+    private RealmDbSet<UniquePlayLevelRelation> UniquePlayLevelRelations => new(this._realm);
+    private RealmDbSet<RateLevelRelation> RateLevelRelations => new(this._realm);
+    private RealmDbSet<Event> Events => new(this._realm);
+    private RealmDbSet<GameSubmittedScore> GameSubmittedScores => new(this._realm);
+    private RealmDbSet<GameAsset> GameAssets => new(this._realm);
+    private RealmDbSet<GameNotification> GameNotifications => new(this._realm);
+    private RealmDbSet<GamePhoto> GamePhotos => new(this._realm);
+    private RealmDbSet<GameAnnouncement> GameAnnouncements => new(this._realm);
+    private RealmDbSet<QueuedRegistration> QueuedRegistrations => new(this._realm);
+    private RealmDbSet<EmailVerificationCode> EmailVerificationCodes => new(this._realm);
+    private RealmDbSet<RequestStatistics> RequestStatistics => new(this._realm);
+    private RealmDbSet<SequentialIdStorage> SequentialIdStorage => new(this._realm);
+    private RealmDbSet<GameContest> GameContests => new(this._realm);
+    private RealmDbSet<AssetDependencyRelation> AssetDependencyRelations => new(this._realm);
+    private RealmDbSet<GameReview> GameReviews => new(this._realm);
+    private RealmDbSet<DisallowedUser> DisallowedUsers => new(this._realm);
 
     internal GameDatabaseContext(IDateTimeProvider time)
     {
@@ -78,7 +78,7 @@ public partial class GameDatabaseContext : RealmDatabaseContext
         };
 
         // no need to do write block, this should only be called in a write transaction
-        this._realm.Add(storage);
+        this.SequentialIdStorage.Add(storage);
 
         return storage.SequentialId;
     }

--- a/Refresh.GameServer/Database/GameDatabaseContext.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Realms;
 using Bunkum.RealmDatabase;
 using Refresh.GameServer.Time;
@@ -48,7 +49,7 @@ public partial class GameDatabaseContext : RealmDatabaseContext
     {
         lock (IdLock)
         {
-            this._realm.Write(() =>
+            this.Write(() =>
             {
                 int newId = this.GetOrCreateSequentialId<T>() + 1;
 
@@ -63,7 +64,7 @@ public partial class GameDatabaseContext : RealmDatabaseContext
         // We've already set a SequentialId so we can be outside the lock at this stage
         if (list != null)
         {
-            this._realm.Write(() =>
+            this.Write(() =>
             {
                 list.Add(obj);
                 writtenCallback?.Invoke();
@@ -76,4 +77,10 @@ public partial class GameDatabaseContext : RealmDatabaseContext
     
     private void AddSequentialObject<T>(T obj) where T : IRealmObject, ISequentialId 
         => this.AddSequentialObject(obj, null, null);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Write(Action callback)
+    {
+        this._realm.Write(callback);
+    }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.cs
@@ -122,4 +122,9 @@ public partial class GameDatabaseContext : RealmDatabaseContext
     {
         this._realm.Write(callback);
     }
+
+    private void RemoveAll<T>() where T : IRealmObject
+    {
+        this._realm.RemoveAll<T>();
+    }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.cs
@@ -2,8 +2,21 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Realms;
 using Bunkum.RealmDatabase;
+using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Time;
 using Refresh.GameServer.Types;
+using Refresh.GameServer.Types.Activity;
+using Refresh.GameServer.Types.Assets;
+using Refresh.GameServer.Types.Comments;
+using Refresh.GameServer.Types.Contests;
+using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.Levels.SkillRewards;
+using Refresh.GameServer.Types.Notifications;
+using Refresh.GameServer.Types.Photos;
+using Refresh.GameServer.Types.Relations;
+using Refresh.GameServer.Types.Reviews;
+using Refresh.GameServer.Types.UserData;
+using Refresh.GameServer.Types.UserData.Leaderboard;
 
 namespace Refresh.GameServer.Database;
 
@@ -13,6 +26,32 @@ public partial class GameDatabaseContext : RealmDatabaseContext
     private static readonly object IdLock = new();
 
     private readonly IDateTimeProvider _time;
+    
+    private IQueryable<GameUser> GameUsers => this._realm.All<GameUser>();
+    private IQueryable<Token> Tokens => this._realm.All<Token>();
+    private IQueryable<GameLevel> GameLevels => this._realm.All<GameLevel>();
+    private IQueryable<GameComment> GameComments => this._realm.All<GameComment>();
+    private IQueryable<CommentRelation> CommentRelations => this._realm.All<CommentRelation>();
+    private IQueryable<FavouriteLevelRelation> FavouriteLevelRelations => this._realm.All<FavouriteLevelRelation>();
+    private IQueryable<QueueLevelRelation> QueueLevelRelations => this._realm.All<QueueLevelRelation>();
+    private IQueryable<FavouriteUserRelation> FavouriteUserRelations => this._realm.All<FavouriteUserRelation>();
+    private IQueryable<PlayLevelRelation> PlayLevelRelations => this._realm.All<PlayLevelRelation>();
+    private IQueryable<UniquePlayLevelRelation> UniquePlayLevelRelations => this._realm.All<UniquePlayLevelRelation>();
+    private IQueryable<RateLevelRelation> RateLevelRelations => this._realm.All<RateLevelRelation>();
+    private IQueryable<Event> Events => this._realm.All<Event>();
+    private IQueryable<GameSubmittedScore> GameSubmittedScores => this._realm.All<GameSubmittedScore>();
+    private IQueryable<GameAsset> GameAssets => this._realm.All<GameAsset>();
+    private IQueryable<GameNotification> GameNotifications => this._realm.All<GameNotification>();
+    private IQueryable<GamePhoto> GamePhotos => this._realm.All<GamePhoto>();
+    private IQueryable<GameAnnouncement> GameAnnouncements => this._realm.All<GameAnnouncement>();
+    private IQueryable<QueuedRegistration> QueuedRegistrations => this._realm.All<QueuedRegistration>();
+    private IQueryable<EmailVerificationCode> EmailVerificationCodes => this._realm.All<EmailVerificationCode>();
+    private IQueryable<RequestStatistics> RequestStatistics => this._realm.All<RequestStatistics>();
+    private IQueryable<SequentialIdStorage> SequentialIdStorage => this._realm.All<SequentialIdStorage>();
+    private IQueryable<GameContest> GameContests => this._realm.All<GameContest>();
+    private IQueryable<AssetDependencyRelation> AssetDependencyRelations => this._realm.All<AssetDependencyRelation>();
+    private IQueryable<GameReview> GameReviews => this._realm.All<GameReview>();
+    private IQueryable<DisallowedUser> DisallowedUsers => this._realm.All<DisallowedUser>();
 
     internal GameDatabaseContext(IDateTimeProvider time)
     {
@@ -23,7 +62,7 @@ public partial class GameDatabaseContext : RealmDatabaseContext
     {
         string name = typeof(T).Name;
 
-        SequentialIdStorage? storage = this._realm.All<SequentialIdStorage>()
+        SequentialIdStorage? storage = this.SequentialIdStorage
             .FirstOrDefault(s => s.TypeName == name);
 
         if (storage != null)
@@ -35,7 +74,7 @@ public partial class GameDatabaseContext : RealmDatabaseContext
         storage = new SequentialIdStorage
         {
             TypeName = name,
-            SequentialId = this._realm.All<T>().Count() * 2, // skip over a bunch of ids incase table is broken
+            SequentialId = this.SequentialIdStorage.Count() * 2, // skip over a bunch of ids incase table is broken
         };
 
         // no need to do write block, this should only be called in a write transaction

--- a/Refresh.GameServer/Database/GameDatabaseContext.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.cs
@@ -74,7 +74,7 @@ public partial class GameDatabaseContext : RealmDatabaseContext
         storage = new SequentialIdStorage
         {
             TypeName = name,
-            SequentialId = this.SequentialIdStorage.Count() * 2, // skip over a bunch of ids incase table is broken
+            SequentialId = this._realm.All<T>().Count() * 2, // skip over a bunch of ids incase table is broken
         };
 
         // no need to do write block, this should only be called in a write transaction

--- a/Refresh.GameServer/Database/RealmDbSet.cs
+++ b/Refresh.GameServer/Database/RealmDbSet.cs
@@ -32,4 +32,14 @@ public class RealmDbSet<T> : IQueryable<T> where T : IRealmObject
     {
         this._realm.Add(objs, update);
     }
+
+    public void Remove(T obj)
+    {
+        this._realm.Remove(obj);
+    }
+    
+    public void RemoveRange(IQueryable<T> objs)
+    {
+        this._realm.RemoveRange(objs);
+    }
 }

--- a/Refresh.GameServer/Database/RealmDbSet.cs
+++ b/Refresh.GameServer/Database/RealmDbSet.cs
@@ -28,6 +28,7 @@ public class RealmDbSet<T> : IQueryable<T> where T : IRealmObject
         this._realm.Add(obj);
     }
 
+    // TODO: update = true will need extra consideration for EF. for now just let consumers specify
     public void AddRange(IEnumerable<T> objs, bool update = false)
     {
         this._realm.Add(objs, update);

--- a/Refresh.GameServer/Database/RealmDbSet.cs
+++ b/Refresh.GameServer/Database/RealmDbSet.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Realms;
+
+namespace Refresh.GameServer.Database;
+
+public class RealmDbSet<T> : IQueryable<T> where T : IRealmObject
+{
+    private readonly Realm _realm;
+    private IQueryable<T> Queryable => this._realm.All<T>();
+
+    public RealmDbSet(Realm realm)
+    {
+        this._realm = realm;
+    }
+
+    [MustDisposeResource] public IEnumerator<T> GetEnumerator() => this.Queryable.GetEnumerator();
+    [MustDisposeResource] IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+    public Type ElementType => typeof(T);
+    public Expression Expression => this.Queryable.Expression;
+    public IQueryProvider Provider => this.Queryable.Provider;
+    
+    // functions for compatibility with EF
+    public void Add(T obj)
+    {
+        this._realm.Add(obj);
+    }
+
+    public void AddRange(IEnumerable<T> objs, bool update = false)
+    {
+        this._realm.Add(objs, update);
+    }
+}


### PR DESCRIPTION
- Introduces `RealmDbSet` class that provides... 'polyfills' I guess... for write operations on the realm, e.g. `this._realm.Add<T>`.
- Instead of using `this._realm.All<T>`, you now obtain queryables from the main class, e.g. `this.GameUsers` for `GameUser`.
- Write blocks now point to an easily replaceable function as discussed [on Discord](https://discord.com/channels/1049223665243389953/1049225857350254632/1252437212855930970).

Usage of `this._realm` is now **banned** outside of the main `GameDatabaseContext` class and `RealmDbSet` to keep source compatibility with EF.

I recommend a commit-by-commit review (and not looking at any of the `GameDatabaseContext.whatever.cs` files) for this one.