### PR TITLE
Reset token expiry date when using a refresh token

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Tokens.cs
@@ -138,6 +138,17 @@ public partial class GameDatabaseContext // Tokens
     
     public DatabaseList<Token> GetAllTokens()
         => new(this.Tokens);
+    
+    public void ResetApiRefreshTokenExpiry(Token token)
+    {
+        if (token.TokenType != TokenType.ApiRefresh)
+            throw new InvalidOperationException("Cannot update a non-refresh token's expiry date");
+        
+        this.Write(() =>
+        {
+            token.ExpiresAt = this._time.Now.AddSeconds(RefreshTokenExpirySeconds);
+        });
+    }
 
     public void AddIpVerificationRequest(GameUser user, string ipAddress)
     {

--- a/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
@@ -113,6 +113,7 @@ public class AuthenticationApiEndpoints : EndpointGroup
         GameUser user = refreshToken.User;
 
         Token token = database.GenerateTokenForUser(user, TokenType.Api, TokenGame.Website, TokenPlatform.Website, context.RemoteIp());
+        database.ResetApiRefreshTokenExpiry(refreshToken);
         
         context.Logger.LogInfo(BunkumCategory.Authentication, $"{user} successfully refreshed their token through the API");
 


### PR DESCRIPTION
I tried to find the Discord conversation behind this, but I couldn't. At some point it was discussed that `ApiRefresh` tokens should reset themselves when used, so no re-login is required ever.

Turns out it was never implemented like this, so users are forced to re-authenticate manually every month as their refresh token expires every month, which is why the website randomly claims that your session has expired. It's not a bug as I thought, it's just... we're stupid.

This PR fixes that.