### PR TITLE
FindRoomMethod: Fix level ID search & always print room state

### DIFF
--- a/Refresh.GameServer/Configuration/GameServerConfig.cs
+++ b/Refresh.GameServer/Configuration/GameServerConfig.cs
@@ -9,7 +9,7 @@ namespace Refresh.GameServer.Configuration;
 [SuppressMessage("ReSharper", "RedundantDefaultMemberInitializer")]
 public class GameServerConfig : Config
 {
-    public override int CurrentConfigVersion => 15;
+    public override int CurrentConfigVersion => 16;
     public override int Version { get; set; } = 0;
 
     protected override void Migrate(int oldVer, dynamic oldConfig) {}
@@ -45,4 +45,8 @@ public class GameServerConfig : Config
     /// The amount of data the user is allowed to upload before all resource uploads get blocked, defaults to 100mb.
     /// </summary>
     public int UserFilesizeQuota { get; set; } = 100 * 1_048_576;
+    /// <summary>
+    /// Whether to print the room state whenever a `FindBestRoom` match returns no results
+    /// </summary>
+    public bool PrintRoomStateWhenNoFoundRooms { get; set; } = true;
 }

--- a/Refresh.GameServer/Endpoints/Game/MatchingEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/MatchingEndpoints.cs
@@ -5,6 +5,7 @@ using Bunkum.Core.Responses;
 using Bunkum.Listener.Protocol;
 using Bunkum.Protocols.Http;
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Matching;
@@ -17,7 +18,14 @@ public class MatchingEndpoints : EndpointGroup
     // [FindBestRoom,["Players":["VitaGamer128"],"Reservations":["0"],"NAT":[2],"Slots":[[5,0]],"Location":[0x17257bc9,0x17257bf2],"Language":1,"BuildVersion":289,"Search":"","RoomState":3]]
     [GameEndpoint("match", HttpMethods.Post, ContentType.Json)]
     [DebugRequestBody, DebugResponseBody]
-    public Response Match(RequestContext context, GameDatabaseContext database, GameUser user, Token token, MatchService service, string body)
+    public Response Match(
+        RequestContext context, 
+        GameDatabaseContext database, 
+        GameUser user, 
+        Token token, 
+        MatchService service, 
+        string body, 
+        GameServerConfig gameServerConfig)
     {
         (string method, string jsonBody) = MatchService.ExtractMethodAndBodyFromJson(body);
         context.Logger.LogInfo(BunkumCategory.Matching, $"Received {method} match request, data: {jsonBody}");
@@ -35,7 +43,7 @@ public class MatchingEndpoints : EndpointGroup
             return BadRequest;
         }
         
-        return service.ExecuteMethod(method, roomData, database, user, token);
+        return service.ExecuteMethod(method, roomData, database, user, token, gameServerConfig);
     }
     
     // Sent by LBP1 to notify the server it has entered a level.

--- a/Refresh.GameServer/Endpoints/Game/MatchingEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/MatchingEndpoints.cs
@@ -6,10 +6,9 @@ using Bunkum.Listener.Protocol;
 using Bunkum.Protocols.Http;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Configuration;
-using Refresh.GameServer.Database;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
-using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Endpoints.Game;
 
@@ -20,11 +19,8 @@ public class MatchingEndpoints : EndpointGroup
     [DebugRequestBody, DebugResponseBody]
     public Response Match(
         RequestContext context, 
-        GameDatabaseContext database, 
-        GameUser user, 
-        Token token, 
-        MatchService service, 
         string body, 
+        DataContext dataContext,
         GameServerConfig gameServerConfig)
     {
         (string method, string jsonBody) = MatchService.ExtractMethodAndBodyFromJson(body);
@@ -43,7 +39,7 @@ public class MatchingEndpoints : EndpointGroup
             return BadRequest;
         }
         
-        return service.ExecuteMethod(method, roomData, database, user, token, gameServerConfig);
+        return dataContext.Match.ExecuteMethod(method, roomData, dataContext, gameServerConfig);
     }
     
     // Sent by LBP1 to notify the server it has entered a level.

--- a/Refresh.GameServer/Services/MatchService.cs
+++ b/Refresh.GameServer/Services/MatchService.cs
@@ -7,7 +7,7 @@ using Bunkum.Core.Responses;
 using Bunkum.Listener.Protocol;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Configuration;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 using Refresh.GameServer.Types.Matching.MatchMethods;
 using Refresh.GameServer.Types.Matching.Responses;
@@ -132,12 +132,12 @@ public partial class MatchService(Logger logger) : EndpointService(logger)
     private IMatchMethod? TryGetMatchMethod(string method) 
         => this._matchMethods.FirstOrDefault(m => m.MethodNames.Contains(method));
 
-    public Response ExecuteMethod(string methodStr, SerializedRoomData roomData, GameDatabaseContext database, GameUser user, Token token, GameServerConfig gameServerConfig)
+    public Response ExecuteMethod(string methodStr, SerializedRoomData roomData, DataContext dataContext, GameServerConfig gameServerConfig)
     {
         IMatchMethod? method = this.TryGetMatchMethod(methodStr);
         if (method == null) return BadRequest;
         
-        Response response = method.Execute(this, this.Logger, database, user, token, roomData, gameServerConfig);
+        Response response = method.Execute(dataContext, roomData, gameServerConfig);
         
         // If there's a response data specified, then there's nothing more we need to do
         if (response.Data.Length != 0) 

--- a/Refresh.GameServer/Services/MatchService.cs
+++ b/Refresh.GameServer/Services/MatchService.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Bunkum.Core.Responses;
 using Bunkum.Listener.Protocol;
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Types.Matching;
 using Refresh.GameServer.Types.Matching.MatchMethods;
@@ -131,12 +132,12 @@ public partial class MatchService(Logger logger) : EndpointService(logger)
     private IMatchMethod? TryGetMatchMethod(string method) 
         => this._matchMethods.FirstOrDefault(m => m.MethodNames.Contains(method));
 
-    public Response ExecuteMethod(string methodStr, SerializedRoomData roomData, GameDatabaseContext database, GameUser user, Token token)
+    public Response ExecuteMethod(string methodStr, SerializedRoomData roomData, GameDatabaseContext database, GameUser user, Token token, GameServerConfig gameServerConfig)
     {
         IMatchMethod? method = this.TryGetMatchMethod(methodStr);
         if (method == null) return BadRequest;
         
-        Response response = method.Execute(this, this.Logger, database, user, token, roomData);
+        Response response = method.Execute(this, this.Logger, database, user, token, roomData, gameServerConfig);
         
         // If there's a response data specified, then there's nothing more we need to do
         if (response.Data.Length != 0) 

--- a/Refresh.GameServer/Types/Matching/MatchMethods/CreateRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/CreateRoomMethod.cs
@@ -2,6 +2,7 @@ using Bunkum.Core;
 using Bunkum.Core.Responses;
 using NotEnoughLogs;
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.UserData;
@@ -12,8 +13,9 @@ public class CreateRoomMethod : IMatchMethod
 {
     public IEnumerable<string> MethodNames => new[] { "CreateRoom" };
 
-    public Response Execute(MatchService service, Logger logger, GameDatabaseContext database, GameUser user, Token token,
-        SerializedRoomData body)
+    public Response Execute(MatchService service, Logger logger, GameDatabaseContext database, GameUser user,
+        Token token,
+        SerializedRoomData body, GameServerConfig gameServerConfig)
     {
         NatType natType = body.NatType == null ? NatType.Open : body.NatType[0];
         GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, natType, body.BuildVersion, body.PassedNoJoinPoint);

--- a/Refresh.GameServer/Types/Matching/MatchMethods/FindRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/FindRoomMethod.cs
@@ -4,6 +4,7 @@ using Bunkum.Listener.Protocol;
 using MongoDB.Bson;
 using NotEnoughLogs;
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Levels;
@@ -19,7 +20,7 @@ public class FindRoomMethod : IMatchMethod
     public Response Execute(MatchService service, Logger logger, GameDatabaseContext database,
         GameUser user,
         Token token,
-        SerializedRoomData body)
+        SerializedRoomData body, GameServerConfig gameServerConfig)
     {
         GameRoom? usersRoom = service.RoomAccessor.GetRoomByUser(user, token.TokenPlatform, token.TokenGame);
         if (usersRoom == null) return BadRequest; // user should already have a room.
@@ -101,7 +102,7 @@ public class FindRoomMethod : IMatchMethod
         List<GameRoom> foundRooms = rooms.ToList();
         
         // If there's no rooms, dump an "overview" of the global room state, to help debug matching issues
-        if (foundRooms.Count <= 0)
+        if (foundRooms.Count <= 0 && gameServerConfig.PrintRoomStateWhenNoFoundRooms)
         {
             if (allRooms.Count == 0)
             {

--- a/Refresh.GameServer/Types/Matching/MatchMethods/IMatchMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/IMatchMethod.cs
@@ -2,6 +2,7 @@ using Bunkum.Core.Responses;
 using JetBrains.Annotations;
 using NotEnoughLogs;
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.UserData;
@@ -14,5 +15,6 @@ public interface IMatchMethod
     IEnumerable<string> MethodNames { get; }
 
     Response Execute(MatchService service, Logger logger,
-        GameDatabaseContext database, GameUser user, Token token, SerializedRoomData body);
+        GameDatabaseContext database, GameUser user, Token token, SerializedRoomData body,
+        GameServerConfig gameServerConfig);
 }

--- a/Refresh.GameServer/Types/Matching/MatchMethods/IMatchMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/IMatchMethod.cs
@@ -1,11 +1,7 @@
 using Bunkum.Core.Responses;
 using JetBrains.Annotations;
-using NotEnoughLogs;
-using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Configuration;
-using Refresh.GameServer.Database;
-using Refresh.GameServer.Services;
-using Refresh.GameServer.Types.UserData;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Types.Matching.MatchMethods;
 
@@ -14,7 +10,5 @@ public interface IMatchMethod
 {
     IEnumerable<string> MethodNames { get; }
 
-    Response Execute(MatchService service, Logger logger,
-        GameDatabaseContext database, GameUser user, Token token, SerializedRoomData body,
-        GameServerConfig gameServerConfig);
+    Response Execute(DataContext dataContext, SerializedRoomData body, GameServerConfig gameServerConfig);
 }

--- a/Refresh.GameServer/Types/Matching/MatchMethods/UpdatePlayersInRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/UpdatePlayersInRoomMethod.cs
@@ -1,6 +1,7 @@
 using Bunkum.Core.Responses;
 using NotEnoughLogs;
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.UserData;
@@ -14,7 +15,7 @@ public class UpdatePlayersInRoomMethod : IMatchMethod
     public Response Execute(MatchService service, Logger logger, GameDatabaseContext database,
         GameUser user,
         Token token,
-        SerializedRoomData body)
+        SerializedRoomData body, GameServerConfig gameServerConfig)
     {
         if (body.Players == null) return BadRequest;
         GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint);

--- a/Refresh.GameServer/Types/Matching/MatchMethods/UpdatePlayersInRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/UpdatePlayersInRoomMethod.cs
@@ -1,9 +1,6 @@
 using Bunkum.Core.Responses;
-using NotEnoughLogs;
-using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Configuration;
-using Refresh.GameServer.Database;
-using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Matching.MatchMethods;
@@ -12,22 +9,19 @@ public class UpdatePlayersInRoomMethod : IMatchMethod
 {
     public IEnumerable<string> MethodNames => new[] { "UpdatePlayersInRoom" };
 
-    public Response Execute(MatchService service, Logger logger, GameDatabaseContext database,
-        GameUser user,
-        Token token,
-        SerializedRoomData body, GameServerConfig gameServerConfig)
+    public Response Execute(DataContext dataContext, SerializedRoomData body, GameServerConfig gameServerConfig)
     {
         if (body.Players == null) return BadRequest;
-        GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint);
+        GameRoom room = dataContext.Match.GetOrCreateRoomByPlayer(dataContext.User!, dataContext.Platform, dataContext.Game, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint);
         
         foreach (string playerUsername in body.Players)
         {
-            GameUser? player = database.GetUserByUsername(playerUsername);
+            GameUser? player = dataContext.Database.GetUserByUsername(playerUsername);
             
             if (player != null)
-                service.AddPlayerToRoom(player, room, token.TokenPlatform, token.TokenGame);
+                dataContext.Match.AddPlayerToRoom(player, room, dataContext.Platform, dataContext.Game);
             else
-                service.AddPlayerToRoom(playerUsername, room);
+                dataContext.Match.AddPlayerToRoom(playerUsername, room);
         }
 
         return OK;

--- a/Refresh.GameServer/Types/Matching/MatchMethods/UpdateRoomDataMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/UpdateRoomDataMethod.cs
@@ -1,11 +1,7 @@
 using Bunkum.Core;
 using Bunkum.Core.Responses;
-using NotEnoughLogs;
-using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Configuration;
-using Refresh.GameServer.Database;
-using Refresh.GameServer.Services;
-using Refresh.GameServer.Types.UserData;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Types.Matching.MatchMethods;
 
@@ -13,19 +9,17 @@ public class UpdateRoomDataMethod : IMatchMethod
 {
     public IEnumerable<string> MethodNames => new[] { "UpdateMyPlayerData" };
 
-    public Response Execute(MatchService service, Logger logger,
-        GameDatabaseContext database, GameUser user, Token token, SerializedRoomData body,
-        GameServerConfig gameServerConfig)
+    public Response Execute(DataContext dataContext, SerializedRoomData body, GameServerConfig gameServerConfig)
     {
-        GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint);
-        if (room.HostId.Id != user.UserId) return Unauthorized;
+        GameRoom room = dataContext.Match.GetOrCreateRoomByPlayer(dataContext.User!, dataContext.Platform, dataContext.Game, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint);
+        if (room.HostId.Id != dataContext.User!.UserId) return Unauthorized;
 
         if (body.RoomState != null) room.RoomState = body.RoomState.Value;
         
         // Players cannot be in multiple levels at once
         if (body.Slots.Count > 1)
         {
-            logger.LogWarning(BunkumCategory.Matching, "Received update room request with multiple slots, rejecting");
+            dataContext.Logger.LogWarning(BunkumCategory.Matching, "Received update room request with multiple slots, rejecting");
             return BadRequest;
         }
         
@@ -33,7 +27,7 @@ public class UpdateRoomDataMethod : IMatchMethod
         {
             if (slot.Count != 2)
             {
-                logger.LogWarning(BunkumCategory.Matching, "Received request with invalid slot, rejecting.");
+                dataContext.Logger.LogWarning(BunkumCategory.Matching, "Received request with invalid slot, rejecting.");
                 return BadRequest;
             }
 
@@ -52,7 +46,7 @@ public class UpdateRoomDataMethod : IMatchMethod
             room.PassedNoJoinPoint = body.PassedNoJoinPoint.Value;
         }
         
-        service.RoomAccessor.UpdateRoom(room);
+        dataContext.Match.RoomAccessor.UpdateRoom(room);
 
         return OK;
     }

--- a/Refresh.GameServer/Types/Matching/MatchMethods/UpdateRoomDataMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/UpdateRoomDataMethod.cs
@@ -2,6 +2,7 @@ using Bunkum.Core;
 using Bunkum.Core.Responses;
 using NotEnoughLogs;
 using Refresh.GameServer.Authentication;
+using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.UserData;
@@ -13,7 +14,8 @@ public class UpdateRoomDataMethod : IMatchMethod
     public IEnumerable<string> MethodNames => new[] { "UpdateMyPlayerData" };
 
     public Response Execute(MatchService service, Logger logger,
-        GameDatabaseContext database, GameUser user, Token token, SerializedRoomData body)
+        GameDatabaseContext database, GameUser user, Token token, SerializedRoomData body,
+        GameServerConfig gameServerConfig)
     {
         GameRoom room = service.GetOrCreateRoomByPlayer(user, token.TokenPlatform, token.TokenGame, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint);
         if (room.HostId.Id != user.UserId) return Unauthorized;

--- a/RefreshTests.GameServer/Tests/Matching/MatchingTests.cs
+++ b/RefreshTests.GameServer/Tests/Matching/MatchingTests.cs
@@ -33,8 +33,8 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
 
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         
         Assert.Multiple(() =>
         {
@@ -73,7 +73,7 @@ public class MatchingTests : GameServerTest
         // Setup room
         GameUser user1 = context.CreateUser();
         Token token1 = context.CreateToken(user1);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
         
         // Tell user1 to try to find a room
         Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData
@@ -82,7 +82,7 @@ public class MatchingTests : GameServerTest
             {
                 NatType.Open,
             },
-        }, context.Database, user1, token1);
+        }, context.Database, user1, token1, context.Server.Value.GameServerConfig);
 
         // Deserialize the result
         List<SerializedStatusCodeMatchResponse> responseObjects =
@@ -117,8 +117,8 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         
         // Tell user2 to try to find a room
         Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData
@@ -126,7 +126,7 @@ public class MatchingTests : GameServerTest
             NatType = new List<NatType> {
                 NatType.Strict,
             },
-        }, context.Database, user2, token2);
+        }, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         
         //Deserialize the result
         List<SerializedStatusCodeMatchResponse> responseObjects =
@@ -170,8 +170,8 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1);
-        match.ExecuteMethod("CreateRoom", roomData2, context.Database, user2, token2);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData2, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         
         // Tell user2 to try to find a room
         Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData
@@ -179,7 +179,7 @@ public class MatchingTests : GameServerTest
             NatType = new List<NatType> {
                 NatType.Strict,
             },
-        }, context.Database, user2, token2);
+        }, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         Assert.That(response.StatusCode, Is.EqualTo(OK));
     }
 
@@ -206,8 +206,8 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         
         // Tell user2 to try to find a room
         Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData
@@ -215,7 +215,7 @@ public class MatchingTests : GameServerTest
             NatType = new List<NatType> {
                 NatType.Open,
             },
-        }, context.Database, user2, token2);
+        }, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         Assert.That(response.StatusCode, Is.EqualTo(OK));
     }
 
@@ -242,8 +242,8 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         
         // Get user1 and user2 in the same room
         roomData.Players = new List<string>
@@ -252,7 +252,7 @@ public class MatchingTests : GameServerTest
             user2.Username,
         };
 
-        match.ExecuteMethod("UpdatePlayersInRoom", roomData, context.Database, user1, token1);
+        match.ExecuteMethod("UpdatePlayersInRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
         GameRoom? room = match.RoomAccessor.GetRoomByUser(user1);
         Assert.Multiple(() =>
         {
@@ -286,8 +286,8 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
         
         // Get user1 and user2 in the same room
         roomData.Players = new List<string>
@@ -297,14 +297,14 @@ public class MatchingTests : GameServerTest
         };
 
         {
-            match.ExecuteMethod("UpdatePlayersInRoom", roomData, context.Database, user1, token1);
+            match.ExecuteMethod("UpdatePlayersInRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
             GameRoom? user1Room = match.RoomAccessor.GetRoomByUser(user1);
             Assert.That(user1Room, Is.Not.Null);
             Assert.That(user1Room!.PlayerIds.FirstOrDefault(r => r.Id == user2.UserId), Is.Not.Null);
         }
 
         {
-            match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2);
+            match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
             GameRoom? user1Room = match.RoomAccessor.GetRoomByUser(user1);
             GameRoom? user2Room = match.RoomAccessor.GetRoomByUser(user2);
             Assert.That(user1Room, Is.Not.Null);

--- a/RefreshTests.GameServer/Tests/Matching/MatchingTests.cs
+++ b/RefreshTests.GameServer/Tests/Matching/MatchingTests.cs
@@ -4,6 +4,7 @@ using Bunkum.Core.Responses;
 using Newtonsoft.Json;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Matching;
 using Refresh.GameServer.Types.Matching.Responses;
 using Refresh.GameServer.Types.UserData;
@@ -33,8 +34,22 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
 
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!,
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         
         Assert.Multiple(() =>
         {
@@ -73,7 +88,14 @@ public class MatchingTests : GameServerTest
         // Setup room
         GameUser user1 = context.CreateUser();
         Token token1 = context.CreateToken(user1);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
         
         // Tell user1 to try to find a room
         Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData
@@ -82,7 +104,14 @@ public class MatchingTests : GameServerTest
             {
                 NatType.Open,
             },
-        }, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        }, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
 
         // Deserialize the result
         List<SerializedStatusCodeMatchResponse> responseObjects =
@@ -117,16 +146,31 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!,
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         
         // Tell user2 to try to find a room
-        Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData
-        {
-            NatType = new List<NatType> {
-                NatType.Strict,
-            },
-        }, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData { NatType = [NatType.Strict], }, new DataContext {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!,
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         
         //Deserialize the result
         List<SerializedStatusCodeMatchResponse> responseObjects =
@@ -170,8 +214,22 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
-        match.ExecuteMethod("CreateRoom", roomData2, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData2, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!,
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         
         // Tell user2 to try to find a room
         Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData
@@ -179,7 +237,14 @@ public class MatchingTests : GameServerTest
             NatType = new List<NatType> {
                 NatType.Strict,
             },
-        }, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        }, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         Assert.That(response.StatusCode, Is.EqualTo(OK));
     }
 
@@ -206,8 +271,22 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!,
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         
         // Tell user2 to try to find a room
         Response response = match.ExecuteMethod("FindBestRoom", new SerializedRoomData
@@ -215,7 +294,14 @@ public class MatchingTests : GameServerTest
             NatType = new List<NatType> {
                 NatType.Open,
             },
-        }, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        }, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         Assert.That(response.StatusCode, Is.EqualTo(OK));
     }
 
@@ -242,8 +328,22 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!,
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         
         // Get user1 and user2 in the same room
         roomData.Players = new List<string>
@@ -252,7 +352,14 @@ public class MatchingTests : GameServerTest
             user2.Username,
         };
 
-        match.ExecuteMethod("UpdatePlayersInRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("UpdatePlayersInRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
         GameRoom? room = match.RoomAccessor.GetRoomByUser(user1);
         Assert.Multiple(() =>
         {
@@ -286,8 +393,22 @@ public class MatchingTests : GameServerTest
         Token token1 = context.CreateToken(user1);
         Token token2 = context.CreateToken(user2);
         
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
-        match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!, //this isn't accessed by matching
+            Match = match,
+            Token = token1,
+        }, context.Server.Value.GameServerConfig);
+        match.ExecuteMethod("CreateRoom", roomData, new DataContext
+        {
+            Database = context.Database,
+            Logger = context.Server.Value.Logger,
+            DataStore = null!,
+            Match = match,
+            Token = token2,
+        }, context.Server.Value.GameServerConfig);
         
         // Get user1 and user2 in the same room
         roomData.Players = new List<string>
@@ -297,14 +418,28 @@ public class MatchingTests : GameServerTest
         };
 
         {
-            match.ExecuteMethod("UpdatePlayersInRoom", roomData, context.Database, user1, token1, context.Server.Value.GameServerConfig);
+            match.ExecuteMethod("UpdatePlayersInRoom", roomData, new DataContext
+            {
+                Database = context.Database,
+                Logger = context.Server.Value.Logger,
+                DataStore = null!, //this isn't accessed by matching
+                Match = match,
+                Token = token1,
+            }, context.Server.Value.GameServerConfig);
             GameRoom? user1Room = match.RoomAccessor.GetRoomByUser(user1);
             Assert.That(user1Room, Is.Not.Null);
             Assert.That(user1Room!.PlayerIds.FirstOrDefault(r => r.Id == user2.UserId), Is.Not.Null);
         }
 
         {
-            match.ExecuteMethod("CreateRoom", roomData, context.Database, user2, token2, context.Server.Value.GameServerConfig);
+            match.ExecuteMethod("CreateRoom", roomData, new DataContext
+            {
+                Database = context.Database,
+                Logger = context.Server.Value.Logger,
+                DataStore = null!, //this isn't accessed by matching
+                Match = match,
+                Token = token2,
+            }, context.Server.Value.GameServerConfig);
             GameRoom? user1Room = match.RoomAccessor.GetRoomByUser(user1);
             GameRoom? user2Room = match.RoomAccessor.GetRoomByUser(user2);
             Assert.That(user1Room, Is.Not.Null);


### PR DESCRIPTION
Printing the room state out always helps a lot with debugging when people state that "dive in doesn't work". 
Often by the time someone responds "can you take a capture of the API room output", the room state has changed enough where it's not as helpful, the API also doesn't expose info like NAT type or build version. This change makes sure that we can easily see exactly what the server was seeing when it filtered down the rooms, and can narrow down why no rooms were found.

If the extra noise does become a problem in the future when we grow and have many rooms, I have made the dump a config option, so that it can be easily disabled/re-enabled when needed.

The level ID search changes should also fix some issues people have been having with dive in.