### PR TITLE
Worker + Discord Webhook refactor

### DIFF
--- a/Refresh.GameServer/Types/Data/DataContextService.cs
+++ b/Refresh.GameServer/Types/Data/DataContextService.cs
@@ -15,8 +15,8 @@ public class DataContextService : Service
     private readonly StorageService _storageService;
     private readonly MatchService _matchService;
     private readonly AuthenticationService _authService;
-    
-    internal DataContextService(StorageService storage, MatchService match, AuthenticationService auth, Logger logger) : base(logger)
+
+    public DataContextService(StorageService storage, MatchService match, AuthenticationService auth, Logger logger) : base(logger)
     {
         this._storageService = storage;
         this._matchService = match;

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using Bunkum.Core.Storage;
 using NotEnoughLogs;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Reviews;
 using Refresh.GameServer.Types.Roles;
@@ -19,10 +20,10 @@ namespace Refresh.GameServer.Workers;
 public class CoolLevelsWorker : IWorker
 {
     public int WorkInterval => 600_000; // Every 10 minutes
-    public void DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database)
+    public void DoWork(DataContext context)
     {
         const int pageSize = 1000;
-        DatabaseList<GameLevel> levels = database.GetUserLevelsChunk(0, pageSize);
+        DatabaseList<GameLevel> levels = context.Database.GetUserLevelsChunk(0, pageSize);
         
         // Don't do anything if there are no levels to process.
         if (levels.TotalItems <= 0) return;
@@ -43,13 +44,13 @@ public class CoolLevelsWorker : IWorker
             
             foreach (GameLevel level in levels.Items)
             {
-                Log(logger, LogLevel.Trace, "Calculating score for '{0}' ({1})", level.Title, level.LevelId);
-                float decayMultiplier = CalculateLevelDecayMultiplier(logger, now, level);
+                Log(context.Logger, LogLevel.Trace, "Calculating score for '{0}' ({1})", level.Title, level.LevelId);
+                float decayMultiplier = CalculateLevelDecayMultiplier(context.Logger, now, level);
                 
                 // Calculate positive & negative score separately so we don't run into issues with
                 // the multiplier having an opposite effect with the negative score as time passes
-                float positiveScore = CalculatePositiveScore(logger, level, database);
-                float negativeScore = CalculateNegativeScore(logger, level, database);
+                float positiveScore = CalculatePositiveScore(level, context);
+                float negativeScore = CalculateNegativeScore(level, context);
                 
                 // Increase to tweak how little negative score gets affected by decay
                 const int negativeScoreDecayMultiplier = 2;
@@ -57,20 +58,20 @@ public class CoolLevelsWorker : IWorker
                 // Weigh everything with the multiplier and set a final score
                 float finalScore = (positiveScore * decayMultiplier) - (negativeScore * Math.Min(1.0f, decayMultiplier * negativeScoreDecayMultiplier));
                 
-                Log(logger, LogLevel.Debug, "Score for '{0}' ({1}) is {2}", level.Title, level.LevelId, finalScore);
+                Log(context.Logger, LogLevel.Debug, "Score for '{0}' ({1}) is {2}", level.Title, level.LevelId, finalScore);
                 scoresToSet.Add(level, finalScore);
                 remaining--;
             }
             
             // Commit scores to database. This method lets us use a dictionary so we can batch everything in one write
-            database.SetLevelScores(scoresToSet);
+            context.Database.SetLevelScores(scoresToSet);
             
             // Load the next page
-            levels = database.GetUserLevelsChunk(levels.Items.Count(), pageSize);
+            levels = context.Database.GetUserLevelsChunk(levels.Items.Count(), pageSize);
         }
         
         stopwatch.Stop();
-        logger.LogInfo(RefreshContext.CoolLevels,  "Calculated scores for {0} levels in {1}ms", levels.TotalItems, stopwatch.ElapsedMilliseconds);
+        context.Logger.LogInfo(RefreshContext.CoolLevels,  "Calculated scores for {0} levels in {1}ms", levels.TotalItems, stopwatch.ElapsedMilliseconds);
     }
     
     [Conditional("COOL_DEBUG")]
@@ -97,7 +98,7 @@ public class CoolLevelsWorker : IWorker
         return multiplier;
     }
 
-    private static float CalculatePositiveScore(Logger logger, GameLevel level, GameDatabaseContext database)
+    private static float CalculatePositiveScore(GameLevel level, DataContext context)
     {
         // Start levels off with a few points to prevent one dislike from bombing the level
         // Don't apply this bonus to reuploads to discourage a flood of 15CR levels.
@@ -111,13 +112,13 @@ public class CoolLevelsWorker : IWorker
         if (level.TeamPicked)
             score += 50;
         
-        int positiveRatings = database.GetTotalRatingsForLevel(level, RatingType.Yay);
-        int negativeRatings = database.GetTotalRatingsForLevel(level, RatingType.Boo);
-        int uniquePlays = database.GetUniquePlaysForLevel(level);
+        int positiveRatings = context.Database.GetTotalRatingsForLevel(level, RatingType.Yay);
+        int negativeRatings = context.Database.GetTotalRatingsForLevel(level, RatingType.Boo);
+        int uniquePlays = context.Database.GetUniquePlaysForLevel(level);
         
         score += positiveRatings * positiveRatingPoints;
         score += uniquePlays * uniquePlayPoints;
-        score += database.GetFavouriteCountForLevel(level) * heartPoints;
+        score += context.Database.GetFavouriteCountForLevel(level) * heartPoints;
         
         // Reward for a good ratio between plays and yays
         float ratingRatio = (positiveRatings - negativeRatings) / (float)uniquePlays;
@@ -129,11 +130,11 @@ public class CoolLevelsWorker : IWorker
         if (level.Publisher?.Role == GameUserRole.Trusted)
             score += trustedAuthorPoints;
 
-        Log(logger, LogLevel.Trace, "positiveScore is {0}", score);
+        Log(context.Logger, LogLevel.Trace, "positiveScore is {0}", score);
         return score;
     }
 
-    private static float CalculateNegativeScore(Logger logger, GameLevel level, GameDatabaseContext database)
+    private static float CalculateNegativeScore(GameLevel level, DataContext context)
     {
         float penalty = 0;
         const float negativeRatingPenalty = 5;
@@ -144,7 +145,7 @@ public class CoolLevelsWorker : IWorker
         // The percentage of how much penalty should be applied at the end of the calculation.
         const float penaltyMultiplier = 0.75f;
         
-        penalty += database.GetTotalRatingsForLevel(level, RatingType.Boo) * negativeRatingPenalty;
+        penalty += context.Database.GetTotalRatingsForLevel(level, RatingType.Boo) * negativeRatingPenalty;
         
         if (level.Publisher == null)
             penalty += noAuthorPenalty;
@@ -153,7 +154,7 @@ public class CoolLevelsWorker : IWorker
         else if (level.Publisher?.Role == GameUserRole.Banned)
             penalty += bannedAuthorPenalty;
 
-        Log(logger, LogLevel.Trace, "negativeScore is {0}", penalty);
+        Log(context.Logger, LogLevel.Trace, "negativeScore is {0}", penalty);
         return penalty * penaltyMultiplier;
     }
 }

--- a/Refresh.GameServer/Workers/IWorker.cs
+++ b/Refresh.GameServer/Workers/IWorker.cs
@@ -1,6 +1,5 @@
-using Bunkum.Core.Storage;
 using NotEnoughLogs;
-using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 
 namespace Refresh.GameServer.Workers;
 
@@ -10,13 +9,13 @@ public interface IWorker
     /// How often to perform work, in milliseconds
     /// </summary>
     public int WorkInterval { get; }
-    
+
     /// <summary>
     /// Instructs the worker to do work.
     /// </summary>
-    /// <param name="logger">A Refresh logger, able to be operated by the worker.</param>
+    /// <param name="context"></param>
     /// <param name="dataStore">The server's data store, for workers to use.</param>
     /// <param name="database">A database context, for workers to use.</param>
     /// <returns>True if the worker did work, false if it did not.</returns>
-    public void DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database);
+    public void DoWork(DataContext context);
 }

--- a/Refresh.GameServer/Workers/PunishmentExpiryWorker.cs
+++ b/Refresh.GameServer/Workers/PunishmentExpiryWorker.cs
@@ -1,6 +1,7 @@
 using Bunkum.Core.Storage;
 using NotEnoughLogs;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
 
@@ -13,25 +14,25 @@ public class PunishmentExpiryWorker : IWorker
 {
     public int WorkInterval => 60_000; // 1 minute
 
-    public void DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database)
+    public void DoWork(DataContext context)
     {
-        DatabaseList<GameUser> bannedUsers = database.GetAllUsersWithRole(GameUserRole.Banned);
-        DatabaseList<GameUser> restrictedUsers = database.GetAllUsersWithRole(GameUserRole.Restricted);
+        DatabaseList<GameUser> bannedUsers = context.Database.GetAllUsersWithRole(GameUserRole.Banned);
+        DatabaseList<GameUser> restrictedUsers = context.Database.GetAllUsersWithRole(GameUserRole.Restricted);
 
         foreach (GameUser user in bannedUsers.Items)
         {
-            if (database.IsUserBanned(user)) continue;
+            if (context.Database.IsUserBanned(user)) continue;
             
-            logger.LogInfo(RefreshContext.Worker, $"Unbanned {user.Username} since their punishment has expired");
-            database.SetUserRole(user, GameUserRole.User);
+            context.Logger.LogInfo(RefreshContext.Worker, $"Unbanned {user.Username} since their punishment has expired");
+            context.Database.SetUserRole(user, GameUserRole.User);
         }
 
         foreach (GameUser user in restrictedUsers.Items)
         {
-            if (database.IsUserRestricted(user)) continue;
+            if (context.Database.IsUserRestricted(user)) continue;
             
-            logger.LogInfo(RefreshContext.Worker, $"Unrestricted {user.Username} since their punishment has expired");
-            database.SetUserRole(user, GameUserRole.User);
+            context.Logger.LogInfo(RefreshContext.Worker, $"Unrestricted {user.Username} since their punishment has expired");
+            context.Database.SetUserRole(user, GameUserRole.User);
         }
     }
 }

--- a/Refresh.GameServer/Workers/RequestStatisticSubmitWorker.cs
+++ b/Refresh.GameServer/Workers/RequestStatisticSubmitWorker.cs
@@ -1,6 +1,7 @@
 using Bunkum.Core.Storage;
 using NotEnoughLogs;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Types.Data;
 using TrackingService = Refresh.GameServer.Services.RequestStatisticTrackingService;
 
 namespace Refresh.GameServer.Workers;
@@ -9,11 +10,11 @@ public class RequestStatisticSubmitWorker : IWorker
 {
     public int WorkInterval => 5_000;
     
-    public void DoWork(Logger logger, IDataStore dataStore, GameDatabaseContext database)
+    public void DoWork(DataContext context)
     {
         (int game, int api) = TrackingService.SubmitAndClearRequests();
         
-        database.IncrementGameRequests(game);
-        database.IncrementApiRequests(api);
+        context.Database.IncrementGameRequests(game);
+        context.Database.IncrementApiRequests(api);
     }
 }

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -1,10 +1,14 @@
+using Bunkum.Core;
 using Bunkum.Core.Services;
+using Bunkum.Core.Storage;
 using Bunkum.Protocols.Http.Direct;
 using JetBrains.Annotations;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Services;
 using Refresh.GameServer.Types;
 using Refresh.GameServer.Types.Contests;
+using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -150,6 +154,19 @@ public class TestContext : IDisposable
 
     [Pure]
     public TService GetService<TService>() where TService : Service => this.Server.Value.GetService<TService>();
+
+    public DataContext GetDataContext(Token? token = null)
+    {
+        return new DataContext
+        {
+            Database = this.Database,
+            Logger = this.Server.Value.Logger,
+            DataStore = (IDataStore)this.GetService<StorageService>()
+                .AddParameterToEndpoint(null!, new BunkumParameterInfo(typeof(IDataStore), ""), null!)!,
+            Match = this.GetService<MatchService>(),
+            Token = token,
+        };
+    }
 
     public void Dispose()
     {

--- a/RefreshTests.GameServer/Tests/Workers/PunishmentExpiryTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/PunishmentExpiryTests.cs
@@ -30,14 +30,14 @@ public class PunishmentExpiryTests : GameServerTest
             Assert.That(context.Database.GetAllUsersWithRole(Banned).Items, Contains.Item(user));
         });
         
-        worker.DoWork(logger, null!, context.Database);
+        worker.DoWork(context.GetDataContext());
         Assert.Multiple(() =>
         {
             Assert.That(user.Role, Is.EqualTo(Banned));
         });
 
         context.Time.TimestampMilliseconds = 2000;
-        worker.DoWork(logger, null!, context.Database);
+        worker.DoWork(context.GetDataContext());
         
         Assert.Multiple(() =>
         {
@@ -59,14 +59,14 @@ public class PunishmentExpiryTests : GameServerTest
         context.Database.RestrictUser(user, "", DateTimeOffset.FromUnixTimeMilliseconds(1000));
         Assert.That(user.Role, Is.EqualTo(Restricted));
         
-        worker.DoWork(logger, null!, context.Database);
+        worker.DoWork(context.GetDataContext());
         Assert.Multiple(() =>
         {
             Assert.That(user.Role, Is.EqualTo(Restricted));
         });
 
         context.Time.TimestampMilliseconds = 2000;
-        worker.DoWork(logger, null!, context.Database);
+        worker.DoWork(context.GetDataContext());
         
         Assert.Multiple(() =>
         {


### PR DESCRIPTION
- Refactor workers to use DataContext
    This makes Workers compatible with `IDataConvertable`. Should help us expand Workers in the future as a side bonus. Admittedly, this causes a bit of jank particularly in tests and having to store the match service, but I think it should be okay.
- Convert to API data types in DiscordIntegrationWorker
    This allows us to get the same results as the API (e.g. applying PSP path, cropped asset URLs, etc.) for free, avoiding code duplication. Closes #574.