### PR TITLE
Refactor CreateUser to accept a role to set, implement curator role

### DIFF
--- a/.idea/.idea.Refresh/.idea/git_toolbox_blame.xml
+++ b/.idea/.idea.Refresh/.idea/git_toolbox_blame.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxBlameSettings">
+    <option name="version" value="2" />
+  </component>
+</project>

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
@@ -6,7 +6,6 @@ using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
-using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Levels;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
@@ -17,7 +16,7 @@ namespace Refresh.GameServer.Endpoints.ApiV3.Admin;
 
 public class AdminLevelApiEndpoints : EndpointGroup
 {
-    [ApiV3Endpoint("admin/levels/id/{id}/teamPick", HttpMethods.Post), MinimumRole(GameUserRole.Admin)]
+    [ApiV3Endpoint("admin/levels/id/{id}/teamPick", HttpMethods.Post), MinimumRole(GameUserRole.Curator)]
     [DocSummary("Marks a level as team picked.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     public ApiOkResponse AddTeamPickToLevel(RequestContext context, GameDatabaseContext database, GameUser user, int id)
@@ -30,7 +29,7 @@ public class AdminLevelApiEndpoints : EndpointGroup
         return new ApiOkResponse();
     }
     
-    [ApiV3Endpoint("admin/levels/id/{id}/removeTeamPick", HttpMethods.Post), MinimumRole(GameUserRole.Admin)]
+    [ApiV3Endpoint("admin/levels/id/{id}/removeTeamPick", HttpMethods.Post), MinimumRole(GameUserRole.Curator)]
     [DocSummary("Removes a level's team pick status.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     public ApiOkResponse RemoveTeamPickFromLevel(RequestContext context, GameDatabaseContext database, int id)
@@ -42,7 +41,7 @@ public class AdminLevelApiEndpoints : EndpointGroup
         return new ApiOkResponse();
     }
     
-    [ApiV3Endpoint("admin/levels/id/{id}", HttpMethods.Patch), MinimumRole(GameUserRole.Admin)]
+    [ApiV3Endpoint("admin/levels/id/{id}", HttpMethods.Patch), MinimumRole(GameUserRole.Curator)]
     [DocSummary("Updates a level.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     [DocError(typeof(ApiAuthenticationError), ApiAuthenticationError.NoPermissionsForObjectWhen)]

--- a/Refresh.GameServer/Types/Roles/GameUserRole.cs
+++ b/Refresh.GameServer/Types/Roles/GameUserRole.cs
@@ -13,6 +13,10 @@ public enum GameUserRole : sbyte
     /// </summary>
     Admin = 127,
     /// <summary>
+    /// A user that doesn't have moderator powers, but may team pick levels, set re-upload data, and adjust the level's game version.
+    /// </summary>
+    Curator = 64,
+    /// <summary>
     /// A user with special permissions. May upload assets when asset uploads are otherwise disabled.
     /// </summary>
     Trusted = 1,

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -95,16 +95,13 @@ public class TestContext : IDisposable
         return client;
     }
 
-    public GameUser CreateUser(string? username = null)
+    public GameUser CreateUser(string? username = null, GameUserRole role = GameUserRole.User)
     {
         username ??= this.UserIncrement.ToString();
-        return this.Database.CreateUser(username, $"{username}@{username}.local");
-    }
+        
+        GameUser user = this.Database.CreateUser(username, $"{username}@{username}.local");
+        if (role != GameUserRole.User) this.Database.SetUserRole(user, role);
 
-    public GameUser CreateAdmin(string? username = null)
-    {
-        GameUser user = this.CreateUser(username);
-        this.Database.SetUserRole(user, GameUserRole.Admin);
         return user;
     }
 

--- a/RefreshTests.GameServer/Tests/ApiV3/EditApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/EditApiTests.cs
@@ -3,6 +3,7 @@ using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
 namespace RefreshTests.GameServer.Tests.ApiV3;
@@ -63,11 +64,13 @@ public class EditApiTests : GameServerTest
     }
 
     [Test]
-    public void AdminCanUpdateLevel()
+    [TestCase(GameUserRole.Admin)]
+    [TestCase(GameUserRole.Curator)]
+    public void RoleCanUpdateLevel(GameUserRole role)
     {
         using TestContext context = this.GetServer();
         GameUser user = context.CreateUser();
-        GameUser admin = context.CreateAdmin();
+        GameUser admin = context.CreateUser(role: role);
         GameLevel level = context.CreateLevel(user, "Not updated");
 
         long oldUpdate = level.UpdateDate;

--- a/RefreshTests.GameServer/Tests/Levels/ContestTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ContestTests.cs
@@ -6,6 +6,7 @@ using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Types.Contests;
 using Refresh.GameServer.Types.Levels;
+using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 using RefreshTests.GameServer.Extensions;
 
@@ -86,7 +87,7 @@ public class ContestTests : GameServerTest
     {
         using TestContext context = this.GetServer();
         GameUser organizer = context.CreateUser();
-        GameUser admin = context.CreateAdmin();
+        GameUser admin = context.CreateUser(role: GameUserRole.Admin);
         GameLevel templateLevel = context.CreateLevel(organizer);
 
         using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, admin);
@@ -117,7 +118,7 @@ public class ContestTests : GameServerTest
     public void CanUpdateContestFromApi()
     {
         using TestContext context = this.GetServer();
-        GameUser admin = context.CreateAdmin();
+        GameUser admin = context.CreateUser(role: GameUserRole.Admin);
         GameContest contest = this.CreateContest(context);
 
         using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, admin);


### PR DESCRIPTION
Implemented as described in #492.

Includes a bonus refactor to `TestContext` to make making users with roles from within tests a bit easier.