### PR TITLE
Prevent users from re-publishing a level twice.

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -7,7 +7,6 @@ using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
-using Refresh.GameServer.Types;
 using Refresh.GameServer.Types.Activity;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Matching;
@@ -391,6 +390,9 @@ public partial class GameDatabaseContext // Levels
                 return null;
         }
     }
+
+    public GameLevel? GetLevelByRootResource(string rootResource) =>
+        this.GameLevels.FirstOrDefault(level => level.RootResource == rootResource);
     
     [Pure]
     public GameLevel? GetLevelById(int id) => this.GameLevels.FirstOrDefault(l => l.LevelId == id);

--- a/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
@@ -57,7 +57,7 @@ public class PublishEndpoints : EndpointGroup
         // If there is an existing level with this root hash, and this isn't an update request, block the upload
         if (existingLevel != null && body.LevelId != existingLevel.LevelId)
         {
-            database.AddPublishFailNotification("You may not re-upload another user's level.", body.ToGameLevel(user), user);
+            database.AddPublishFailNotification("The level you tried to publish has already been uploaded by another user.", body.ToGameLevel(user), user);
  
             return false;
         }

--- a/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
@@ -29,7 +29,7 @@ public class PublishEndpoints : EndpointGroup
     /// <param name="guidChecker">The associated GuidCheckerService with the request</param>
     /// <param name="game">The game the level is being submitted from</param>
     /// <returns>Whether or not validation succeeded</returns>
-    private static bool VerifyLevel(GameLevelRequest body, GameUser user, Logger logger, GuidCheckerService guidChecker, TokenGame game, GameDatabaseContext database)
+    private static bool VerifyLevel(GameLevelRequest body, DataContext dataContext, GuidCheckerService guidChecker)
     {
         if (body.Title.Length > 256)
         {
@@ -49,43 +49,51 @@ public class PublishEndpoints : EndpointGroup
         //If the icon hash is a GUID hash, verify its a valid texture GUID
         if (body.IconHash.StartsWith('g'))
         {
-            if (!guidChecker.IsTextureGuid(game, long.Parse(body.IconHash.AsSpan()[1..])))
+            if (!guidChecker.IsTextureGuid(dataContext.Game, long.Parse(body.IconHash.AsSpan()[1..])))
                 return false;
         }
 
-        GameLevel? existingLevel = database.GetLevelByRootResource(body.RootResource);
+        GameLevel? existingLevel = dataContext.Database.GetLevelByRootResource(body.RootResource);
         // If there is an existing level with this root hash, and this isn't an update request, block the upload
         if (existingLevel != null && body.LevelId != existingLevel.LevelId)
         {
-            database.AddPublishFailNotification("The level you tried to publish has already been uploaded by another user.", body.ToGameLevel(user), user);
- 
+            dataContext.Database.AddPublishFailNotification("The level you tried to publish has already been uploaded by another user.", body.ToGameLevel(dataContext.User!), dataContext.User!);
+
             return false;
         }
-        
+
         return true;
     }
-    
+
     [GameEndpoint("startPublish", ContentType.Xml, HttpMethods.Post)]
     [NullStatusCode(BadRequest)]
-    public SerializedLevelResources? StartPublish(RequestContext context, GameUser user, GameDatabaseContext database, GameLevelRequest body, CommandService command, IDataStore dataStore, GuidCheckerService guidChecker, Token token)
+    public SerializedLevelResources? StartPublish(RequestContext context,
+        GameUser user,
+        GameLevelRequest body,
+        CommandService command,
+        IDataStore dataStore,
+        GuidCheckerService guidChecker,
+        DataContext dataContext)
     {
         //If verifying the request fails, return null
-        if (!VerifyLevel(body, user, context.Logger, guidChecker, token.TokenGame, database)) return null;
-        
-        List<string> hashes = new();
-        hashes.AddRange(body.XmlResources);
-        hashes.Add(body.RootResource);
-        hashes.Add(body.IconHash);
+        if (!VerifyLevel(body, dataContext, guidChecker)) return null;
+
+        List<string> hashes =
+        [
+            .. body.XmlResources,
+            body.RootResource,
+            body.IconHash
+        ];
 
         //Remove all invalid or GUID assets
         hashes.RemoveAll(r => r == "0" || r.StartsWith('g') || string.IsNullOrWhiteSpace(r));
-        
+
         //Verify all hashes are valid SHA1 hashes
         if (hashes.Any(hash => !CommonPatterns.Sha1Regex().IsMatch(hash))) return null;
 
         //Mark the user as publishing
         command.StartPublishing(user.UserId);
-            
+
         return new SerializedLevelResources
         {
             Resources = hashes.Where(r => !dataStore.ExistsInStore(r)).ToArray(),
@@ -103,8 +111,8 @@ public class PublishEndpoints : EndpointGroup
         GuidCheckerService guidChecker, DataContext dataContext)
     {
         //If verifying the request fails, return BadRequest
-        if (!VerifyLevel(body, user, context.Logger, guidChecker, token.TokenGame, database)) return BadRequest;
-        
+        if (!VerifyLevel(body, dataContext, guidChecker)) return BadRequest;
+
         GameLevel level = body.ToGameLevel(user);
         level.GameVersion = token.TokenGame;
 
@@ -112,7 +120,7 @@ public class PublishEndpoints : EndpointGroup
         level.MaxPlayers = Math.Clamp(level.MaxPlayers, 1, 4);
 
         string rootResourcePath = context.IsPSP() ? $"psp/{level.RootResource}" : level.RootResource;
-        
+
         //Check if the root resource is a SHA1 hash
         if (!CommonPatterns.Sha1Regex().IsMatch(level.RootResource)) return BadRequest;
         //Make sure the root resource exists in the data store
@@ -128,11 +136,11 @@ public class PublishEndpoints : EndpointGroup
             {
                 return new Response(GameLevelResponse.FromOld(newBody, dataContext)!, ContentType.Xml);
             }
-            
+
             database.AddPublishFailNotification("You may not republish another user's level.", level, user);
             return BadRequest;
         }
-        
+
         //Mark the user as no longer publishing
         commandService.StopPublishing(user.UserId);
 
@@ -140,9 +148,9 @@ public class PublishEndpoints : EndpointGroup
 
         database.AddLevel(level);
         database.CreateLevelUploadEvent(user, level);
-        
+
         context.Logger.LogInfo(BunkumCategory.UserContent, "User {0} (id: {1}) uploaded level id {2}", user.Username, user.UserId, level.LevelId);
-        
+
         return new Response(GameLevelResponse.FromOld(level, dataContext)!, ContentType.Xml);
     }
 

--- a/RefreshTests.GameServer/Tests/Levels/PublishEndpointsTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/PublishEndpointsTests.cs
@@ -400,7 +400,62 @@ public class PublishEndpointsTests : GameServerTest
         message = client2.PostAsync("/lbp/publish", new StringContent(level.AsXML())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(BadRequest));
     }
+    
+    [Test]
+    public void CantPublishSameRootLevelHashTwice()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user1 = context.CreateUser();
+        GameUser user2 = context.CreateUser();
 
+        using HttpClient client1 = context.GetAuthenticatedClient(TokenType.Game, user1);
+        using HttpClient client2 = context.GetAuthenticatedClient(TokenType.Game, user2);
+
+        GameLevelRequest level = new()
+        {
+            LevelId = 0,
+            Title = "TEST LEVEL",
+            IconHash = "g719",
+            Description = "DESCRIPTION",
+            Location = new GameLocation(),
+            GameVersion = 0,
+            RootResource = TEST_ASSET_HASH,
+            PublishDate = 0,
+            UpdateDate = 0,
+            MinPlayers = 0,
+            MaxPlayers = 0,
+            EnforceMinMaxPlayers = false,
+            SameScreenGame = false,
+            SkillRewards = new List<GameSkillReward>(),
+        };
+
+        HttpResponseMessage message = client1.PostAsync("/lbp/startPublish", new StringContent(level.AsXML())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(OK));
+
+        SerializedLevelResources resourcesToUpload = message.Content.ReadAsXML<SerializedLevelResources>();
+        Assert.That(resourcesToUpload.Resources, Has.Length.EqualTo(1));
+        Assert.That(resourcesToUpload.Resources[0], Is.EqualTo(TEST_ASSET_HASH));
+
+        //Upload our """level"""
+        message = client1.PostAsync($"/lbp/upload/{TEST_ASSET_HASH}", new ReadOnlyMemoryContent("LVLb"u8.ToArray())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(OK));
+        
+        //As user 1, publish a level
+        message = client1.PostAsync("/lbp/publish", new StringContent(level.AsXML())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(OK));
+
+        GameLevelResponse response = message.Content.ReadAsXML<GameLevelResponse>();
+        Assert.That(response.Title, Is.EqualTo(level.Title));
+        Assert.That(response.Description, Is.EqualTo(level.Description));
+
+        level.Title = "REPUBLISH!";
+        level.Description = "PANA KIN!!!! MI PAIN PEKO E SINA";
+        
+        //As user 2, try to publish a level with the same root hash
+        message = client2.PostAsync("/lbp/publish", new StringContent(level.AsXML())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(BadRequest));
+    }
+    
     [Test]
     public void UnpublishLevel()
     {


### PR DESCRIPTION
This should curb the reuploads on the official instance by a small amount. There isnt a good reason for a person to want to do this in a circumstance other than spamming/uploading a duplicate level. This is something we'd want to do after the dry archive import anyway, so might as well do it now since its very little code, and helps an immediate issue.