### PR TITLE
Fix incorrect rank when paginating scores

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
@@ -104,6 +104,6 @@ public class LeaderboardEndpoints : EndpointGroup
         if (level == null) return NotFound;
         
         (int skip, int count) = context.GetPageData();
-        return new Response(SerializedScoreList.FromSubmittedEnumerable(database.GetTopScoresForLevel(level, count, skip, (byte)type).Items), ContentType.Xml);
+        return new Response(SerializedScoreList.FromSubmittedEnumerable(database.GetTopScoresForLevel(level, count, skip, (byte)type).Items, skip), ContentType.Xml);
     }
 }

--- a/Refresh.GameServer/Types/Lists/SerializedScoreList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedScoreList.cs
@@ -9,11 +9,11 @@ public class SerializedScoreList
     [XmlElement("playRecord")]
     public List<SerializedLeaderboardScore> Scores { get; set; } = new();
 
-    public static SerializedScoreList FromSubmittedEnumerable(IEnumerable<GameSubmittedScore> list)
+    public static SerializedScoreList FromSubmittedEnumerable(IEnumerable<GameSubmittedScore> list, int skip)
     {
         SerializedScoreList value = new();
 
-        int i = 0;
+        int i = skip;
         foreach (GameSubmittedScore score in list)
         {
             i++;


### PR DESCRIPTION
Closes #498

Previously when serializing scores, the scores' ranks would not be set properly after the first page. This is because the game depends on a `Rank` value being set correctly server-side.

The server-side was failing to take in the `skip` query parameter when setting the Rank value, so every page would begin at rank #1.

To fix, pass it in when making the `SerializedScoreList`.