### PR TITLE
Exclude level author's relations from cool levels

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -60,9 +60,9 @@ public partial class GameDatabaseContext // Relations
         return true;
     }
     
-    public int GetFavouriteCountForLevel(GameLevel level) => this.FavouriteLevelRelations
-        .Count(r => r.Level == level);
-    
+    public int GetFavouriteCountForLevel(GameLevel level, bool includingAuthor = true) => this.FavouriteLevelRelations
+            .Count(r => r.Level == level && (includingAuthor || r.User != level.Publisher));
+
     #endregion
 
     #region Favouriting Users
@@ -301,8 +301,11 @@ public partial class GameDatabaseContext // Relations
         return true;
     }
     
-    public int GetTotalRatingsForLevel(GameLevel level, RatingType type) =>
-        this.RateLevelRelations.Count(r => r.Level == level && r._RatingType == (int)type);
+    public int GetTotalRatingsForLevel(GameLevel level, RatingType type, bool includingAuthor = true) =>
+        this.RateLevelRelations.Count(r =>
+            r.Level == level &&
+            r._RatingType == (int)type && 
+            (includingAuthor || r.User != level.Publisher));
     
     /// <summary>
     /// Adds a review to the database, deleting any old ones by the user on that level.
@@ -408,8 +411,8 @@ public partial class GameDatabaseContext // Relations
     public int GetTotalPlaysForLevelByUser(GameLevel level, GameUser user) =>
         this.GetAllPlaysForLevelByUser(level, user).Sum(playLevelRelation => playLevelRelation.Count);
     
-    public int GetUniquePlaysForLevel(GameLevel level) =>
-        this.UniquePlayLevelRelations.Count(r => r.Level == level);
+    public int GetUniquePlaysForLevel(GameLevel level, bool includingAuthor = true) =>
+        this.UniquePlayLevelRelations.Count(r => r.Level == level && (includingAuthor || r.User != level.Publisher));
 
     #endregion
 

--- a/Refresh.GameServer/Workers/CoolLevelsWorker.cs
+++ b/Refresh.GameServer/Workers/CoolLevelsWorker.cs
@@ -110,13 +110,13 @@ public class CoolLevelsWorker : IWorker
         if (level.TeamPicked)
             score += 50;
         
-        int positiveRatings = context.Database.GetTotalRatingsForLevel(level, RatingType.Yay);
-        int negativeRatings = context.Database.GetTotalRatingsForLevel(level, RatingType.Boo);
-        int uniquePlays = context.Database.GetUniquePlaysForLevel(level);
+        int positiveRatings = context.Database.GetTotalRatingsForLevel(level, RatingType.Yay, false);
+        int negativeRatings = context.Database.GetTotalRatingsForLevel(level, RatingType.Boo, false);
+        int uniquePlays = context.Database.GetUniquePlaysForLevel(level, false);
         
         score += positiveRatings * positiveRatingPoints;
         score += uniquePlays * uniquePlayPoints;
-        score += context.Database.GetFavouriteCountForLevel(level) * heartPoints;
+        score += context.Database.GetFavouriteCountForLevel(level, false) * heartPoints;
         
         // Reward for a good ratio between plays and yays
         float ratingRatio = (positiveRatings - negativeRatings) / (float)uniquePlays;
@@ -143,7 +143,7 @@ public class CoolLevelsWorker : IWorker
         // The percentage of how much penalty should be applied at the end of the calculation.
         const float penaltyMultiplier = 0.75f;
         
-        penalty += context.Database.GetTotalRatingsForLevel(level, RatingType.Boo) * negativeRatingPenalty;
+        penalty += context.Database.GetTotalRatingsForLevel(level, RatingType.Boo, false) * negativeRatingPenalty;
         
         if (level.Publisher == null)
             penalty += noAuthorPenalty;


### PR DESCRIPTION
More anti-sackattack1 and pro-crankylandlord propaganda.

In English, this means that people who heart their own levels won't be able to gain CR from doing so.