### PR TITLE
Implement friend leaderboards

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
+using Bunkum.Core.Endpoints.Debugging;
 using Bunkum.Core.RateLimit;
 using Bunkum.Core.Responses;
 using Bunkum.Listener.Protocol;
@@ -11,6 +12,7 @@ using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Lists;
 using Refresh.GameServer.Types.Roles;
+using Refresh.GameServer.Types.Scores;
 using Refresh.GameServer.Types.UserData;
 using Refresh.GameServer.Types.UserData.Leaderboard;
 
@@ -65,6 +67,25 @@ public class LeaderboardEndpoints : EndpointGroup
         MultiLeaderboard multiLeaderboard = new(database, level, token.TokenGame);
         
         return new Response(SerializedMultiLeaderboardResponse.FromOld(multiLeaderboard), ContentType.Xml);
+    }
+
+    [GameEndpoint("scoreboard/friends/{slotType}/{id}", HttpMethods.Post, ContentType.Xml)]
+    [RateLimitSettings(RequestTimeoutDuration, MaxRequestAmount, RequestBlockDuration, BucketName)]
+    [DebugRequestBody]
+    [DebugResponseBody]
+    [NullStatusCode(NotFound)]
+    public SerializedScoreLeaderboardList? GetLevelFriendLeaderboard(
+        RequestContext context, 
+        GameUser user, 
+        GameDatabaseContext database, 
+        string slotType, 
+        int id, 
+        FriendScoresRequest body)
+    {
+        GameLevel? level = database.GetLevelByIdAndType(slotType, id);
+        if (level == null) return null;
+        
+        return SerializedScoreLeaderboardList.FromSubmittedEnumerable(database.GetLevelTopScoresByFriends(user, level, 10, body.Type));
     }
     
     [GameEndpoint("scoreboard/{slotType}/{id}", ContentType.Xml, HttpMethods.Post)]

--- a/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LeaderboardEndpoints.cs
@@ -71,8 +71,6 @@ public class LeaderboardEndpoints : EndpointGroup
 
     [GameEndpoint("scoreboard/friends/{slotType}/{id}", HttpMethods.Post, ContentType.Xml)]
     [RateLimitSettings(RequestTimeoutDuration, MaxRequestAmount, RequestBlockDuration, BucketName)]
-    [DebugRequestBody]
-    [DebugResponseBody]
     [NullStatusCode(NotFound)]
     public SerializedScoreLeaderboardList? GetLevelFriendLeaderboard(
         RequestContext context, 

--- a/Refresh.GameServer/Types/Scores/FriendScoresRequest.cs
+++ b/Refresh.GameServer/Types/Scores/FriendScoresRequest.cs
@@ -1,0 +1,13 @@
+using System.Xml.Serialization;
+
+namespace Refresh.GameServer.Types.Scores;
+
+[XmlRoot("playRecord")]
+public class FriendScoresRequest
+{
+    [XmlElement("playerIds")]
+    public List<string> Usernames { get; set; }
+    
+    [XmlElement("type")]
+    public byte Type { get; set; }
+}


### PR DESCRIPTION
The query here is extraordinarily slow (~10s in Debug mode on my machine, with a warmed up JIT). But leaving it as a 404 causes the game to wait a full 30 seconds between requests, so even though these requests are serial in LBP, its still faster for users in the end to have it implemented.

We can optimize the query after Postgres gets in.