### PR TITLE
Allow conversion of assets not in the database to images

### DIFF
--- a/Refresh.GameServer/Importing/Importer.cs
+++ b/Refresh.GameServer/Importing/Importer.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using Bunkum.Core;
+using JetBrains.Annotations;
 using NotEnoughLogs;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Resources;
@@ -181,6 +182,7 @@ public abstract class Importer
         return true;
     }
 
+    [Pure]
     protected (GameAssetType, GameAssetFormat) DetermineAssetType(Span<byte> data, TokenPlatform? tokenPlatform)
     {
         GameAssetType? lbpAssetType = GameAssetTypeExtensions.LbpMagicToGameAssetType(data.Slice(0, 3));

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -59,6 +59,9 @@ public class RefreshGameServer : RefreshServer
         DryArchiveConfig dryConfig = Config.LoadFromJsonFile<DryArchiveConfig>("dry.json", this.Logger);
         if (dryConfig.Enabled)
             this._dataStore = new AggregateDataStore(dataStore, new DryDataStore(dryConfig));
+
+        // Uncomment if you want to use production refresh as a source for assets
+        // this._dataStore = new AggregateDataStore(dataStore, new RemoteRefreshDataStore());
         
         this.SetupInitializer(() =>
         {

--- a/Refresh.GameServer/Storage/RemoteRefreshDataStore.cs
+++ b/Refresh.GameServer/Storage/RemoteRefreshDataStore.cs
@@ -1,0 +1,70 @@
+using Bunkum.Core.Storage;
+using JetBrains.Annotations;
+
+namespace Refresh.GameServer.Storage;
+
+/// <summary>
+/// A datastore that uses production Refresh as a data source.
+/// Intended for testing purposes only; performance is not considered.
+/// </summary>
+public class RemoteRefreshDataStore : IDataStore
+{
+    private const string SourceUrl = "https://lbp.littlebigrefresh.com/api/v3/"; 
+    private const string WriteError = $"{nameof(RemoteRefreshDataStore)} is a read-only source, and cannot be written to.";
+    private const bool HideImages = true;
+    
+    private readonly HttpClient _client = new()
+    {
+        BaseAddress = new Uri(SourceUrl),
+    };
+    
+    [Pure]
+    private string? GetPath(ReadOnlySpan<char> key)
+    {
+        if (key.StartsWith("png/"))
+            return $"assets/{key[4..]}/image";
+
+        return $"assets/{key}/download";
+    }
+
+    private HttpResponseMessage Get(string endpoint)
+    {
+        HttpResponseMessage message = this._client.GetAsync(endpoint).Result;
+        return message;
+    }
+    
+    public bool ExistsInStore(string key)
+    {
+        if (HideImages && key.StartsWith("png/"))
+            return false;
+
+        string? path = this.GetPath(key);
+
+        if (path == null)
+            throw new FormatException("The key was invalid.");
+        
+        HttpResponseMessage resp = this.Get(path);
+        return resp.IsSuccessStatusCode;
+    }
+
+    public bool WriteToStore(string key, byte[] data) => throw new InvalidOperationException(WriteError);
+
+    public byte[] GetDataFromStore(string key)
+    {
+        string? path = this.GetPath(key);
+        
+        if (path == null)
+            throw new FormatException("The key was invalid.");
+
+        HttpResponseMessage resp = this.Get(path);
+        resp.EnsureSuccessStatusCode();
+        
+        return resp.Content.ReadAsByteArrayAsync().Result;
+    }
+    
+    public bool RemoveFromStore(string key) => throw new InvalidOperationException(WriteError);
+    public string[] GetKeysFromStore() => []; // TODO: Implement when we want to store these as GameAssets
+    public bool WriteToStoreFromStream(string key, Stream data) => throw new InvalidOperationException(WriteError);
+    public Stream GetStreamFromStore(string key) => new MemoryStream(this.GetDataFromStore(key));
+    public Stream OpenWriteStream(string key) => throw new InvalidOperationException(WriteError);
+}


### PR DESCRIPTION
Implemented as discussed on [Discord](https://discord.com/channels/1049223665243389953/1049225857350254632/1270832582501597378).

For ease of testing, use the included new `IDataStore` named `RemoteRefreshDataStore` to use prod as a storage backend, then look at reuploads from the archive. Notice that they now have icons.