### PR TITLE
Add support for adventures

### DIFF
--- a/Refresh.Common/Refresh.Common.csproj
+++ b/Refresh.Common/Refresh.Common.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Bunkum" Version="4.7.1" />
-      <PackageReference Include="Bunkum.Protocols.Http" Version="4.7.1" />
+      <PackageReference Include="Bunkum" Version="4.8.1" />
+      <PackageReference Include="Bunkum.Protocols.Http" Version="4.8.1" />
     </ItemGroup>
 
 </Project>

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -352,6 +352,12 @@ public partial class GameDatabaseContext // Levels
             .OrderByDescending(l => l.Score), skip, count);
 
     [Pure]
+    public DatabaseList<GameLevel> GetAdventureLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings) =>
+        new(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+            .FilterByLevelFilterSettings(user, levelFilterSettings)
+            .Where(l => l.IsAdventure), skip, count);
+
+    [Pure]
     public DatabaseList<GameLevel> SearchForLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings, string query)
     {
         IQueryable<GameLevel> validLevels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(user, levelFilterSettings);

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -33,7 +33,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 137;
+    protected override ulong SchemaVersion => 138;
 
     protected override string Filename => "refreshGameServer.realm";
     
@@ -309,6 +309,12 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
                     newLevel.DateTeamPicked = DateTimeOffset.FromUnixTimeMilliseconds(oldLevel.UpdateDate);
                 else
                     newLevel.DateTeamPicked = null;
+            }
+            
+            // In version 138 we added support for Adventures in LBP3. Set their status to false by default.
+            if (oldVersion < 138)
+            {
+                newLevel.IsAdventure = false;
             }
         }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
@@ -16,6 +16,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
     public required bool IsReUpload { get; set; }
     public required string? OriginalPublisher { get; set; }
 
+    public required bool IsAdventure { get; set; }
     public required string Title { get; set; }
     public required string IconHash { get; set; }
     public required string Description { get; set; }
@@ -58,6 +59,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
         
         return new ApiGameLevelResponse
         {
+            IsAdventure = level.IsAdventure,
             Title = level.Title,
             Publisher = ApiGameUserResponse.FromOld(level.Publisher, dataContext),
             OriginalPublisher = level.OriginalPublisher,

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Request/GameLevelRequest.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Request/GameLevelRequest.cs
@@ -11,6 +11,8 @@ namespace Refresh.GameServer.Endpoints.Game.DataTypes.Request;
 public class GameLevelRequest
 {
     [XmlElement("id")] public required int LevelId { get; set; }
+    
+    [XmlElement("isAdventurePlanet")] public required bool IsAdventure { get; set; }
 
     [XmlElement("name")] public required string Title { get; set; }
     [XmlElement("icon")] public required string IconHash { get; set; }
@@ -46,10 +48,13 @@ public class GameLevelRequest
     
     [XmlElement("backgroundGUID")] public string? BackgroundGuid { get; set; }
     
+    [XmlArray("slots")] public GameLevelRequest[]? Slots { get; set; }
+    
     public GameLevel ToGameLevel(GameUser publisher) =>
         new()
         {
             LevelId = this.LevelId,
+            IsAdventure = this.IsAdventure,
             Title = this.Title,
             IconHash = this.IconHash,
             Description = this.Description,

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -19,6 +19,8 @@ namespace Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLevel>
 {
     [XmlElement("id")] public required int LevelId { get; set; }
+    
+    [XmlElement("isAdventurePlanet")] public required bool IsAdventure { get; set; }
 
     [XmlElement("name")] public required string Title { get; set; }
     [XmlElement("icon")] public required string IconHash { get; set; }
@@ -96,6 +98,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         return new GameLevelResponse
         {
             LevelId = dataContext.Game == TokenGame.LittleBigPlanet3 ? LevelIdFromHash(hash) : int.MaxValue,
+            IsAdventure = false,
             Title = $"Hashed Level - {hash}",
             IconHash = "0",
             GameVersion = 0,
@@ -143,6 +146,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         GameLevelResponse response = new()
         {
             LevelId = old.LevelId,
+            IsAdventure = old.IsAdventure,
             Title = old.Title,
             IconHash = old.IconHash,
             Description = old.Description,

--- a/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
@@ -1,14 +1,17 @@
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
+using Bunkum.Core.Endpoints.Debugging;
 using Bunkum.Core.Responses;
 using Bunkum.Listener.Protocol;
 using Bunkum.Protocols.Http;
 using Refresh.Common.Constants;
+using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Request;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types.Assets;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.UserData;
@@ -33,12 +36,13 @@ public class PublishEndpoints : EndpointGroup
             body.Description = body.Description[..UgcConstantLimits.DescriptionLimit];
             
         if (body.MaxPlayers is > 4 or < 0 || body.MinPlayers is > 4 or < 0)
-        {
             return false;
-        }
 
-        //If the icon hash is a GUID hash, verify its a valid texture GUID
+        //If the icon hash is a GUID hash, verify that its a valid texture GUID
         if (body.IconHash.StartsWith('g') && !dataContext.GuidChecker.IsTextureGuid(dataContext.Game, long.Parse(body.IconHash.AsSpan()[1..]))) 
+            return false;
+
+        if (body.IsAdventure && dataContext.Game != TokenGame.LittleBigPlanet3)
             return false;
 
         GameLevel? existingLevel = dataContext.Database.GetLevelByRootResource(body.RootResource);
@@ -55,6 +59,8 @@ public class PublishEndpoints : EndpointGroup
 
     [GameEndpoint("startPublish", ContentType.Xml, HttpMethods.Post)]
     [NullStatusCode(BadRequest)]
+    [DebugRequestBody]
+    [DebugResponseBody]
     [RequireEmailVerified]
     public SerializedLevelResources? StartPublish(RequestContext context,
         GameLevelRequest body,
@@ -62,13 +68,28 @@ public class PublishEndpoints : EndpointGroup
         DataContext dataContext)
     {
         //If verifying the request fails, return null
-        if (!VerifyLevel(body, dataContext)) return null;
+        if (!VerifyLevel(body, dataContext))
+        {
+            context.Logger.LogInfo(RefreshContext.Publishing, "Failed to verify root level");
+            return null;
+        }
+
+        if (body.Slots != null)
+        {
+            foreach (GameLevelRequest innerLevel in body.Slots)
+            {
+                if (VerifyLevel(body, dataContext)) continue;
+
+                context.Logger.LogInfo(RefreshContext.Publishing, "Failed to verify inner level {0}", innerLevel.LevelId);
+                return null;
+            }
+        }
 
         List<string> hashes =
         [
-            .. body.XmlResources,
+            ..body.XmlResources,
             body.RootResource,
-            body.IconHash
+            body.IconHash,
         ];
 
         //Remove all invalid or GUID assets
@@ -111,6 +132,23 @@ public class PublishEndpoints : EndpointGroup
         //Make sure the root resource exists in the data store
         if (!dataContext.DataStore.ExistsInStore(rootResourcePath)) return NotFound;
 
+        GameAsset? asset = dataContext.Database.GetAssetFromHash(level.RootResource);
+        if (asset != null)
+        {
+            // ReSharper disable once ConvertIfStatementToSwitchStatement
+            if (level.IsAdventure && asset.AssetType != GameAssetType.AdventureCreateProfile)
+            {
+                dataContext.Database.AddPublishFailNotification("The uploaded adventure data was corrupted.", level, dataContext.User!);
+                return BadRequest;
+            }
+
+            if (!level.IsAdventure && asset.AssetType != GameAssetType.Level)
+            {
+                dataContext.Database.AddPublishFailNotification("The uploaded level data was corrupted.", level, dataContext.User!);
+                return BadRequest;
+            }
+        }
+
         if (level.LevelId != default) // Republish requests contain the id of the old level
         {
             context.Logger.LogInfo(BunkumCategory.UserContent, "Republishing level id {0}", level.LevelId);
@@ -122,7 +160,7 @@ public class PublishEndpoints : EndpointGroup
                 return new Response(GameLevelResponse.FromOld(newBody, dataContext)!, ContentType.Xml);
             }
 
-            dataContext.Database.AddPublishFailNotification("You may not republish another user's level.", level, dataContext.User);
+            dataContext.Database.AddPublishFailNotification("You may not republish another user's level.", level, dataContext.User!);
             return BadRequest;
         }
 

--- a/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
@@ -59,8 +59,6 @@ public class PublishEndpoints : EndpointGroup
 
     [GameEndpoint("startPublish", ContentType.Xml, HttpMethods.Post)]
     [NullStatusCode(BadRequest)]
-    [DebugRequestBody]
-    [DebugResponseBody]
     [RequireEmailVerified]
     public SerializedLevelResources? StartPublish(RequestContext context,
         GameLevelRequest body,

--- a/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
@@ -76,7 +76,7 @@ public class PublishEndpoints : EndpointGroup
         {
             foreach (GameLevelRequest innerLevel in body.Slots)
             {
-                if (VerifyLevel(body, dataContext)) continue;
+                if (VerifyLevel(innerLevel, dataContext)) continue;
 
                 context.Logger.LogInfo(RefreshContext.Publishing, "Failed to verify inner level {0}", innerLevel.LevelId);
                 return null;

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -52,12 +52,12 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'!='DebugLocalBunkum'">
-        <PackageReference Include="Bunkum" Version="4.7.1" />
-        <PackageReference Include="Bunkum.RealmDatabase" Version="4.7.1" />
-        <PackageReference Include="Bunkum.AutoDiscover" Version="4.7.1" />
-        <PackageReference Include="Bunkum.HealthChecks" Version="4.7.1" />
-        <PackageReference Include="Bunkum.HealthChecks.RealmDatabase" Version="4.7.1" />
-        <PackageReference Include="Bunkum.Protocols.Http" Version="4.7.1" />
+        <PackageReference Include="Bunkum" Version="4.8.1" />
+        <PackageReference Include="Bunkum.RealmDatabase" Version="4.8.1" />
+        <PackageReference Include="Bunkum.AutoDiscover" Version="4.8.1" />
+        <PackageReference Include="Bunkum.HealthChecks" Version="4.8.1" />
+        <PackageReference Include="Bunkum.HealthChecks.RealmDatabase" Version="4.8.1" />
+        <PackageReference Include="Bunkum.Protocols.Http" Version="4.8.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/RefreshContext.cs
+++ b/Refresh.GameServer/RefreshContext.cs
@@ -8,4 +8,5 @@ public enum RefreshContext
     PasswordReset,
     LevelListOverride,
     CoolLevels,
+    Publishing,
 }

--- a/Refresh.GameServer/Types/Levels/Categories/AdventureCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/AdventureCategory.cs
@@ -1,0 +1,24 @@
+using Bunkum.Core;
+using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
+using Refresh.GameServer.Types.Data;
+using Refresh.GameServer.Types.UserData;
+
+namespace Refresh.GameServer.Types.Levels.Categories;
+
+public class AdventureCategory : LevelCategory
+{
+    public AdventureCategory() : base("adventure", Array.Empty<string>(), false)
+    {
+        this.Name = "Adventures";
+        this.Description = "Storylines and other big projects by the community.";
+        this.FontAwesomeIcon = "book-bookmark";
+        this.IconHash = "g820625";
+    }
+
+    public override DatabaseList<GameLevel>? Fetch(RequestContext context, int skip, int count, DataContext dataContext,
+        LevelFilterSettings levelFilterSettings, GameUser? _)
+    {
+        return dataContext.Database.GetAdventureLevels(count, skip, dataContext.User, levelFilterSettings);
+    }
+}

--- a/Refresh.GameServer/Types/Levels/Categories/CategoryService.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/CategoryService.cs
@@ -31,6 +31,7 @@ public class CategoryService : EndpointService
         new ByTagCategory(),
         new DeveloperLevelsCategory(),
         new ContestCategory(),
+        new AdventureCategory(),
     ];
 
     internal CategoryService(Logger logger) : base(logger)

--- a/Refresh.GameServer/Types/Levels/GameLevel.cs
+++ b/Refresh.GameServer/Types/Levels/GameLevel.cs
@@ -16,6 +16,8 @@ namespace Refresh.GameServer.Types.Levels;
 public partial class GameLevel : IRealmObject, ISequentialId
 {
     [PrimaryKey] public int LevelId { get; set; }
+    
+    public bool IsAdventure { get; set; }
 
     [Indexed(IndexType.FullText)]
     public string Title { get; set; } = "";

--- a/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
@@ -17,6 +17,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     //NOTE: THIS MUST BE AT THE TOP OF THE XML RESPONSE OR ELSE LBP PSP WILL CRASH
     [XmlElement("id")] public required int LevelId { get; set; }
     
+    [XmlElement("isAdventurePlanet")] public required bool IsAdventure { get; set; }
     [XmlElement("name")] public required string Title { get; set; } = string.Empty;
     [XmlElement("icon")] public required string IconHash { get; set; } = string.Empty;
     [XmlElement("game")] public required int GameVersion { get; set; }
@@ -76,6 +77,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
         return new GameMinimalLevelResponse
         {
             Title = level.Title,
+            IsAdventure = level.IsAdventure,
             IconHash = dataContext.Database.GetAssetFromHash(level.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? level.IconHash,
             GameVersion = level.GameVersion,
             RootResource = level.RootResource,

--- a/Refresh.GameServer/Types/Levels/SerializedLevelResources.cs
+++ b/Refresh.GameServer/Types/Levels/SerializedLevelResources.cs
@@ -4,7 +4,7 @@ namespace Refresh.GameServer.Types.Levels;
 
 #nullable disable
 
-[XmlRoot("slot")]
+[XmlRoot("slot"), XmlType("slot")]
 public class SerializedLevelResources
 {
     [XmlElement("resource")] public string[] Resources { get; set; }

--- a/Refresh.HttpsProxy/Refresh.HttpsProxy.csproj
+++ b/Refresh.HttpsProxy/Refresh.HttpsProxy.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Bunkum.Protocols.Https" Version="4.7.1" />
+      <PackageReference Include="Bunkum.Protocols.Https" Version="4.8.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/RefreshTests.GameServer/Tests/Levels/PublishEndpointsTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/PublishEndpointsTests.cs
@@ -28,6 +28,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "TEST LEVEL",
             IconHash = "g719",
             Description = "DESCRIPTION",
@@ -91,6 +92,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = new string('*', UgcConstantLimits.TitleLimit * 2),
             IconHash = "g0",
             Description = "Normal length",
@@ -129,6 +131,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "Normal Title!",
             IconHash = "g0",
             Description = new string('=', UgcConstantLimits.DescriptionLimit * 2),
@@ -167,6 +170,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "Normal Title!",
             IconHash = "g0",
             Description = "Normal Description",
@@ -200,6 +204,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "Normal Title!",
             IconHash = "g0",
             Description = "Normal Description",
@@ -233,6 +238,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "Normal Title!",
             IconHash = "g0",
             Description = "Normal Description",
@@ -269,6 +275,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "Normal Title!",
             IconHash = "g0",
             Description = "Normal Description",
@@ -301,6 +308,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "Normal Title!",
             IconHash = "g0",
             Description = "Normal Description",
@@ -334,6 +342,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "Normal Title!",
             IconHash = "g719",
             Description = "Normal Description",
@@ -369,6 +378,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "TEST LEVEL",
             IconHash = "g719",
             Description = "DESCRIPTION",
@@ -425,6 +435,7 @@ public class PublishEndpointsTests : GameServerTest
         GameLevelRequest level = new()
         {
             LevelId = 0,
+            IsAdventure = false,
             Title = "TEST LEVEL",
             IconHash = "g719",
             Description = "DESCRIPTION",


### PR DESCRIPTION
Pretty straight-forward. Includes a category that only shows adventures levels as a side-bonus.

This also checks against the `GameAsset` type to see if the RootLevel is the expected type, returning an error if so. This only happens if the `GameAsset` is available; the only case where this would happen would be when re-uploading an adventure/level from the dry archive.