### PR TITLE
Remove `GamePhotoSubject` from database schema

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -32,9 +32,10 @@ public partial class GameDatabaseContext // Photos
             newPhoto.Level = this.GetLevelById(photo.Level.LevelId);
 
         float[] bounds = new float[SerializedPhotoSubject.FloatCount];
+
+        byte subjects = 0;
         foreach (SerializedPhotoSubject subject in photo.PhotoSubjects)
         {
-            GamePhotoSubject newSubject = new();
             GameUser? subjectUser = null;
             
             if (!string.IsNullOrEmpty(subject.Username)) 
@@ -42,11 +43,40 @@ public partial class GameDatabaseContext // Photos
             
             SerializedPhotoSubject.ParseBoundsList(subject.BoundsList, bounds);
 
-            newSubject.User = subjectUser;
-            newSubject.DisplayName = subject.DisplayName;
-            foreach (float coord in bounds) newSubject.Bounds.Add(coord);
-            
-            newPhoto.Subjects.Add(newSubject);
+            subjects++;
+            switch (subjects)
+            {
+                case 1:
+                    newPhoto.Subject1User = subjectUser;
+                    newPhoto.Subject1DisplayName = subject.DisplayName;
+                    foreach (float bound in bounds)
+                        newPhoto.Subject1Bounds.Add(bound);
+                    
+                    break;
+                case 2:
+                    newPhoto.Subject2User = subjectUser;
+                    newPhoto.Subject2DisplayName = subject.DisplayName;
+                    foreach (float bound in bounds)
+                        newPhoto.Subject2Bounds.Add(bound);
+                    
+                    break;
+                case 3:
+                    newPhoto.Subject3User = subjectUser;
+                    newPhoto.Subject3DisplayName = subject.DisplayName;
+                    foreach (float bound in bounds)
+                        newPhoto.Subject3Bounds.Add(bound);
+
+                    break;
+                case 4:
+                    newPhoto.Subject4User = subjectUser;
+                    newPhoto.Subject4DisplayName = subject.DisplayName;
+                    foreach (float bound in bounds)
+                        newPhoto.Subject4Bounds.Add(bound);
+
+                    break;
+                default:
+                    throw new InvalidOperationException($"Tried to process subject #{subjects}");
+            }
         }
 
         this.AddSequentialObject(newPhoto);

--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -33,7 +33,7 @@ public partial class GameDatabaseContext // Photos
 
         float[] bounds = new float[SerializedPhotoSubject.FloatCount];
 
-        byte subjects = 0;
+        List<GamePhotoSubject> gameSubjects = new(photo.PhotoSubjects.Count);
         foreach (SerializedPhotoSubject subject in photo.PhotoSubjects)
         {
             GameUser? subjectUser = null;
@@ -43,41 +43,10 @@ public partial class GameDatabaseContext // Photos
             
             SerializedPhotoSubject.ParseBoundsList(subject.BoundsList, bounds);
 
-            subjects++;
-            switch (subjects)
-            {
-                case 1:
-                    newPhoto.Subject1User = subjectUser;
-                    newPhoto.Subject1DisplayName = subject.DisplayName;
-                    foreach (float bound in bounds)
-                        newPhoto.Subject1Bounds.Add(bound);
-                    
-                    break;
-                case 2:
-                    newPhoto.Subject2User = subjectUser;
-                    newPhoto.Subject2DisplayName = subject.DisplayName;
-                    foreach (float bound in bounds)
-                        newPhoto.Subject2Bounds.Add(bound);
-                    
-                    break;
-                case 3:
-                    newPhoto.Subject3User = subjectUser;
-                    newPhoto.Subject3DisplayName = subject.DisplayName;
-                    foreach (float bound in bounds)
-                        newPhoto.Subject3Bounds.Add(bound);
-
-                    break;
-                case 4:
-                    newPhoto.Subject4User = subjectUser;
-                    newPhoto.Subject4DisplayName = subject.DisplayName;
-                    foreach (float bound in bounds)
-                        newPhoto.Subject4Bounds.Add(bound);
-
-                    break;
-                default:
-                    throw new InvalidOperationException($"Tried to process subject #{subjects}");
-            }
+            gameSubjects.Add(new GamePhotoSubject(subjectUser, subject.DisplayName, bounds));
         }
+
+        newPhoto.Subjects = gameSubjects;
 
         this.AddSequentialObject(newPhoto);
     }

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -12,11 +12,9 @@ using Refresh.GameServer.Types.Contests;
 using Refresh.GameServer.Types.Levels.SkillRewards;
 using Refresh.GameServer.Types.Notifications;
 using Refresh.GameServer.Types.Relations;
-using Refresh.GameServer.Types.Report;
 using Refresh.GameServer.Types.Reviews;
 using Refresh.GameServer.Types.UserData.Leaderboard;
-using GamePhoto = Refresh.GameServer.Types.Photos.GamePhoto;
-using GamePhotoSubject = Refresh.GameServer.Types.Photos.GamePhotoSubject;
+using Refresh.GameServer.Types.Photos;
 
 namespace Refresh.GameServer.Database;
 
@@ -58,7 +56,6 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         typeof(GameAsset),
         typeof(GameNotification),
         typeof(GamePhoto),
-        typeof(GamePhotoSubject),
         typeof(GameIpVerificationRequest),
         typeof(GameAnnouncement),
         typeof(QueuedRegistration),

--- a/Refresh.GameServer/Types/Photos/GamePhoto.cs
+++ b/Refresh.GameServer/Types/Photos/GamePhoto.cs
@@ -29,7 +29,53 @@ public partial class GamePhoto : IRealmObject, ISequentialId
     public GameAsset LargeAsset { get; set; }
     public string PlanHash { get; set; }
     
-    public IList<GamePhotoSubject> Subjects { get; }
+    [Ignored]
+    public IReadOnlyCollection<GamePhotoSubject> Subjects
+    {
+        get
+        {
+            List<GamePhotoSubject> subjects = new(4);
+            
+            if (this.Subject1DisplayName != null)
+                subjects.Add(new GamePhotoSubject(this.Subject1User, this.Subject1DisplayName, this.Subject1Bounds));
+            else return subjects;
+            
+            if (this.Subject2DisplayName != null)
+                subjects.Add(new GamePhotoSubject(this.Subject2User, this.Subject2DisplayName, this.Subject2Bounds));
+            else return subjects;
+            
+            if (this.Subject3DisplayName != null)
+                subjects.Add(new GamePhotoSubject(this.Subject3User, this.Subject3DisplayName, this.Subject3Bounds));
+            else return subjects;
+            
+            if (this.Subject4DisplayName != null)
+                subjects.Add(new GamePhotoSubject(this.Subject4User, this.Subject4DisplayName, this.Subject4Bounds));
+
+            return subjects;
+        }
+    }
+
+#nullable enable
+    #pragma warning disable CS8618 // realm forces us to have a non-nullable IList<float> so we have to have these shenanigans
+    
+    public GameUser? Subject1User { get; set; }
+    public string? Subject1DisplayName { get; set; }
+    public IList<float> Subject1Bounds { get; }
+    
+    public GameUser? Subject2User { get; set; }
+    public string? Subject2DisplayName { get; set; }
+    public IList<float> Subject2Bounds { get; }
+    
+    public GameUser? Subject3User { get; set; }
+    public string? Subject3DisplayName { get; set; }
+    public IList<float> Subject3Bounds { get; }
+    
+    public GameUser? Subject4User { get; set; }
+    public string? Subject4DisplayName { get; set; }
+    public IList<float> Subject4Bounds { get; }
+    
+    #pragma warning restore CS8618
+    #nullable disable
     
     [JsonIgnore] public int SequentialId
     {

--- a/Refresh.GameServer/Types/Photos/GamePhoto.cs
+++ b/Refresh.GameServer/Types/Photos/GamePhoto.cs
@@ -28,9 +28,11 @@ public partial class GamePhoto : IRealmObject, ISequentialId
     public GameAsset MediumAsset { get; set; }
     public GameAsset LargeAsset { get; set; }
     public string PlanHash { get; set; }
+
+    #region Subjects
     
     [Ignored]
-    public IReadOnlyCollection<GamePhotoSubject> Subjects
+    public IReadOnlyList<GamePhotoSubject> Subjects
     {
         get
         {
@@ -53,6 +55,62 @@ public partial class GamePhoto : IRealmObject, ISequentialId
 
             return subjects;
         }
+        set
+        {
+            if (value.Count > 4) throw new InvalidOperationException("Too many subjects. Should be caught beforehand by input validation");
+            this.ClearSubjects();
+
+            if (value.Count >= 1)
+            {
+                this.Subject1User = value[0].User;
+                this.Subject1DisplayName = value[0].DisplayName;
+                foreach (float bound in value[0].Bounds)
+                    this.Subject1Bounds.Add(bound);
+            }
+            
+            if (value.Count >= 2)
+            {
+                this.Subject2User = value[1].User;
+                this.Subject2DisplayName = value[1].DisplayName;
+                foreach (float bound in value[1].Bounds)
+                    this.Subject2Bounds.Add(bound);
+            }
+            
+            if (value.Count >= 3)
+            {
+                this.Subject3User = value[2].User;
+                this.Subject3DisplayName = value[2].DisplayName;
+                foreach (float bound in value[2].Bounds)
+                    this.Subject3Bounds.Add(bound);
+            }
+            
+            if (value.Count >= 4)
+            {
+                this.Subject4User = value[3].User;
+                this.Subject4DisplayName = value[3].DisplayName;
+                foreach (float bound in value[3].Bounds)
+                    this.Subject4Bounds.Add(bound);
+            }
+        }
+    }
+
+    private void ClearSubjects()
+    {
+        this.Subject1User = null;
+        this.Subject1DisplayName = null;
+        this.Subject1Bounds.Clear();
+        
+        this.Subject2User = null;
+        this.Subject2DisplayName = null;
+        this.Subject2Bounds.Clear();
+        
+        this.Subject3User = null;
+        this.Subject3DisplayName = null;
+        this.Subject3Bounds.Clear();
+        
+        this.Subject4User = null;
+        this.Subject4DisplayName = null;
+        this.Subject4Bounds.Clear();
     }
 
 #nullable enable
@@ -76,6 +134,8 @@ public partial class GamePhoto : IRealmObject, ISequentialId
     
     #pragma warning restore CS8618
     #nullable disable
+    
+    #endregion
     
     [JsonIgnore] public int SequentialId
     {

--- a/Refresh.GameServer/Types/Photos/GamePhotoSubject.cs
+++ b/Refresh.GameServer/Types/Photos/GamePhotoSubject.cs
@@ -1,16 +1,23 @@
 using System.Xml.Serialization;
-using Realms;
 using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Photos;
 
 [XmlRoot("subject")]
 [XmlType("subject")]
-public partial class GamePhotoSubject : IEmbeddedObject
+public class GamePhotoSubject
 {
-    public GameUser? User { get; set; }
+    public GamePhotoSubject() {}
 
-#nullable disable
+    public GamePhotoSubject(GameUser? user, string displayName, IList<float> bounds)
+    {
+        this.User = user;
+        this.DisplayName = displayName;
+        this.Bounds = bounds;
+    }
+
+    public GameUser? User { get; set; }
+    
     public string DisplayName { get; set; }
     public IList<float> Bounds { get; }
 }


### PR DESCRIPTION
Instead of storing a list of `GamePhotoSubject`s as `IEmbeddedObject`s under `GamePhoto`, I took the fields of `GamePhotoSubject` and unrolled them to 4 (not arbitrary, this represents the max number of players you may have in an LBP lobby) sets of fields under `GamePhoto`.

This makes things sloppy when handling model code, but does make it compatible with Postgres. I've done my best to mask this behind the existing `Subjects` list, which I've repurposed to be a getter/setter that emulates the original behavior, while still keeping the `GamePhotoSubject` class for compatibility/ease of use with existing code.

I've included migrations which are a little sketchy, but they seem to work fine on my end. Uploading new photos is untested in-game but it uses mostly the same code as the migrations so it should be okay.