### PR TITLE
CoolLevelsWorker: Use an exponential decay function for CR

### DIFF
--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -82,20 +82,18 @@ public class CoolLevelsWorker : IWorker
 
     private static float CalculateLevelDecayMultiplier(Logger logger, long now, GameLevel level)
     {
-        const int decayMonths = 2;
-        const int decaySeconds = decayMonths * 30 * 24 * 3600;
-        const float minimumMultiplier = 0.1f;
+        const int secondsPerMonth = 30 * 24 * 3600;
         
-        // Use seconds. Lets us not worry about float stuff
-        long publishDate = level.PublishDate / 1000;
-        long elapsed = now - publishDate;
+        // Use months
+        double publishDate = level.PublishDate / 1000d / secondsPerMonth;
+        double elapsedMonths = ((double)now / secondsPerMonth) - publishDate;
 
-        // Get a scale from 0.0f to 1.0f, the percent of decay
-        float multiplier = 1.0f - Math.Min(1.0f, (float)elapsed / decaySeconds);
-        multiplier = Math.Max(minimumMultiplier, multiplier); // Clamp to minimum multiplier
+        // Get a scale from 0.0f to 1.0f, the percent of decay, using an exponential decay function
+        // https://www.desmos.com/calculator/87wbuh1gcy
+        double multiplier = Math.Pow(Math.E, -elapsedMonths);
         
         Log(logger, LogLevel.Trace, "Decay multiplier is {0}", multiplier);
-        return multiplier;
+        return (float)multiplier;
     }
 
     private static float CalculatePositiveScore(GameLevel level, DataContext context)


### PR DESCRIPTION
This causes cool levels to *much* more aggressively favor levels from the past month or two, and past that the decay quickly converges with 0. Removing the bottom limit makes sure that cool rating will always go down, even if an older level gets popular again.

Cool Levels after this PR:

![image](https://github.com/user-attachments/assets/3ccca2dd-aea0-484c-9040-cf7fb896a89a)
