### PR TITLE
Implement reupload marking for all levels of a user

### DIFF
--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -67,6 +67,9 @@ internal class CommandLineManager
         
         [Option("fully-delete-user", HelpText = "Fully deletes a user, entirely removing the row and allowing people to register with that username once again. Not recommended.")]
         public bool FullyDeleteUser { get; set; }
+        
+        [Option("mark-all-reuploads", HelpText = "Marks all levels uploaded by a user as re-uploaded. Username or Email options are required if this is set.")]
+        public bool MarkAllReuploads { get; set; }
     }
 
     internal void StartWithArgs(string[] args)
@@ -194,6 +197,11 @@ internal class CommandLineManager
         {
             GameUser user = this.GetUserOrFail(options);
             this._server.FullyDeleteUser(user);
+        }
+        else if (options.MarkAllReuploads)
+        {
+            GameUser user = this.GetUserOrFail(options);
+            this._server.MarkAllReuploads(user);
         }
     }
 }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -413,4 +413,20 @@ public partial class GameDatabaseContext // Users
                 user.ProfileVisibility = settings.ProfileVisibility.Value;
         });            
     }
+
+    public void MarkAllReuploads(GameUser user)
+    {
+        IQueryable<GameLevel> levels = this.GameLevels.Where(l => l.Publisher == user);
+            
+        this.Write(() =>
+        {
+            foreach (GameLevel level in levels)
+            {
+                level.IsReUpload = true;
+                // normally, we'd also set the original publisher when marking a reupload.
+                // but since were doing this blindly, we shouldn't because the level might already be a reupload.
+                // we'd be setting it to null here, which could be loss of information.
+            }
+        });
+    }
 }

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -187,7 +187,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         {
             string publisher;
             if (!old.IsReUpload)
-                publisher = "!DeletedUser";
+                publisher = FakeUserConstants.DeletedUserName;
             else
                 publisher = string.IsNullOrEmpty(old.OriginalPublisher)
                     ? FakeUserConstants.UnknownUserName

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -251,6 +251,12 @@ public class RefreshGameServer : RefreshServer
         using GameDatabaseContext context = this.GetContext();
         context.FullyDeleteUser(user);
     }
+    
+    public void MarkAllReuploads(GameUser user)
+    {
+        using GameDatabaseContext context = this.GetContext();
+        context.MarkAllReuploads(user);
+    }
 
     public override void Dispose()
     {


### PR DESCRIPTION
Helps with moderating those who are re-uploading story levels. This is only accessible with the CLI but in the future we may want to allow curators to do this. For now I just want curators to ask.
