### PR TITLE
Add Refresh.HttpsProxy

### DIFF
--- a/Refresh.Common/Extensions/MemoryStreamExtensions.cs
+++ b/Refresh.Common/Extensions/MemoryStreamExtensions.cs
@@ -1,0 +1,8 @@
+using System.Text;
+
+namespace Refresh.Common.Extensions;
+
+public static class MemoryStreamExtensions
+{
+    public static void WriteString(this MemoryStream ms, string str) => ms.Write(Encoding.UTF8.GetBytes(str));
+}

--- a/Refresh.GameServer/Extensions/MemoryStreamExtensions.cs
+++ b/Refresh.GameServer/Extensions/MemoryStreamExtensions.cs
@@ -1,8 +1,0 @@
-using System.Text;
-
-namespace Refresh.GameServer.Extensions;
-
-internal static class MemoryStreamExtensions
-{
-    internal static void WriteString(this MemoryStream ms, string str) => ms.Write(Encoding.UTF8.GetBytes(str));
-}

--- a/Refresh.GameServer/Middlewares/DigestMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/DigestMiddleware.cs
@@ -3,8 +3,8 @@ using System.Security.Cryptography;
 using Bunkum.Listener.Request;
 using Bunkum.Core.Database;
 using Bunkum.Core.Endpoints.Middlewares;
+using Refresh.Common.Extensions;
 using Refresh.GameServer.Endpoints;
-using Refresh.GameServer.Extensions;
 
 namespace Refresh.GameServer.Middlewares;
 

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -52,12 +52,12 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'!='DebugLocalBunkum'">
-        <PackageReference Include="Bunkum" Version="4.5.6" />
-        <PackageReference Include="Bunkum.RealmDatabase" Version="4.5.6" />
-        <PackageReference Include="Bunkum.AutoDiscover" Version="4.5.6" />
-        <PackageReference Include="Bunkum.HealthChecks" Version="4.5.6" />
-        <PackageReference Include="Bunkum.HealthChecks.RealmDatabase" Version="4.5.6" />
-        <PackageReference Include="Bunkum.Protocols.Http" Version="4.5.6" />
+        <PackageReference Include="Bunkum" Version="4.6.0" />
+        <PackageReference Include="Bunkum.RealmDatabase" Version="4.6.0" />
+        <PackageReference Include="Bunkum.AutoDiscover" Version="4.6.0" />
+        <PackageReference Include="Bunkum.HealthChecks" Version="4.6.0" />
+        <PackageReference Include="Bunkum.HealthChecks.RealmDatabase" Version="4.6.0" />
+        <PackageReference Include="Bunkum.Protocols.Http" Version="4.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.HttpsProxy/Config/ProxyConfig.cs
+++ b/Refresh.HttpsProxy/Config/ProxyConfig.cs
@@ -7,7 +7,7 @@ public class ProxyConfig : Bunkum.Core.Configuration.Config
     
     protected override void Migrate(int oldVer, dynamic oldConfig) { }
 
-    public string Target { get; set; } = "https://lbp.littlebigrefresh.com";
+    public string TargetServerUrl { get; set; } = "https://lbp.littlebigrefresh.com";
     public string Ps3Digest { get; set; } = "CustomServerDigest";
     public string Ps4Digest { get; set; } = "CustomServerDigest";
 }

--- a/Refresh.HttpsProxy/Config/ProxyConfig.cs
+++ b/Refresh.HttpsProxy/Config/ProxyConfig.cs
@@ -1,0 +1,13 @@
+namespace Refresh.HttpsProxy.Config;
+
+public class ProxyConfig : Bunkum.Core.Configuration.Config
+{
+    public override int CurrentConfigVersion => 1;
+    public override int Version { get; set; }
+    
+    protected override void Migrate(int oldVer, dynamic oldConfig) { }
+
+    public string Target { get; set; } = "https://lbp.littlebigrefresh.com";
+    public string Ps3Digest { get; set; } = "CustomServerDigest";
+    public string Ps4Digest { get; set; } = "CustomServerDigest";
+}

--- a/Refresh.HttpsProxy/Middlewares/DigestMiddleware.cs
+++ b/Refresh.HttpsProxy/Middlewares/DigestMiddleware.cs
@@ -1,0 +1,91 @@
+using System.Security.Cryptography;
+using System.Text;
+using Bunkum.Core.Database;
+using Bunkum.Core.Endpoints.Middlewares;
+using Bunkum.Listener.Request;
+using Refresh.Common.Extensions;
+using Refresh.HttpsProxy.Config;
+
+namespace Refresh.HttpsProxy.Middlewares;
+
+public class DigestMiddleware(ProxyConfig config) : IMiddleware
+{
+    public string CalculatePs3Digest(string route, Stream body, string auth, bool isUpload)
+    {
+        using MemoryStream ms = new();
+        
+        // If this request is not to an upload endpoint, then we copy the body of the request into the digest data
+        if (!isUpload)
+        {
+            body.CopyTo(ms);
+            body.Seek(0, SeekOrigin.Begin);
+        }
+        
+        ms.WriteString(auth);
+        ms.WriteString(route);
+        ms.WriteString(config.Ps3Digest);
+
+        ms.Position = 0;
+        using SHA1 sha = SHA1.Create();
+        string digestResponse = Convert.ToHexString(sha.ComputeHash(ms)).ToLower();
+
+        return digestResponse;
+    }
+
+    public string CalculatePs4Digest(string route, Stream body, string auth, bool isUpload)
+    {
+        using MemoryStream ms = new();
+        
+        // If this request is not to an upload endpoint, then we copy the body of the request into the digest data
+        if (!isUpload)
+        {
+            body.CopyTo(ms);
+            body.Seek(0, SeekOrigin.Begin);
+        }
+        
+        ms.WriteString(auth);
+        ms.WriteString(route);
+
+        ms.Position = 0;
+        
+        using HMACSHA1 hmac = new(Encoding.UTF8.GetBytes(config.Ps4Digest));
+        string digestResponse = Convert.ToHexString(hmac.ComputeHash(ms)).ToLower();
+
+        return digestResponse;
+    }
+    
+    public void HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database, Action next)
+    {
+        string route = context.Uri.AbsolutePath;
+        
+        //If this isn't an LBP endpoint, dont do digest
+        if (!route.StartsWith("/LITTLEBIGPLANETPS3_XML/"))
+        {
+            next();
+            return;
+        }
+        
+        bool isUpload = route.StartsWith("/LITTLEBIGPLANETPS3_XML/upload/");
+        string auth = context.Cookies["MM_AUTH"] ?? string.Empty;
+        
+        // For upload requests, the X-Digest-B header is in use instead by the client
+        string digestHeader = isUpload ? "X-Digest-B" : "X-Digest-A";
+        string clientDigest = context.RequestHeaders[digestHeader] ?? string.Empty;
+            
+        // Pass through the client's digest right back to the digest B response
+        context.ResponseHeaders["X-Digest-B"] = clientDigest;
+
+        // Run the rest of the middlewares
+        next();
+        
+        // Make sure the calculation reads the whole response stream
+        context.ResponseStream.Seek(0, SeekOrigin.Begin);
+        
+        // If we are a PS4 client, use the PS4 digest code
+        if (context.RequestHeaders["User-Agent"] == "MM CHTTPClient LBP3 01.26")
+            context.ResponseHeaders["X-Digest-A"] = this.CalculatePs4Digest(route, context.ResponseStream, auth, isUpload);
+        // Else, use PS3 digest code
+        else
+            context.ResponseHeaders["X-Digest-A"] = this.CalculatePs3Digest(route, context.ResponseStream, auth, isUpload);
+    }
+}

--- a/Refresh.HttpsProxy/Middlewares/ProxyMiddleware.cs
+++ b/Refresh.HttpsProxy/Middlewares/ProxyMiddleware.cs
@@ -30,9 +30,7 @@ public class ProxyMiddleware(ProxyConfig config) : IMiddleware
         for (int i = 0; i < context.Query.Count; i++)
         {
             string key = context.Query.GetKey(i)!;
-            
             string name = HttpUtility.HtmlEncode(key);
-
             string value = HttpUtility.HtmlEncode(context.Query[key]!);
 
             queryString.AppendFormat("{0}={1}", name, value);

--- a/Refresh.HttpsProxy/Middlewares/ProxyMiddleware.cs
+++ b/Refresh.HttpsProxy/Middlewares/ProxyMiddleware.cs
@@ -1,0 +1,82 @@
+using System.Text;
+using System.Web;
+using Bunkum.Core.Database;
+using Bunkum.Core.Endpoints.Middlewares;
+using Bunkum.Listener.Request;
+using Refresh.HttpsProxy.Config;
+
+namespace Refresh.HttpsProxy.Middlewares;
+
+public class ProxyMiddleware(ProxyConfig config) : IMiddleware
+{
+    private readonly ThreadLocal<HttpClient> _httpClients = new(() => new HttpClient());
+    
+    public void HandleRequest(ListenerContext context, Lazy<IDatabaseContext> database, Action next)
+    {
+        HttpClient client = this._httpClients.Value!;
+
+        UriBuilder uri = new(config.Target)
+        {
+            Path = context.Uri.AbsolutePath,
+        };
+
+        StringBuilder queryString = new();
+
+        // We apparently need to prepend this ourselves
+        if (context.Query.Count > 0) 
+            queryString.Append('?');
+
+        // Fill in all the query strings
+        for (int i = 0; i < context.Query.Count; i++)
+        {
+            string key = context.Query.GetKey(i)!;
+            
+            string name = HttpUtility.HtmlEncode(key);
+
+            string value = HttpUtility.HtmlEncode(context.Query[key]!);
+
+            queryString.AppendFormat("{0}={1}", name, value);
+
+            if (i < context.Query.Count - 1)
+                queryString.Append('&');
+        }
+        
+        uri.Query = queryString.ToString();
+
+        HttpRequestMessage requestMessage = new()
+        {
+            RequestUri = uri.Uri,
+            Content = new StreamContent(context.InputStream), 
+            Method = new HttpMethod(context.Method.Value), 
+            Version = new Version(1, 1), 
+            VersionPolicy = HttpVersionPolicy.RequestVersionExact,
+        };
+
+        // Move all the request headers over
+        for (int i = 0; i < context.RequestHeaders.Count; i++)
+        {
+            string key = context.RequestHeaders.GetKey(i)!;
+            string[] value = context.RequestHeaders.GetValues(i)!;
+
+            // Fixup the host value to the correct one, so that the request actually goes through
+            if (key.Equals("Host", StringComparison.InvariantCultureIgnoreCase))
+                value = [uri.Host];
+            
+            requestMessage.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        // Send our HTTP request
+        HttpResponseMessage response = client.Send(requestMessage);
+
+        //Set the response information
+        context.ResponseCode = response.StatusCode;
+        
+        context.ResponseHeaders.Clear();
+        foreach (KeyValuePair<string, IEnumerable<string>> responseHeader in response.Headers)
+        {
+            context.ResponseHeaders[responseHeader.Key] = string.Join(',', responseHeader.Value);
+        }
+        context.ResponseStream.SetLength(0);
+        response.Content.ReadAsStream().CopyTo(context.ResponseStream);
+    }
+}

--- a/Refresh.HttpsProxy/Middlewares/ProxyMiddleware.cs
+++ b/Refresh.HttpsProxy/Middlewares/ProxyMiddleware.cs
@@ -15,7 +15,7 @@ public class ProxyMiddleware(ProxyConfig config) : IMiddleware
     {
         HttpClient client = this._httpClients.Value!;
 
-        UriBuilder uri = new(config.Target)
+        UriBuilder uri = new(config.TargetServerUrl)
         {
             Path = context.Uri.AbsolutePath,
         };

--- a/Refresh.HttpsProxy/Program.cs
+++ b/Refresh.HttpsProxy/Program.cs
@@ -1,0 +1,45 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using Bunkum.Core;
+using Bunkum.Core.Configuration;
+using Bunkum.Protocols.Http;
+using Bunkum.Protocols.Https;
+using NotEnoughLogs;
+using NotEnoughLogs.Behaviour;
+using Refresh.HttpsProxy.Config;
+using Refresh.HttpsProxy.Middlewares;
+
+LoggerConfiguration loggerConfiguration = new()
+{
+    Behaviour = new QueueLoggingBehaviour(),
+#if DEBUG
+    MaxLevel = LogLevel.Trace,
+#else
+    MaxLevel = LogLevel.Info,
+#endif
+};
+
+// Initialize a Bunkum server for HTTPS
+BunkumServer httpsServer = new BunkumHttpsServer(loggerConfiguration);
+
+// Initialize a Bunkum server for HTTP
+BunkumServer httpServer = new BunkumHttpServer(loggerConfiguration);
+
+ProxyConfig config = Config.LoadFromJsonFile<ProxyConfig>("proxy.json", httpsServer.Logger);
+
+httpsServer.Initialize = s =>
+{
+    s.AddMiddleware(new ProxyMiddleware(config));
+    s.AddMiddleware(new DigestMiddleware(config));
+};
+
+httpServer.Initialize = s =>
+{
+    s.AddMiddleware(new ProxyMiddleware(config));
+    s.AddMiddleware(new DigestMiddleware(config));
+};
+
+// Start the server in multi-threaded mode, and let Bunkum manage the rest.
+httpsServer.Start();
+httpServer.Start();
+await Task.Delay(-1);

--- a/Refresh.HttpsProxy/Refresh.HttpsProxy.csproj
+++ b/Refresh.HttpsProxy/Refresh.HttpsProxy.csproj
@@ -1,14 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Bunkum" Version="4.6.0" />
-      <PackageReference Include="Bunkum.Protocols.Http" Version="4.6.0" />
+      <PackageReference Include="Bunkum.Protocols.Https" Version="4.6.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Refresh.Common\Refresh.Common.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Refresh.sln
+++ b/Refresh.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RefreshTests.GameServer", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refresh.Common", "Refresh.Common\Refresh.Common.csproj", "{A3D76B31-8732-4134-907B-F36773DF70D3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refresh.HttpsProxy", "Refresh.HttpsProxy\Refresh.HttpsProxy.csproj", "{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,12 @@ Global
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.DebugLocalBunkum|Any CPU.ActiveCfg = Debug|Any CPU
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.DebugLocalBunkum|Any CPU.Build.0 = Debug|Any CPU
+		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.DebugLocalBunkum|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.DebugLocalBunkum|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection


### PR DESCRIPTION
This adds a simple proxy capable of forwarding LBP3 traffic on ports 10061 (HTTPS) and 10060 (HTTP) to another gameserver, it also overrides the original server's digest, allowing clients with non-patched digest keys to connect without the actual gameserver having to support the proxied game's digest.