### PR TITLE
Team Picks refactor

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -85,11 +85,11 @@ public partial class GameDatabaseContext // Levels
         newLevel.Publisher = author;
         newLevel.PublishDate = oldLevel.PublishDate;
         newLevel.UpdateDate = this._time.TimestampMilliseconds; // Set the last modified date
+        newLevel.TeamPicked = oldLevel.TeamPicked;
         
         // If the actual contents of the level haven't changed, extract some extra information
         if (oldLevel.RootResource == newLevel.RootResource)
         {
-            newLevel.TeamPicked = oldLevel.TeamPicked;
             newLevel.GameVersion = oldLevel.GameVersion;
         }
         

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -33,7 +33,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 136;
+    protected override ulong SchemaVersion => 137;
 
     protected override string Filename => "refreshGameServer.realm";
     
@@ -299,6 +299,16 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
                         Timestamp = comment.Timestamp,
                     });
                 }
+            }
+
+            // In version 137 we started storing the date at which levels were picked instead of just that they are picked.
+            // Since this is new information, let's set this to the date of the last update. 
+            if (oldVersion < 137)
+            {
+                if (oldLevel.TeamPicked)
+                    newLevel.DateTeamPicked = DateTimeOffset.FromUnixTimeMilliseconds(oldLevel.UpdateDate);
+                else
+                    newLevel.DateTeamPicked = null;
             }
         }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
@@ -44,6 +44,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
     
     public required int UniquePlays { get; set; }
     public required bool TeamPicked { get; set; }
+    public required DateTimeOffset? DateTeamPicked { get; set; }
     public required GameLevelType LevelType { get; set; }
     public required bool IsLocked { get; set; }
     public required bool IsSubLevel { get; set; }
@@ -77,6 +78,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
             Hearts = dataContext.Database.GetFavouriteCountForLevel(level),
             UniquePlays = dataContext.Database.GetUniquePlaysForLevel(level),
             TeamPicked = level.TeamPicked,
+            DateTeamPicked = level.DateTeamPicked,
             RootLevelHash = level.RootResource,
             GameVersion = level.GameVersion,
             LevelType = level.LevelType,

--- a/Refresh.GameServer/Types/Levels/GameLevel.cs
+++ b/Refresh.GameServer/Types/Levels/GameLevel.cs
@@ -42,7 +42,9 @@ public partial class GameLevel : IRealmObject, ISequentialId
     public bool EnforceMinMaxPlayers { get; set; }
     
     public bool SameScreenGame { get; set; }
-    public bool TeamPicked { get; set; }
+    [Ignored]
+    public bool TeamPicked => this.DateTeamPicked != null;
+    public DateTimeOffset? DateTeamPicked { get; set; }
     
     /// <summary>
     /// The GUID of the background, this seems to only be used by LBP PSP


### PR DESCRIPTION
Some improvements suggested by CrankyLandlord of the curators team. Closes #584.

- Always retain team pick status when updating level
- Store date of team picks instead of just that the level is team picked