### PR TITLE
Show levels from the last active contest after a contest has ended

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
@@ -52,6 +52,15 @@ public partial class GameDatabaseContext // Contests
             .FirstOrDefault();
     }
     
+    public GameContest? GetLastActiveContest()
+    {
+        DateTimeOffset now = this._time.Now;
+        return this.GameContests
+            .Where(c => c.EndDate <= now)
+            .OrderByDescending(c => c.EndDate)
+            .FirstOrDefault();
+    }
+    
     public GameContest UpdateContest(ApiContestRequest body, GameContest contest, GameUser? newOrganizer = null)
     {
         this.Write(() =>

--- a/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Contests.cs
@@ -52,7 +52,7 @@ public partial class GameDatabaseContext // Contests
             .FirstOrDefault();
     }
     
-    public GameContest? GetLastActiveContest()
+    public GameContest? GetLatestCompletedContest()
     {
         DateTimeOffset now = this._time.Now;
         return this.GameContests

--- a/Refresh.GameServer/Types/Levels/Categories/ContestCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/ContestCategory.cs
@@ -25,8 +25,11 @@ public class ContestCategory : LevelCategory
         string? contestId = context.QueryString["contest"];
         GameContest? contest = dataContext.Database.GetContestById(contestId);
         
-        // if we cant find one by a query param try getting an active contest instead
+        // if we can't find one by a query param, try getting an active contest instead
         contest ??= dataContext.Database.GetNewestActiveContest();
+
+        // if there's no active contest, then try to use the last one that ended
+        contest ??= dataContext.Database.GetLastActiveContest();
         
         // if not, then fail
         if (contest == null)

--- a/Refresh.GameServer/Types/Levels/Categories/ContestCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/ContestCategory.cs
@@ -29,7 +29,7 @@ public class ContestCategory : LevelCategory
         contest ??= dataContext.Database.GetNewestActiveContest();
 
         // if there's no active contest, then try to use the last one that ended
-        contest ??= dataContext.Database.GetLastActiveContest();
+        contest ??= dataContext.Database.GetLatestCompletedContest();
         
         // if not, then fail
         if (contest == null)

--- a/RefreshTests.GameServer/Tests/Levels/ContestTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ContestTests.cs
@@ -225,4 +225,36 @@ public class ContestTests : GameServerTest
         oldestContest = context.Database.GetNewestActiveContest();
         Assert.That(oldestContest, Is.Null);
     }
+    
+    [Test]
+    public void LastActiveContestIsCorrectOne()
+    {
+        using TestContext context = this.GetServer(false);
+        // contests end after 10ms
+        context.Time.TimestampMilliseconds = 0; // start at 0ms
+        this.CreateContest(context, id: "0");
+        
+        // should return null during an active contest
+        GameContest? oldestContest = context.Database.GetLastActiveContest();
+        Assert.That(oldestContest, Is.Null);
+        
+        context.Time.TimestampMilliseconds = 5; // advance 5ms, create a new contest.
+        this.CreateContest(context, id: "5");
+        
+        // jump to 14ms, after 0 has ended
+        context.Time.TimestampMilliseconds = 14;
+        
+        // 0 should be the last active contest
+        oldestContest = context.Database.GetLastActiveContest();
+        Assert.That(oldestContest, Is.Not.Null);
+        Assert.That(oldestContest!.ContestId, Is.EqualTo("0"));
+        
+        // jump to 15ms, 5 should be dead
+        context.Time.TimestampMilliseconds = 15;
+        
+        // the last active contest should be 5
+        oldestContest = context.Database.GetLastActiveContest();
+        Assert.That(oldestContest, Is.Not.Null);
+        Assert.That(oldestContest!.ContestId, Is.EqualTo("5"));
+    }
 }

--- a/RefreshTests.GameServer/Tests/Levels/ContestTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ContestTests.cs
@@ -235,7 +235,7 @@ public class ContestTests : GameServerTest
         this.CreateContest(context, id: "0");
         
         // should return null during an active contest
-        GameContest? oldestContest = context.Database.GetLastActiveContest();
+        GameContest? oldestContest = context.Database.GetLatestCompletedContest();
         Assert.That(oldestContest, Is.Null);
         
         context.Time.TimestampMilliseconds = 5; // advance 5ms, create a new contest.
@@ -245,7 +245,7 @@ public class ContestTests : GameServerTest
         context.Time.TimestampMilliseconds = 14;
         
         // 0 should be the last active contest
-        oldestContest = context.Database.GetLastActiveContest();
+        oldestContest = context.Database.GetLatestCompletedContest();
         Assert.That(oldestContest, Is.Not.Null);
         Assert.That(oldestContest!.ContestId, Is.EqualTo("0"));
         
@@ -253,7 +253,7 @@ public class ContestTests : GameServerTest
         context.Time.TimestampMilliseconds = 15;
         
         // the last active contest should be 5
-        oldestContest = context.Database.GetLastActiveContest();
+        oldestContest = context.Database.GetLatestCompletedContest();
         Assert.That(oldestContest, Is.Not.Null);
         Assert.That(oldestContest!.ContestId, Is.EqualTo("5"));
     }


### PR DESCRIPTION
Right now, our contest category is empty, but people still care about #LBWSBR. This makes it so that the contest category will *always* have levels from that contest, despite the fact it's over.