### PR TITLE
Add ability for admins to ask users for verification codes

### DIFF
--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -70,6 +70,9 @@ internal class CommandLineManager
         
         [Option("mark-all-reuploads", HelpText = "Marks all levels uploaded by a user as re-uploaded. Username or Email options are required if this is set.")]
         public bool MarkAllReuploads { get; set; }
+        
+        [Option("ask-for-verification", HelpText = "Sends a verification code to confirm a user's identity over an untrusted channel. Username or Email options are required if this is set.")]
+        public bool AskUserForVerification { get; set; }
     }
 
     internal void StartWithArgs(string[] args)
@@ -202,6 +205,16 @@ internal class CommandLineManager
         {
             GameUser user = this.GetUserOrFail(options);
             this._server.MarkAllReuploads(user);
+        }
+        else if (options.AskUserForVerification)
+        {
+            GameUser user = this.GetUserOrFail(options);
+            string code = this._server.AskUserForVerification(user);
+            Console.WriteLine($"The code has been sent to {user.Username}'s notifications.");
+            Console.WriteLine();
+            Console.WriteLine($"\tCode: {code}");
+            Console.WriteLine();
+            Console.WriteLine("If the user does not reply to you with *exactly* this code, assume the worst.");
         }
     }
 }

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -11,6 +11,7 @@ using Bunkum.HealthChecks;
 using Bunkum.HealthChecks.RealmDatabase;
 using Bunkum.Protocols.Http;
 using Refresh.Common;
+using Refresh.Common.Verification;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Configuration;
 using Refresh.GameServer.Database;
@@ -259,6 +260,20 @@ public class RefreshGameServer : RefreshServer
     {
         using GameDatabaseContext context = this.GetContext();
         context.MarkAllReuploads(user);
+    }
+
+    public string AskUserForVerification(GameUser user)
+    {
+        using GameDatabaseContext context = this.GetContext();
+        string code = CodeHelper.GenerateDigitCode();
+
+        string text = $"An admin is requesting a code to verify that you currently have access to your account. " +
+                      $"Please share the code '{code}' with the admin you're currently speaking with. " +
+                      "If you're not in contact with any such staff member, please report this immediately.";
+        
+        context.AddNotification("Admin Verification Request (Action Required)", text, user, "shield");
+
+        return code;
     }
 
     public override void Dispose()


### PR DESCRIPTION
From an idea I had after a frustrating email conversation. The idea is that if I want to verify someone is an account-holder (such as over Discord or via an untrusted email) I can send them a code, and ask them to retrieve it for me.

If the code matches with the one I sent then I can proceed with whatever action they're asking for.

To achieve this, I just use the existing notifications infrastructure with the same code generation from email verification.