### PR TITLE
Ignore game build version when matching

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/MatchingEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/MatchingEndpoints.cs
@@ -50,7 +50,7 @@ public class MatchingEndpoints : EndpointGroup
     [GameEndpoint("enterLevel/{slotType}/{id}", HttpMethods.Post)]
     public Response EnterLevel(RequestContext context, Token token, MatchService matchService, string slotType, int id)
     {
-        GameRoom room = matchService.GetOrCreateRoomByPlayer(token.User, token.TokenPlatform, token.TokenGame, NatType.Strict, null, false);
+        GameRoom room = matchService.GetOrCreateRoomByPlayer(token.User, token.TokenPlatform, token.TokenGame, NatType.Strict, false);
         
         // User slot ID of 0 means pod/moon level
         if (id == 0 && slotType == "user")

--- a/Refresh.GameServer/Services/MatchService.cs
+++ b/Refresh.GameServer/Services/MatchService.cs
@@ -26,15 +26,14 @@ public partial class MatchService(Logger logger) : EndpointService(logger)
         GameUser player, 
         TokenPlatform platform, 
         TokenGame game, 
-        NatType natType, 
-        int? buildVersion,
+        NatType natType,
         bool? passedNoJoinPoint = null)
     {
         GameRoom? room = this.RoomAccessor.GetRoomByUser(player, platform, game);
         
         // ReSharper disable once ConvertIfStatementToNullCoalescingExpression
         if (room == null)
-            room = this.CreateRoomByPlayer(player, platform, game, natType, buildVersion, passedNoJoinPoint);
+            room = this.CreateRoomByPlayer(player, platform, game, natType, passedNoJoinPoint);
 
         return room;
     }
@@ -43,11 +42,10 @@ public partial class MatchService(Logger logger) : EndpointService(logger)
         GameUser player, 
         TokenPlatform platform, 
         TokenGame game, 
-        NatType natType, 
-        int? buildVersion,
+        NatType natType,
         bool? passedNoJoinPoint = null)
     {
-        GameRoom room = new(player, platform, game, natType, buildVersion, passedNoJoinPoint);
+        GameRoom room = new(player, platform, game, natType, passedNoJoinPoint);
         this.RoomAccessor.AddRoom(room);
         return room;
     }
@@ -56,14 +54,13 @@ public partial class MatchService(Logger logger) : EndpointService(logger)
         GameUser player, 
         TokenPlatform platform, 
         TokenGame game, 
-        NatType natType, 
-        int? buildVersion,
+        NatType natType,
         bool? passedNoJoinPoint = null)
     {
         GameRoom? room = this.RoomAccessor.GetRoomByUser(player, platform, game);
         if (room == null)
         {
-            return this.CreateRoomByPlayer(player, platform, game, natType, buildVersion, passedNoJoinPoint);
+            return this.CreateRoomByPlayer(player, platform, game, natType, passedNoJoinPoint);
         }
         
         // Remove player from old room
@@ -71,7 +68,7 @@ public partial class MatchService(Logger logger) : EndpointService(logger)
         // Update the room on the room accessor
         this.RoomAccessor.UpdateRoom(room);
         
-        return this.CreateRoomByPlayer(player, platform, game, natType, buildVersion, passedNoJoinPoint);
+        return this.CreateRoomByPlayer(player, platform, game, natType, passedNoJoinPoint);
     }
     
     public int GetPlayerCountForLevel(RoomSlotType type, int id)

--- a/Refresh.GameServer/Types/Matching/GameRoom.cs
+++ b/Refresh.GameServer/Types/Matching/GameRoom.cs
@@ -8,13 +8,12 @@ namespace Refresh.GameServer.Types.Matching;
 
 public class GameRoom
 {
-    public GameRoom(GameUser host, TokenPlatform platform, TokenGame game, NatType natType, int? buildVersion, bool? passedNoJoinPoint)
+    public GameRoom(GameUser host, TokenPlatform platform, TokenGame game, NatType natType, bool? passedNoJoinPoint)
     {
         this.PlayerIds.Add(new GameRoomPlayer(host.Username, host.UserId));
         this.Platform = platform;
         this.Game = game;
         this.NatType = natType;
-        this.BuildVersion = buildVersion;
         this.PassedNoJoinPoint = passedNoJoinPoint ?? false;
     }
 
@@ -29,8 +28,7 @@ public class GameRoom
     public readonly NatType NatType;
 
     public DateTimeOffset LastContact;
-    
-    public int? BuildVersion;
+
     public bool PassedNoJoinPoint;
 
     public List<GameUser?> GetPlayers(GameDatabaseContext database) =>

--- a/Refresh.GameServer/Types/Matching/IRoomAccessor.cs
+++ b/Refresh.GameServer/Types/Matching/IRoomAccessor.cs
@@ -98,17 +98,17 @@ public interface IRoomAccessor
     /// <param name="platform">The platform to check for</param>
     /// <param name="game">The game to check for</param>
     /// <returns>The found room, or null if not found</returns>
-    public GameRoom? GetRoomByUser(GameUser user, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null) => this.GetRoomByUserUuid(user.UserId, platform, game, buildVersion);
+    public GameRoom? GetRoomByUser(GameUser user, TokenPlatform? platform = null, TokenGame? game = null) => this.GetRoomByUserUuid(user.UserId, platform, game);
     /// <summary>
     /// Gets a room by a user's UUID.
     /// </summary>
     /// <param name="uuid">The user UUID to search for</param>
     /// <returns>The found room, or null if not found</returns>
-    public GameRoom? GetRoomByUserUuid(ObjectId uuid, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null);
+    public GameRoom? GetRoomByUserUuid(ObjectId uuid, TokenPlatform? platform = null, TokenGame? game = null);
     /// <summary>
     /// Gets a room by a user's username.
     /// </summary>
     /// <param name="username">The username to search for</param>
     /// <returns>The found room, or null if not found</returns>
-    public GameRoom? GetRoomByUsername(string username, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null);
+    public GameRoom? GetRoomByUsername(string username, TokenPlatform? platform = null, TokenGame? game = null);
 }

--- a/Refresh.GameServer/Types/Matching/MatchMethods/CreateRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/CreateRoomMethod.cs
@@ -12,10 +12,10 @@ public class CreateRoomMethod : IMatchMethod
     public Response Execute(DataContext dataContext, SerializedRoomData body, GameServerConfig gameServerConfig)
     {
         NatType natType = body.NatType == null ? NatType.Open : body.NatType[0];
-        GameRoom room = dataContext.Match.GetOrCreateRoomByPlayer(dataContext.User!, dataContext.Platform, dataContext.Game, natType, body.BuildVersion, body.PassedNoJoinPoint);
+        GameRoom room = dataContext.Match.GetOrCreateRoomByPlayer(dataContext.User!, dataContext.Platform, dataContext.Game, natType, body.PassedNoJoinPoint);
         if (room.HostId.Id != dataContext.User!.UserId)
         {
-            room = dataContext.Match.SplitUserIntoNewRoom(dataContext.User, dataContext.Platform, dataContext.Game, natType, body.BuildVersion, body.PassedNoJoinPoint);
+            room = dataContext.Match.SplitUserIntoNewRoom(dataContext.User, dataContext.Platform, dataContext.Game, natType, body.PassedNoJoinPoint);
         }
 
         if (body.RoomState != null) room.RoomState = body.RoomState.Value;

--- a/Refresh.GameServer/Types/Matching/MatchMethods/FindRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/FindRoomMethod.cs
@@ -69,9 +69,7 @@ public class FindRoomMethod : IMatchMethod
                 (userLevelIds.Count == 0 || r.LevelType != RoomSlotType.Online || userLevelIds.Contains(r.LevelId)) &&
                 (developerLevelIds.Count == 0 || r.LevelType != RoomSlotType.Story || developerLevelIds.Contains(r.LevelId)) &&
                 // Make sure that we don't try to match the player into a full room, or a room which won't fit the user's current room
-                usersRoom.PlayerIds.Count + r.PlayerIds.Count <= 4 &&
-                // Match the build version of the rooms, or dont match build versions if the game doesnt specify it
-                (body.BuildVersion == null || (r.BuildVersion ?? 0) == body.BuildVersion))
+                usersRoom.PlayerIds.Count + r.PlayerIds.Count <= 4)
             // Shuffle the rooms around before sorting, this is because the selection is based on a weighted average towards the top of the range,
             // so there would be a bias towards longer lasting rooms without this shuffle
             .OrderBy(r => Random.Shared.Next())
@@ -117,9 +115,8 @@ public class FindRoomMethod : IMatchMethod
 
                 foreach (GameRoom logRoom in allRooms)
                     dataContext.Logger.LogInfo(BunkumCategory.Matching,
-                        "Room {0}: Nat Type {1}, Level {2} ({3}), Build Version {4}",
-                        logRoom.RoomId, logRoom.NatType, logRoom.LevelId, logRoom.LevelType,
-                        logRoom.BuildVersion ?? 0);
+                        "Room {0}: Nat Type {1}, Level {2} ({3})",
+                        logRoom.RoomId, logRoom.NatType, logRoom.LevelId, logRoom.LevelType);
             }
             else
             {

--- a/Refresh.GameServer/Types/Matching/MatchMethods/UpdatePlayersInRoomMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/UpdatePlayersInRoomMethod.cs
@@ -12,7 +12,7 @@ public class UpdatePlayersInRoomMethod : IMatchMethod
     public Response Execute(DataContext dataContext, SerializedRoomData body, GameServerConfig gameServerConfig)
     {
         if (body.Players == null) return BadRequest;
-        GameRoom room = dataContext.Match.GetOrCreateRoomByPlayer(dataContext.User!, dataContext.Platform, dataContext.Game, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint);
+        GameRoom room = dataContext.Match.GetOrCreateRoomByPlayer(dataContext.User!, dataContext.Platform, dataContext.Game, body.NatType == null ? NatType.Open : body.NatType[0], body.PassedNoJoinPoint);
         
         foreach (string playerUsername in body.Players)
         {

--- a/Refresh.GameServer/Types/Matching/MatchMethods/UpdateRoomDataMethod.cs
+++ b/Refresh.GameServer/Types/Matching/MatchMethods/UpdateRoomDataMethod.cs
@@ -11,7 +11,7 @@ public class UpdateRoomDataMethod : IMatchMethod
 
     public Response Execute(DataContext dataContext, SerializedRoomData body, GameServerConfig gameServerConfig)
     {
-        GameRoom room = dataContext.Match.GetOrCreateRoomByPlayer(dataContext.User!, dataContext.Platform, dataContext.Game, body.NatType == null ? NatType.Open : body.NatType[0], body.BuildVersion, body.PassedNoJoinPoint);
+        GameRoom room = dataContext.Match.GetOrCreateRoomByPlayer(dataContext.User!, dataContext.Platform, dataContext.Game, body.NatType == null ? NatType.Open : body.NatType[0], body.PassedNoJoinPoint);
         if (room.HostId.Id != dataContext.User!.UserId) return Unauthorized;
 
         if (body.RoomState != null) room.RoomState = body.RoomState.Value;

--- a/Refresh.GameServer/Types/Matching/RoomAccessors/InMemoryRoomAccessor.cs
+++ b/Refresh.GameServer/Types/Matching/RoomAccessors/InMemoryRoomAccessor.cs
@@ -149,7 +149,7 @@ public class InMemoryRoomAccessor(Logger logger) : IRoomAccessor
     }
 
     /// <inheritdoc/>
-    public GameRoom? GetRoomByUserUuid(ObjectId uuid, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null)
+    public GameRoom? GetRoomByUserUuid(ObjectId uuid, TokenPlatform? platform = null, TokenGame? game = null)
     {
         lock (this._rooms)
         {
@@ -157,13 +157,12 @@ public class InMemoryRoomAccessor(Logger logger) : IRoomAccessor
             return this._rooms.FirstOrDefault(r =>
                 r.PlayerIds.Any(p => p.Id == uuid) &&
                 (platform == null || r.Platform == platform) &&
-                (game == null || r.Game == game) &&
-                (buildVersion == null || r.BuildVersion == buildVersion));
+                (game == null || r.Game == game));
         }
     }
     
     /// <inheritdoc/>
-    public GameRoom? GetRoomByUsername(string username, TokenPlatform? platform = null, TokenGame? game = null, int? buildVersion = null)
+    public GameRoom? GetRoomByUsername(string username, TokenPlatform? platform = null, TokenGame? game = null)
     {
         lock (this._rooms)
         {
@@ -171,8 +170,7 @@ public class InMemoryRoomAccessor(Logger logger) : IRoomAccessor
             return this._rooms.FirstOrDefault(r =>
                     r.PlayerIds.Any(p => p.Username == username) &&
                     (platform == null || r.Platform == platform) &&
-                    (game == null || r.Game == game) &&
-                    (buildVersion == null || r.BuildVersion == buildVersion));
+                    (game == null || r.Game == game));
         }
     }
 }

--- a/Refresh.GameServer/Types/Matching/SerializedRoomData.cs
+++ b/Refresh.GameServer/Types/Matching/SerializedRoomData.cs
@@ -47,8 +47,8 @@ public class SerializedRoomData
     [JsonProperty("Language")]
     public byte? Language { get; set; }
 
-    [JsonProperty("BuildVersion")]
-    public int? BuildVersion { get; set; }
+    // [JsonProperty("BuildVersion")]
+    // public int? BuildVersion { get; set; }
 
     [JsonProperty("Search")]
     public string? Search { get; set; }


### PR DESCRIPTION
In the future, we're going to ensure the user is on the latest game version via enforcing user agent (old builds will be sent to `BetaBuild`). Tracking `BuildVersion` seems to cause issues as shown [here](https://discord.com/channels/1049223665243389953/1049225857350254632/1266966969697960037) so let's just stop tracking/comparing against that for now.