### PR TITLE
Flag modded levels + per-user mod filtering

### DIFF
--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -26,6 +26,9 @@ internal class CommandLineManager
         [Option("convert-images", HelpText = "Convert all images in the database to .PNGs. Otherwise, images will be converted as they are used.")]
         public bool ImportImages { get; set; }
         
+        [Option("flag-modded-levels", HelpText = "Go through all uploaded levels and update the modded status of each level.")]
+        public bool FlagModdedLevels { get; set; }
+        
         [Option("generate-docs", HelpText = "Generates documentation for API V3 endpoints.")]
         public bool GenerateDocumentation { get; set; }
         
@@ -127,6 +130,10 @@ internal class CommandLineManager
         else if (options.ImportImages)
         {
             this._server.ImportImages();
+        }
+        else if (options.FlagModdedLevels)
+        {
+            this._server.FlagModdedLevels();
         }
         else if (options.GenerateDocumentation)
         {

--- a/Refresh.GameServer/Configuration/GameServerConfig.cs
+++ b/Refresh.GameServer/Configuration/GameServerConfig.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Bunkum.Core.Configuration;
 using Microsoft.CSharp.RuntimeBinder;
+using Refresh.GameServer.Types.Assets;
 using Refresh.GameServer.Types.Roles;
 
 namespace Refresh.GameServer.Configuration;
@@ -52,17 +53,9 @@ public class GameServerConfig : Config
 
     public string LicenseText { get; set; } = "Welcome to Refresh!";
 
-    public ConfigAssetFlags BlockedAssetFlags { get; set; } = new()
-    {
-        Dangerous = true,
-        Modded = true,
-    };
+    public ConfigAssetFlags BlockedAssetFlags { get; set; } = new(AssetFlags.Dangerous | AssetFlags.Modded);
     /// <seealso cref="GameUserRole.Trusted"/>
-    public ConfigAssetFlags BlockedAssetFlagsForTrustedUsers { get; set; } = new()
-    {
-        Dangerous = true,
-        Modded = true,
-    };
+    public ConfigAssetFlags BlockedAssetFlagsForTrustedUsers { get; set; } = new(AssetFlags.Dangerous | AssetFlags.Modded);
     public bool AllowUsersToUseIpAuthentication { get; set; } = false;
     public bool UseTicketVerification { get; set; } = true;
     public bool RegistrationEnabled { get; set; } = true;

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -406,7 +406,10 @@ public partial class GameDatabaseContext // Levels
     
     [Pure]
     public int GetTotalLevelCount() => this.GameLevels.Count(l => l._Source == (int)GameLevelSource.User);
-    
+
+    [Pure]
+    public int GetModdedLevelCount() => this.GameLevels.Count(l => l._Source == (int)GameLevelSource.User && l.Modded);
+
     public int GetTotalLevelsPublishedByUser(GameUser user)
         => this.GameLevels
             .Count(r => r.Publisher == user);

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -201,6 +201,9 @@ public partial class GameDatabaseContext // Users
             
             if (data.ProfileVisibility != null)
                 user.ProfileVisibility = data.ProfileVisibility.Value;
+
+            if (data.ShowModdedContent != null)
+                user.ShowModdedContent = data.ShowModdedContent.Value;
         });
     }
 
@@ -367,6 +370,14 @@ public partial class GameDatabaseContext // Users
         this.Write(() =>
         {
             user.UnescapeXmlSequences = value;
+        });
+    }
+
+    public void SetShowModdedContent(GameUser user, bool value)
+    {
+        this.Write(() =>
+        {
+            user.ShowModdedContent = value;
         });
     }
 

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -327,6 +327,7 @@ public partial class GameDatabaseContext // Users
                 foreach (GamePhotoSubject subject in photo.Subjects.Where(s => s.User?.UserId == user.UserId))
                     subject.User = null;
             
+            this.GameSubmittedScores.RemoveRange(s => s.Players[0] == user);
             this.FavouriteLevelRelations.RemoveRange(r => r.User == user);
             this.FavouriteUserRelations.RemoveRange(r => r.UserToFavourite == user);
             this.FavouriteUserRelations.RemoveRange(r => r.UserFavouriting == user);

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -33,7 +33,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 143;
+    protected override ulong SchemaVersion => 145;
 
     protected override string Filename => "refreshGameServer.realm";
     
@@ -97,8 +97,8 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         IQueryable<dynamic>? oldUsers = migration.OldRealm.DynamicApi.All("GameUser");
         IQueryable<GameUser>? newUsers = migration.NewRealm.All<GameUser>();
 
-        // only run all this if old version < 134, since thats the last time these were changed (update this accordingly)
-        if (oldVersion < 134)
+        // only run all this if old version < 145, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 145)
             for (int i = 0; i < newUsers.Count(); i++)
             {
                 dynamic oldUser = oldUsers.ElementAt(i);
@@ -216,6 +216,9 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
                         });
                     }
                 }
+
+                if (oldVersion < 145)
+                    newUser.ShowModdedContent = true;
             }
 
         IQueryable<dynamic>? oldLevels = migration.OldRealm.DynamicApi.All("GameLevel");

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -33,7 +33,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 141;
+    protected override ulong SchemaVersion => 143;
 
     protected override string Filename => "refreshGameServer.realm";
     
@@ -97,237 +97,285 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         IQueryable<dynamic>? oldUsers = migration.OldRealm.DynamicApi.All("GameUser");
         IQueryable<GameUser>? newUsers = migration.NewRealm.All<GameUser>();
 
-        for (int i = 0; i < newUsers.Count(); i++)
-        {
-            dynamic oldUser = oldUsers.ElementAt(i);
-            GameUser newUser = newUsers.ElementAt(i);
-
-            if (oldVersion < 3)
+        // only run all this if old version < 134, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 134)
+            for (int i = 0; i < newUsers.Count(); i++)
             {
-                newUser.Description = "";
-                newUser.LocationX = 0;
-                newUser.LocationY = 0;
-            }
+                dynamic oldUser = oldUsers.ElementAt(i);
+                GameUser newUser = newUsers.ElementAt(i);
 
-            //In version 4, GameLocation went from TopLevel -> Embedded, and UserPins was added
-            if (oldVersion < 4) newUser.Pins = new UserPins();
-
-            // In version 12, users were given IconHashes
-            if (oldVersion < 12) newUser.IconHash = "0";
-
-            // In version 13, users were given PlanetsHashes
-            if (oldVersion < 13) newUser.Lbp2PlanetsHash = "0";
-
-            // In version 23, users were given bcrypt passwords
-            if (oldVersion < 23) newUser.PasswordBcrypt = null;
-
-            // In version 26, users were given join dates
-            if (oldVersion < 26) newUser.JoinDate = DateTimeOffset.MinValue;
-
-            // In version 40, we switched to Realm source generators which requires some values to be reset
-            if (oldVersion < 40)
-            {
-                newUser.IconHash = oldUser.IconHash;
-                newUser.Description = oldUser.Description;
-                newUser.Lbp2PlanetsHash = oldUser.PlanetsHash;
-            }
-            
-            // In version 67, users switched to dates to store their join date
-            if (oldVersion < 67) newUser.JoinDate = DateTimeOffset.FromUnixTimeMilliseconds(oldUser.JoinDate);
-            
-            // In version 69 (nice), users were given last login dates. For now, we'll set that to now.
-            if(oldVersion < 69 /*nice*/) newUser.LastLoginDate = DateTimeOffset.Now;
-            
-            // In version 72, users got settings for permissions regarding certain platforms.
-            // To avoid breakage, we set them to true for existing users.
-            if (oldVersion < 72)
-            {
-                newUser.PsnAuthenticationAllowed = true;
-                newUser.RpcnAuthenticationAllowed = true;
-            }
-            
-            // In version 81, we split out planet hashes for LBP2, LBP Vita, and LBP3
-            // Since we've supported LBP2 as the primary game so far, set LBP2's hash to the old hash
-            if (oldVersion < 81)
-            {
-                newUser.Lbp2PlanetsHash = oldUser.PlanetsHash;
-                newUser.Lbp3PlanetsHash = oldUser.PlanetsHash; // Planets are forwards compatible
-            }
-            
-            // Fix vita
-            if (oldVersion < 82)
-            {
-                newUser.VitaPlanetsHash = "0";
-            }
-
-            // In version 100, we started enforcing lowercase email addresses
-            if (oldVersion < 100) newUser.EmailAddress = oldUser.EmailAddress?.ToLowerInvariant();
-
-            // Version was bumped here to delete invalid favourite level relations
-            if (oldVersion < 101) migration.NewRealm.RemoveRange(migration.OldRealm.All<FavouriteLevelRelation>().Where(r => r.User.UserId == newUser.UserId && r.Level == null));
-
-            // In version 102 we split the Vita icon hash from the PS3 icon hash
-            if (oldVersion < 102) newUser.VitaIconHash = "0";
-            
-            //In version 117, we started tracking the amount of data the user has uploaded to the server
-            if (oldVersion < 117)
-            {
-                newUser.FilesizeQuotaUsage = migration.NewRealm.All<GameAsset>()
-                    .AsEnumerable()
-                    .Where(a => a.OriginalUploader?.UserId == newUser.UserId)
-                    .Sum(a => a.SizeInBytes);
-            }
-            
-            // In version 129, we split locations from an embedded object out to two fields
-            if (oldVersion < 129)
-            {
-                // cast required because apparently they're stored as longs???
-                newUser.LocationX = (int)oldUser.Location.X;
-                newUser.LocationY = (int)oldUser.Location.Y;
-            }
-            
-            // In version 134, we split GameComments into multiple tables.
-            // This migration creates GameProfileComments
-            if (oldVersion < 134)
-            {
-                foreach (dynamic comment in oldUser.ProfileComments)
+                if (oldVersion < 3)
                 {
-                    GameUser? author = comment.Author != null ? migration.NewRealm.Find<GameUser>(comment.Author.UserId) : null;
-                    if (author == null)
-                    {
-                        Console.WriteLine($"Skipping migration for profile comment id {comment.SequentialId} due to missing author");
-                        continue;
-                    }
+                    newUser.Description = "";
+                    newUser.LocationX = 0;
+                    newUser.LocationY = 0;
+                }
 
-                    migration.NewRealm.Add(new GameProfileComment
+                //In version 4, GameLocation went from TopLevel -> Embedded, and UserPins was added
+                if (oldVersion < 4) newUser.Pins = new UserPins();
+
+                // In version 12, users were given IconHashes
+                if (oldVersion < 12) newUser.IconHash = "0";
+
+                // In version 13, users were given PlanetsHashes
+                if (oldVersion < 13) newUser.Lbp2PlanetsHash = "0";
+
+                // In version 23, users were given bcrypt passwords
+                if (oldVersion < 23) newUser.PasswordBcrypt = null;
+
+                // In version 26, users were given join dates
+                if (oldVersion < 26) newUser.JoinDate = DateTimeOffset.MinValue;
+
+                // In version 40, we switched to Realm source generators which requires some values to be reset
+                if (oldVersion < 40)
+                {
+                    newUser.IconHash = oldUser.IconHash;
+                    newUser.Description = oldUser.Description;
+                    newUser.Lbp2PlanetsHash = oldUser.PlanetsHash;
+                }
+
+                // In version 67, users switched to dates to store their join date
+                if (oldVersion < 67) newUser.JoinDate = DateTimeOffset.FromUnixTimeMilliseconds(oldUser.JoinDate);
+
+                // In version 69 (nice), users were given last login dates. For now, we'll set that to now.
+                if (oldVersion < 69 /*nice*/) newUser.LastLoginDate = DateTimeOffset.Now;
+
+                // In version 72, users got settings for permissions regarding certain platforms.
+                // To avoid breakage, we set them to true for existing users.
+                if (oldVersion < 72)
+                {
+                    newUser.PsnAuthenticationAllowed = true;
+                    newUser.RpcnAuthenticationAllowed = true;
+                }
+
+                // In version 81, we split out planet hashes for LBP2, LBP Vita, and LBP3
+                // Since we've supported LBP2 as the primary game so far, set LBP2's hash to the old hash
+                if (oldVersion < 81)
+                {
+                    newUser.Lbp2PlanetsHash = oldUser.PlanetsHash;
+                    newUser.Lbp3PlanetsHash = oldUser.PlanetsHash; // Planets are forwards compatible
+                }
+
+                // Fix vita
+                if (oldVersion < 82)
+                {
+                    newUser.VitaPlanetsHash = "0";
+                }
+
+                // In version 100, we started enforcing lowercase email addresses
+                if (oldVersion < 100) newUser.EmailAddress = oldUser.EmailAddress?.ToLowerInvariant();
+
+                // Version was bumped here to delete invalid favourite level relations
+                if (oldVersion < 101)
+                    migration.NewRealm.RemoveRange(migration.OldRealm.All<FavouriteLevelRelation>()
+                        .Where(r => r.User.UserId == newUser.UserId && r.Level == null));
+
+                // In version 102 we split the Vita icon hash from the PS3 icon hash
+                if (oldVersion < 102) newUser.VitaIconHash = "0";
+
+                //In version 117, we started tracking the amount of data the user has uploaded to the server
+                if (oldVersion < 117)
+                {
+                    newUser.FilesizeQuotaUsage = migration.NewRealm.All<GameAsset>()
+                        .AsEnumerable()
+                        .Where(a => a.OriginalUploader?.UserId == newUser.UserId)
+                        .Sum(a => a.SizeInBytes);
+                }
+
+                // In version 129, we split locations from an embedded object out to two fields
+                if (oldVersion < 129)
+                {
+                    // cast required because apparently they're stored as longs???
+                    newUser.LocationX = (int)oldUser.Location.X;
+                    newUser.LocationY = (int)oldUser.Location.Y;
+                }
+
+                // In version 134, we split GameComments into multiple tables.
+                // This migration creates GameProfileComments
+                if (oldVersion < 134)
+                {
+                    foreach (dynamic comment in oldUser.ProfileComments)
                     {
-                        SequentialId = (int)comment.SequentialId,
-                        Author = author,
-                        Profile = newUser,
-                        Content = comment.Content,
-                        Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(comment.Timestamp),
-                    });
+                        GameUser? author = comment.Author != null
+                            ? migration.NewRealm.Find<GameUser>(comment.Author.UserId)
+                            : null;
+                        if (author == null)
+                        {
+                            Console.WriteLine(
+                                $"Skipping migration for profile comment id {comment.SequentialId} due to missing author");
+                            continue;
+                        }
+
+                        migration.NewRealm.Add(new GameProfileComment
+                        {
+                            SequentialId = (int)comment.SequentialId,
+                            Author = author,
+                            Profile = newUser,
+                            Content = comment.Content,
+                            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(comment.Timestamp),
+                        });
+                    }
                 }
             }
-        }
 
         IQueryable<dynamic>? oldLevels = migration.OldRealm.DynamicApi.All("GameLevel");
         IQueryable<GameLevel>? newLevels = migration.NewRealm.All<GameLevel>();
 
-        for (int i = 0; i < newLevels.Count(); i++)
-        {
-            dynamic oldLevel = oldLevels.ElementAt(i);
-            GameLevel newLevel = newLevels.ElementAt(i);
+        // only run all this if old version < 143, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 143)
+            for (int i = 0; i < newLevels.Count(); i++)
+            {
+                dynamic oldLevel = oldLevels.ElementAt(i);
+                GameLevel newLevel = newLevels.ElementAt(i);
 
-            // In version 10, GameLevels switched to int-based ids.
-            if (oldVersion < 10)
-            {
-                newLevel.LevelId = i + 1;
-            }
-
-            // In version 11, timestamps were added to levels.
-            if (oldVersion < 11)
-            {
-                // Since we dont have a reference point for when the level was actually uploaded, default to now
-                newLevel.PublishDate = DateTimeOffset.Now;
-                newLevel.UpdateDate = DateTimeOffset.Now;
-            }
-
-            // In version 14, level timestamps were fixed
-            if (oldVersion < 14)
-            {
-                newLevel.PublishDate = oldLevel.PublishDate * 1000;
-                newLevel.UpdateDate = oldLevel.UpdateDate * 1000;
-            }
-            
-            // In version 40, we switched to Realm source generators which requires some values to be reset
-            if (oldVersion < 40)
-            {
-                newLevel.Title = oldLevel.Title;
-                newLevel.IconHash = oldLevel.IconHash;
-                newLevel.Description = oldLevel.Description;
-                newLevel.RootResource = oldLevel.RootResource;
-            }
-
-            // In version 57, we implemented minimum and maximum players which are 1 and 4 by default
-            if (oldVersion < 57)
-            {
-                newLevel.MinPlayers = 1;
-                newLevel.MaxPlayers = 4;
-            }
-            
-            // In version 79, we started tracking the version in which the level was uploaded from
-            // Set all levels to LBP2 by default, since that's the version we've supported up until now.
-            if (oldVersion < 79)
-            {
-                newLevel._GameVersion = (int)TokenGame.LittleBigPlanet2;
-            }
-
-            // In version 92, we started storing both user and story levels.
-            // Set all existing levels to user levels, since that's what has existed up until now.
-            if (oldVersion < 92)
-            {
-                newLevel._Source = (int)GameLevelSource.User;
-            }
-            
-            // In version 129, we split locations from an embedded object out to two fields
-            if (oldVersion < 129)
-            {
-                newLevel.LocationX = (int)oldLevel.Location.X;
-                newLevel.LocationY = (int)oldLevel.Location.Y;
-            }
-            
-            // In version 134, we split GameComments into multiple tables.
-            // This migration creates GameLevelComments
-            if (oldVersion < 134)
-            {
-                foreach (dynamic comment in oldLevel.LevelComments)
+                // In version 10, GameLevels switched to int-based ids.
+                if (oldVersion < 10)
                 {
-                    GameUser? author = comment.Author != null ? migration.NewRealm.Find<GameUser>(comment.Author.UserId) : null;
-                    if (author == null)
-                    {
-                        Console.WriteLine($"Skipping migration for level comment id {comment.SequentialId} due to missing author");
-                        continue;
-                    }
+                    newLevel.LevelId = i + 1;
+                }
 
-                    migration.NewRealm.Add(new GameLevelComment
+                // In version 11, timestamps were added to levels.
+                if (oldVersion < 11)
+                {
+                    // Since we dont have a reference point for when the level was actually uploaded, default to now
+                    newLevel.PublishDate = DateTimeOffset.Now;
+                    newLevel.UpdateDate = DateTimeOffset.Now;
+                }
+
+                // In version 14, level timestamps were fixed
+                if (oldVersion < 14)
+                {
+                    newLevel.PublishDate = oldLevel.PublishDate * 1000;
+                    newLevel.UpdateDate = oldLevel.UpdateDate * 1000;
+                }
+
+                // In version 40, we switched to Realm source generators which requires some values to be reset
+                if (oldVersion < 40)
+                {
+                    newLevel.Title = oldLevel.Title;
+                    newLevel.IconHash = oldLevel.IconHash;
+                    newLevel.Description = oldLevel.Description;
+                    newLevel.RootResource = oldLevel.RootResource;
+                }
+
+                // In version 57, we implemented minimum and maximum players which are 1 and 4 by default
+                if (oldVersion < 57)
+                {
+                    newLevel.MinPlayers = 1;
+                    newLevel.MaxPlayers = 4;
+                }
+
+                // In version 79, we started tracking the version in which the level was uploaded from
+                // Set all levels to LBP2 by default, since that's the version we've supported up until now.
+                if (oldVersion < 79)
+                {
+                    newLevel._GameVersion = (int)TokenGame.LittleBigPlanet2;
+                }
+
+                // In version 92, we started storing both user and story levels.
+                // Set all existing levels to user levels, since that's what has existed up until now.
+                if (oldVersion < 92)
+                {
+                    newLevel._Source = (int)GameLevelSource.User;
+                }
+
+                // In version 129, we split locations from an embedded object out to two fields
+                if (oldVersion < 129)
+                {
+                    newLevel.LocationX = (int)oldLevel.Location.X;
+                    newLevel.LocationY = (int)oldLevel.Location.Y;
+                }
+
+                // In version 134, we split GameComments into multiple tables.
+                // This migration creates GameLevelComments
+                if (oldVersion < 134)
+                {
+                    foreach (dynamic comment in oldLevel.LevelComments)
                     {
-                        SequentialId = (int)comment.SequentialId,
-                        Author = author,
-                        Level = newLevel,
-                        Content = comment.Content,
-                        Timestamp = comment.Timestamp,
-                    });
+                        GameUser? author = comment.Author != null
+                            ? migration.NewRealm.Find<GameUser>(comment.Author.UserId)
+                            : null;
+                        if (author == null)
+                        {
+                            Console.WriteLine(
+                                $"Skipping migration for level comment id {comment.SequentialId} due to missing author");
+                            continue;
+                        }
+
+                        migration.NewRealm.Add(new GameLevelComment
+                        {
+                            SequentialId = (int)comment.SequentialId,
+                            Author = author,
+                            Level = newLevel,
+                            Content = comment.Content,
+                            Timestamp = comment.Timestamp,
+                        });
+                    }
+                }
+
+                // In version 137 we started storing the date at which levels were picked instead of just that they are picked.
+                // Since this is new information, let's set this to the date of the last update. 
+                if (oldVersion < 137)
+                {
+                    if (oldLevel.TeamPicked)
+                        newLevel.DateTeamPicked = DateTimeOffset.FromUnixTimeMilliseconds(oldLevel.UpdateDate);
+                    else
+                        newLevel.DateTeamPicked = null;
+                }
+
+                // In version 138 we added support for Adventures in LBP3. Set their status to false by default.
+                if (oldVersion < 138)
+                {
+                    newLevel.IsAdventure = false;
+                }
+
+                // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
+                if (oldVersion < 140)
+                {
+                    newLevel.PublishDate = DateTimeOffset.FromUnixTimeMilliseconds(oldLevel.PublishDate);
+                    newLevel.UpdateDate = DateTimeOffset.FromUnixTimeMilliseconds(oldLevel.UpdateDate);
+                }
+
+                // In version 143, we added a "Modded" tag to levels
+                if (oldVersion < 143)
+                {
+                    if (!newLevel.RootResource.StartsWith('g'))
+                    {
+                        void TraverseDependenciesRecursively(GameAsset asset, Action<string, GameAsset?> callback)
+                        {
+                            callback(asset.AssetHash, asset);
+                            foreach (string internalAssetHash in migration.NewRealm.All<AssetDependencyRelation>().Where(d => d.Dependent == asset.AssetHash).AsEnumerable().Select(d => d.Dependency))
+                            {
+                                GameAsset? internalAsset = migration.NewRealm.Find<GameAsset>(internalAssetHash);
+            
+                                // Only run this if this is null, since the next recursion will trigger its own callback
+                                if(internalAsset == null)
+                                    callback(internalAssetHash, internalAsset);
+
+                                if(internalAsset != null)
+                                    TraverseDependenciesRecursively(internalAsset, callback);
+                            }
+                        }
+                        
+                        GameAsset? asset = migration.NewRealm.Find<GameAsset>(newLevel.RootResource);
+
+                        if (asset != null)
+                        {
+                            bool modded = false;
+                            TraverseDependenciesRecursively(asset, (s, gameAsset) =>
+                            {
+                                if (gameAsset != null && (gameAsset.AssetFlags & AssetFlags.Modded) != 0) 
+                                    modded = true;
+                            });
+                            newLevel.Modded = modded;
+                        }
+                    }
                 }
             }
 
-            // In version 137 we started storing the date at which levels were picked instead of just that they are picked.
-            // Since this is new information, let's set this to the date of the last update. 
-            if (oldVersion < 137)
-            {
-                if (oldLevel.TeamPicked)
-                    newLevel.DateTeamPicked = DateTimeOffset.FromUnixTimeMilliseconds(oldLevel.UpdateDate);
-                else
-                    newLevel.DateTeamPicked = null;
-            }
-            
-            // In version 138 we added support for Adventures in LBP3. Set their status to false by default.
-            if (oldVersion < 138)
-            {
-                newLevel.IsAdventure = false;
-            }
-            
-            // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
-            if (oldVersion < 140)
-            {
-                newLevel.PublishDate = DateTimeOffset.FromUnixTimeMilliseconds(oldLevel.PublishDate);
-                newLevel.UpdateDate = DateTimeOffset.FromUnixTimeMilliseconds(oldLevel.UpdateDate);
-            }
-        }
-
         // In version 22, tokens added expiry and types so just wipe them all
         if (oldVersion < 22) migration.NewRealm.RemoveAll<Token>();
-                
+
         // In version 35, tokens added platforms and games
         if (oldVersion < 35) migration.NewRealm.RemoveAll<Token>();
 
@@ -335,283 +383,322 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         IQueryable<Event>? newEvents = migration.NewRealm.All<Event>();
 
         List<Event> eventsToNuke = new();
-        for (int i = 0; i < newEvents.Count(); i++)
-        {
-            dynamic oldEvent = oldEvents.ElementAt(i);
-            Event newEvent = newEvents.ElementAt(i);
-
-            // In version 30, events were given timestamps
-            // Version 32 fixes events with broken timestamps
-            if (oldVersion < 30 || oldVersion < 32 && newEvent.Timestamp.ToUnixTimeMilliseconds() == 0)
-                newEvent.Timestamp = DateTimeOffset.Now;
-
-            // Converts events to use millisecond timestamps
-            if (oldVersion < 33 && newEvent.Timestamp.ToUnixTimeMilliseconds() < 1000000000000)
-                newEvent.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldEvent.Timestamp * 1000);
-
-            // fixup for dumb bad code not clearing score events when levels are deleted
-            if (oldVersion < 96 && newEvent.StoredDataType == EventDataType.Score)
+        // only run all this if old version < 140, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 140)
+            for (int i = 0; i < newEvents.Count(); i++)
             {
-                GameSubmittedScore? score = migration.NewRealm.All<GameSubmittedScore>().FirstOrDefault(s => s.ScoreId == newEvent.StoredObjectId);
-                if(score == null) eventsToNuke.Add(newEvent);
+                dynamic oldEvent = oldEvents.ElementAt(i);
+                Event newEvent = newEvents.ElementAt(i);
+
+                // In version 30, events were given timestamps
+                // Version 32 fixes events with broken timestamps
+                if (oldVersion < 30 || oldVersion < 32 && newEvent.Timestamp.ToUnixTimeMilliseconds() == 0)
+                    newEvent.Timestamp = DateTimeOffset.Now;
+
+                // Converts events to use millisecond timestamps
+                if (oldVersion < 33 && newEvent.Timestamp.ToUnixTimeMilliseconds() < 1000000000000)
+                    newEvent.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldEvent.Timestamp * 1000);
+
+                // fixup for dumb bad code not clearing score events when levels are deleted
+                if (oldVersion < 96 && newEvent.StoredDataType == EventDataType.Score)
+                {
+                    GameSubmittedScore? score = migration.NewRealm.All<GameSubmittedScore>()
+                        .FirstOrDefault(s => s.ScoreId == newEvent.StoredObjectId);
+                    if (score == null) eventsToNuke.Add(newEvent);
+                }
+
+                // In version 131, we removed the LevelPlay event
+                if (oldVersion < 131 && newEvent.EventType == EventType.LevelPlay)
+                    eventsToNuke.Add(newEvent);
+
+                // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
+                if (oldVersion < 140)
+                    newEvent.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldEvent.Timestamp);
             }
-            
-            // In version 131, we removed the LevelPlay event
-            if (oldVersion < 131 && newEvent.EventType == EventType.LevelPlay)
-                eventsToNuke.Add(newEvent);
-            
-            // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
-            if (oldVersion < 140)
-                newEvent.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldEvent.Timestamp);
-        }
-        
+
         // realm won't let you use an IEnumerable in RemoveRange. too bad!
         foreach (Event eventToNuke in eventsToNuke)
         {
             migration.NewRealm.Remove(eventToNuke);
         }
-        
+
         // In version 126, we started tracking token IP; there's no way for us to acquire this after the fact, so let's just clear all the tokens
-        if (oldVersion < 126) 
+        if (oldVersion < 126)
             migration.NewRealm.RemoveAll<Token>();
-        
+
         // IQueryable<dynamic>? oldTokens = migration.OldRealm.DynamicApi.All("Token");
         IQueryable<Token>? newTokens = migration.NewRealm.All<Token>();
 
-        for (int i = 0; i < newTokens.Count(); i++)
-        {
-            // dynamic oldToken = oldTokens.ElementAt(i);
-            Token newToken = newTokens.ElementAt(i);
+        // only run all this if old version < 36, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 36)
+            for (int i = 0; i < newTokens.Count(); i++)
+            {
+                // dynamic oldToken = oldTokens.ElementAt(i);
+                Token newToken = newTokens.ElementAt(i);
 
-            if (oldVersion < 36) newToken.LoginDate = DateTimeOffset.FromUnixTimeMilliseconds(timestampMilliseconds);
-        }
-        
+                if (oldVersion < 36)
+                    newToken.LoginDate = DateTimeOffset.FromUnixTimeMilliseconds(timestampMilliseconds);
+            }
+
         IQueryable<dynamic>? oldPhotos = migration.OldRealm.DynamicApi.All("GamePhoto");
         IQueryable<GamePhoto>? newPhotos = migration.NewRealm.All<GamePhoto>();
 
-        for (int i = 0; i < oldPhotos.Count(); i++)
-        {
-            dynamic oldPhoto = oldPhotos.ElementAt(i);
-            GamePhoto newPhoto = newPhotos.ElementAt(i);
-
-            // In version 52, the timestamp on photos were corrected
-            if (oldVersion < 52)
+        // only run all this if old version < 133, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 133)
+            for (int i = 0; i < oldPhotos.Count(); i++)
             {
-                newPhoto.TakenAt = DateTimeOffset.FromUnixTimeSeconds(oldPhoto.TakenAt.ToUnixTimeMilliseconds());
-            }
+                dynamic oldPhoto = oldPhotos.ElementAt(i);
+                GamePhoto newPhoto = newPhotos.ElementAt(i);
 
-            if (oldVersion < 110)
-            {
-                newPhoto.LargeAsset = migration.NewRealm.Find<GameAsset>(oldPhoto.LargeHash.StartsWith("psp/") ? oldPhoto.LargeHash.Substring(4) : oldPhoto.LargeHash);
-                newPhoto.MediumAsset = migration.NewRealm.Find<GameAsset>(oldPhoto.MediumHash.StartsWith("psp/") ? oldPhoto.MediumHash.Substring(4) : oldPhoto.MediumHash);
-                newPhoto.SmallAsset = migration.NewRealm.Find<GameAsset>(oldPhoto.SmallHash.StartsWith("psp/") ? oldPhoto.SmallHash.Substring(4) : oldPhoto.SmallHash);
-            }
-
-            // In version 133, we removed GamePhotoSubject from the schema entirely, and instead we put 4 'unrolled' sets of fields in the GamePhoto.
-            // This makes things chaotic code-wise, but is significantly more compatible with Postgres.
-            if (oldVersion < 133)
-            {
-                List<GamePhotoSubject> oldSubjects = new(oldPhoto.Subjects.Count);
-                foreach(dynamic subject in oldPhoto.Subjects)
+                // In version 52, the timestamp on photos were corrected
+                if (oldVersion < 52)
                 {
-                    List<float> bounds = new(4);
-                    foreach (float bound in subject.Bounds) bounds.Add(bound);
-
-                    GameUser? user = subject.User != null ? migration.NewRealm.Find<GameUser>(subject.User.UserId) : null;
-                    oldSubjects.Add(new GamePhotoSubject(user, subject.DisplayName, bounds));
+                    newPhoto.TakenAt = DateTimeOffset.FromUnixTimeSeconds(oldPhoto.TakenAt.ToUnixTimeMilliseconds());
                 }
 
-                newPhoto.Subjects = oldSubjects;
+                if (oldVersion < 110)
+                {
+                    newPhoto.LargeAsset = migration.NewRealm.Find<GameAsset>(oldPhoto.LargeHash.StartsWith("psp/")
+                        ? oldPhoto.LargeHash.Substring(4)
+                        : oldPhoto.LargeHash);
+                    newPhoto.MediumAsset = migration.NewRealm.Find<GameAsset>(oldPhoto.MediumHash.StartsWith("psp/")
+                        ? oldPhoto.MediumHash.Substring(4)
+                        : oldPhoto.MediumHash);
+                    newPhoto.SmallAsset = migration.NewRealm.Find<GameAsset>(oldPhoto.SmallHash.StartsWith("psp/")
+                        ? oldPhoto.SmallHash.Substring(4)
+                        : oldPhoto.SmallHash);
+                }
+
+                // In version 133, we removed GamePhotoSubject from the schema entirely, and instead we put 4 'unrolled' sets of fields in the GamePhoto.
+                // This makes things chaotic code-wise, but is significantly more compatible with Postgres.
+                if (oldVersion < 133)
+                {
+                    List<GamePhotoSubject> oldSubjects = new(oldPhoto.Subjects.Count);
+                    foreach (dynamic subject in oldPhoto.Subjects)
+                    {
+                        List<float> bounds = new(4);
+                        foreach (float bound in subject.Bounds) bounds.Add(bound);
+
+                        GameUser? user = subject.User != null
+                            ? migration.NewRealm.Find<GameUser>(subject.User.UserId)
+                            : null;
+                        oldSubjects.Add(new GamePhotoSubject(user, subject.DisplayName, bounds));
+                    }
+
+                    newPhoto.Subjects = oldSubjects;
+                }
             }
-        }
-        
+
         IQueryable<dynamic>? oldAssets = migration.OldRealm.DynamicApi.All("GameAsset");
         IQueryable<GameAsset>? newAssets = migration.NewRealm.All<GameAsset>();
 
-        for (int i = 0; i < newAssets.Count(); i++)
-        {
-            dynamic oldAsset = oldAssets.ElementAt(i);
-            GameAsset newAsset = newAssets.ElementAt(i);
-            
-            if (oldVersion < 88)
+        // only run all this if old version < 136, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 136)
+            for (int i = 0; i < newAssets.Count(); i++)
             {
-                // We don't have any more advanced heuristics here,
-                // but TGA files are the only asset currently affected by the tracking of `IsPSP`,
-                // and PSP is the only game to upload TGA files.
-                newAsset.IsPSP = newAsset.AssetType == GameAssetType.Tga;
-            }
+                dynamic oldAsset = oldAssets.ElementAt(i);
+                GameAsset newAsset = newAssets.ElementAt(i);
 
-            // In version 128 assets were moved from a list on the asset to a separate "relations" table
-            if (oldVersion < 128)
-            {
-                IList<string> dependencies = oldAsset.Dependencies;
-                
-                foreach (string dependency in dependencies)
+                if (oldVersion < 88)
                 {
-                    migration.NewRealm.Add(new AssetDependencyRelation
+                    // We don't have any more advanced heuristics here,
+                    // but TGA files are the only asset currently affected by the tracking of `IsPSP`,
+                    // and PSP is the only game to upload TGA files.
+                    newAsset.IsPSP = newAsset.AssetType == GameAssetType.Tga;
+                }
+
+                // In version 128 assets were moved from a list on the asset to a separate "relations" table
+                if (oldVersion < 128)
+                {
+                    IList<string> dependencies = oldAsset.Dependencies;
+
+                    foreach (string dependency in dependencies)
                     {
-                        Dependent = oldAsset.AssetHash,
-                        Dependency = dependency,
-                    });
+                        migration.NewRealm.Add(new AssetDependencyRelation
+                        {
+                            Dependent = oldAsset.AssetHash,
+                            Dependency = dependency,
+                        });
+                    }
+                }
+
+                // In version 136, we started tracking asset types differently, so we need to convert to the new system
+                if (oldVersion < 136)
+                {
+                    newAsset.AssetType = (int)oldAsset._AssetType switch
+                    {
+                        -1 => GameAssetType.Unknown,
+                        0 => GameAssetType.Level,
+                        1 => GameAssetType.Plan,
+                        2 => GameAssetType.Texture,
+                        3 => GameAssetType.Jpeg,
+                        4 => GameAssetType.Png,
+                        5 => GameAssetType.GfxMaterial,
+                        6 => GameAssetType.Mesh,
+                        7 => GameAssetType.GameDataTexture,
+                        8 => GameAssetType.Palette,
+                        9 => GameAssetType.Script,
+                        10 => GameAssetType.ThingRecording,
+                        11 => GameAssetType.VoiceRecording,
+                        12 => GameAssetType.Painting,
+                        13 => GameAssetType.Tga,
+                        14 => GameAssetType.SyncedProfile,
+                        15 => GameAssetType.Mip,
+                        16 => GameAssetType.GriefSongState,
+                        17 => GameAssetType.Material,
+                        18 => GameAssetType.SoftPhysicsSettings,
+                        19 => GameAssetType.Bevel,
+                        20 => GameAssetType.StreamingLevelChunk,
+                        21 => GameAssetType.Animation,
+                        _ => throw new Exception("Invalid asset type " + oldAsset._AssetType),
+                    };
+                    newAsset.AssetFormat = (int)oldAsset._AssetType switch
+                    {
+                        -1 => GameAssetFormat.Unknown,
+                        0 => GameAssetFormat.Binary,
+                        1 => GameAssetFormat.Binary,
+                        2 => GameAssetFormat.CompressedTexture,
+                        3 => GameAssetFormat.Unknown,
+                        4 => GameAssetFormat.Unknown,
+                        5 => GameAssetFormat.Binary,
+                        6 => GameAssetFormat.Binary,
+                        7 => GameAssetFormat.CompressedTexture,
+                        8 => GameAssetFormat.Binary,
+                        9 => GameAssetFormat.Binary,
+                        10 => GameAssetFormat.Binary,
+                        11 => GameAssetFormat.Binary,
+                        12 => GameAssetFormat.Binary,
+                        13 => GameAssetFormat.Unknown,
+                        14 => GameAssetFormat.Binary,
+                        15 => GameAssetFormat.Unknown,
+                        16 => GameAssetFormat.Unknown,
+                        17 => GameAssetFormat.Binary,
+                        18 => GameAssetFormat.Text,
+                        19 => GameAssetFormat.Binary,
+                        20 => GameAssetFormat.Binary,
+                        21 => GameAssetFormat.Binary,
+                        _ => throw new Exception("Invalid asset type " + oldAsset._AssetType),
+                    };
                 }
             }
-            
-            // In version 136, we started tracking asset types differently, so we need to convert to the new system
-            if (oldVersion < 136)
-            {
-                newAsset.AssetType = (int)oldAsset._AssetType switch
-                {
-                    -1 => GameAssetType.Unknown,
-                    0 => GameAssetType.Level,
-                    1 => GameAssetType.Plan,
-                    2 => GameAssetType.Texture,
-                    3 => GameAssetType.Jpeg,
-                    4 => GameAssetType.Png,
-                    5 => GameAssetType.GfxMaterial,
-                    6 => GameAssetType.Mesh,
-                    7 => GameAssetType.GameDataTexture,
-                    8 => GameAssetType.Palette,
-                    9 => GameAssetType.Script,
-                    10 => GameAssetType.ThingRecording,
-                    11 => GameAssetType.VoiceRecording,
-                    12 => GameAssetType.Painting,
-                    13 => GameAssetType.Tga,
-                    14 => GameAssetType.SyncedProfile,
-                    15 => GameAssetType.Mip,
-                    16 => GameAssetType.GriefSongState,
-                    17 => GameAssetType.Material,
-                    18 => GameAssetType.SoftPhysicsSettings,
-                    19 => GameAssetType.Bevel,
-                    20 => GameAssetType.StreamingLevelChunk,
-                    21 => GameAssetType.Animation,
-                    _ => throw new Exception("Invalid asset type " + oldAsset._AssetType),
-                };
-                newAsset.AssetFormat = (int)oldAsset._AssetType switch
-                {
-                    -1 => GameAssetFormat.Unknown,
-                    0 => GameAssetFormat.Binary,
-                    1 => GameAssetFormat.Binary,
-                    2 => GameAssetFormat.CompressedTexture,
-                    3 => GameAssetFormat.Unknown,
-                    4 => GameAssetFormat.Unknown,
-                    5 => GameAssetFormat.Binary,
-                    6 => GameAssetFormat.Binary,
-                    7 => GameAssetFormat.CompressedTexture,
-                    8 => GameAssetFormat.Binary,
-                    9 => GameAssetFormat.Binary,
-                    10 => GameAssetFormat.Binary,
-                    11 => GameAssetFormat.Binary,
-                    12 => GameAssetFormat.Binary,
-                    13 => GameAssetFormat.Unknown,
-                    14 => GameAssetFormat.Binary,
-                    15 => GameAssetFormat.Unknown,
-                    16 => GameAssetFormat.Unknown,
-                    17 => GameAssetFormat.Binary,
-                    18 => GameAssetFormat.Text,
-                    19 => GameAssetFormat.Binary,
-                    20 => GameAssetFormat.Binary,
-                    21 => GameAssetFormat.Binary,
-                    _ => throw new Exception("Invalid asset type " + oldAsset._AssetType),
-                };
-            }
-        }
-        
+
         // Remove all scores with a null level, as in version 92 we started tracking story leaderboards differently
-        if (oldVersion < 92) migration.NewRealm.RemoveRange(migration.NewRealm.All<GameSubmittedScore>().Where(s => s.Level == null));
-        
+        if (oldVersion < 92)
+            migration.NewRealm.RemoveRange(migration.NewRealm.All<GameSubmittedScore>().Where(s => s.Level == null));
+
+        // fuck realm.
+        if (oldVersion < 142)
+            foreach (GameSubmittedScore score in migration.NewRealm.All<GameSubmittedScore>().AsEnumerable()
+                         .Where(s => !s.Players.Any()).ToList())
+                migration.NewRealm.Remove(score);
+
         IQueryable<dynamic>? oldScores = migration.OldRealm.DynamicApi.All("GameSubmittedScore");
         IQueryable<GameSubmittedScore>? newScores = migration.NewRealm.All<GameSubmittedScore>();
 
-        for (int i = 0; i < newScores.Count(); i++)
-        {
-            dynamic oldScore = oldScores.ElementAt(i);
-            GameSubmittedScore newScore = newScores.ElementAt(i);
-
-            if (oldVersion < 92)
+        // only run all this if old version < 104, since thats the last time scores were changed (update this accordingly)
+        if (oldVersion < 104)
+            for (int i = 0; i < newScores.Count(); i++)
             {
-                newScore.Game = newScore.Level.GameVersion;
-            }
+                dynamic oldScore = oldScores.ElementAt(i);
+                GameSubmittedScore newScore = newScores.ElementAt(i);
 
-            // In version 104 we started tracking the platform
-            if (oldVersion < 104)
-            {
-                // Determine the most reasonable platform for the score's game
-                TokenPlatform platform = newScore.Game switch
+                if (oldVersion < 92)
                 {
-                    TokenGame.LittleBigPlanet1 => TokenPlatform.PS3,
-                    TokenGame.LittleBigPlanet2 => TokenPlatform.PS3,
-                    TokenGame.LittleBigPlanet3 => TokenPlatform.PS3,
-                    TokenGame.LittleBigPlanetVita => TokenPlatform.Vita,
-                    TokenGame.LittleBigPlanetPSP => TokenPlatform.PSP,
-                    TokenGame.BetaBuild => TokenPlatform.RPCS3,
-                    TokenGame.Website => throw new InvalidOperationException($"what? score id {newScore.ScoreId} by {newScore.Players[0].Username} is fucked"),
-                    _ => throw new ArgumentOutOfRangeException(),
-                };
+                    newScore.Game = newScore.Level.GameVersion;
+                }
 
-                newScore.Platform = platform;
+                // In version 104 we started tracking the platform
+                if (oldVersion < 104)
+                {
+                    // Determine the most reasonable platform for the score's game
+                    TokenPlatform platform = newScore.Game switch
+                    {
+                        TokenGame.LittleBigPlanet1 => TokenPlatform.PS3,
+                        TokenGame.LittleBigPlanet2 => TokenPlatform.PS3,
+                        TokenGame.LittleBigPlanet3 => TokenPlatform.PS3,
+                        TokenGame.LittleBigPlanetVita => TokenPlatform.Vita,
+                        TokenGame.LittleBigPlanetPSP => TokenPlatform.PSP,
+                        TokenGame.BetaBuild => TokenPlatform.RPCS3,
+                        TokenGame.Website => throw new InvalidOperationException(
+                            $"what? score id {newScore.ScoreId} by {newScore.Players[0].Username} is fucked"),
+                        _ => throw new ArgumentOutOfRangeException(),
+                    };
+
+                    newScore.Platform = platform;
+                }
             }
-        }
-        
+
         IQueryable<dynamic>? oldPlayLevelRelations = migration.OldRealm.DynamicApi.All("PlayLevelRelation");
         IQueryable<PlayLevelRelation>? newPlayLevelRelations = migration.NewRealm.All<PlayLevelRelation>();
 
-        for (int i = 0; i < newPlayLevelRelations.Count(); i++)
-        {
-            dynamic oldPlayLevelRelation = oldPlayLevelRelations.ElementAt(i);
-            PlayLevelRelation newPlayLevelRelation = newPlayLevelRelations.ElementAt(i);
-
-            //In version 93, we added a count to PlayLevelRelation
-            if (oldVersion < 93)
+        // only run all this if old version < 140, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 140)
+            for (int i = 0; i < newPlayLevelRelations.Count(); i++)
             {
-                newPlayLevelRelation.Count = 1;
+                dynamic oldPlayLevelRelation = oldPlayLevelRelations.ElementAt(i);
+                PlayLevelRelation newPlayLevelRelation = newPlayLevelRelations.ElementAt(i);
+
+                //In version 93, we added a count to PlayLevelRelation
+                if (oldVersion < 93)
+                {
+                    newPlayLevelRelation.Count = 1;
+                }
+
+                // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
+                if (oldVersion < 140)
+                    newPlayLevelRelation.Timestamp =
+                        DateTimeOffset.FromUnixTimeMilliseconds(oldPlayLevelRelation.Timestamp);
             }
-            
-            // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
-            if (oldVersion < 140)
-                newPlayLevelRelation.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldPlayLevelRelation.Timestamp);
-        }
 
         // We weren't deleting reviews when a level was deleted. Version 139 fixes this.
         if (oldVersion < 139)
             migration.NewRealm.RemoveRange(migration.NewRealm.All<GameReview>().Where(r => r.Level == null));
-        
+
         IQueryable<dynamic>? oldLevelComments = migration.OldRealm.DynamicApi.All("GameLevelComment");
         IQueryable<GameLevelComment>? newLevelComments = migration.NewRealm.All<GameLevelComment>();
 
-        for (int i = 0; i < newLevelComments.Count(); i++)
-        {
-            dynamic oldLevelComment = oldLevelComments.ElementAt(i);
-            GameLevelComment newLevelComment = newLevelComments.ElementAt(i);
+        // only run all this if old version < 140, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 140)
+            for (int i = 0; i < newLevelComments.Count(); i++)
+            {
+                dynamic oldLevelComment = oldLevelComments.ElementAt(i);
+                GameLevelComment newLevelComment = newLevelComments.ElementAt(i);
 
-            // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
-            if (oldVersion < 140)
-                newLevelComment.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldLevelComment.Timestamp);
-        }
-        
+                // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
+                if (oldVersion < 140)
+                    newLevelComment.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldLevelComment.Timestamp);
+            }
+
         IQueryable<dynamic>? oldProfileComments = migration.OldRealm.DynamicApi.All("GameProfileComment");
         IQueryable<GameProfileComment>? newProfileComments = migration.NewRealm.All<GameProfileComment>();
 
-        for (int i = 0; i < newProfileComments.Count(); i++)
-        {
-            dynamic oldProfileComment = oldProfileComments.ElementAt(i);
-            GameProfileComment newProfileComment = newProfileComments.ElementAt(i);
+        // only run all this if old version < 140, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 140)
+            for (int i = 0; i < newProfileComments.Count(); i++)
+            {
+                dynamic oldProfileComment = oldProfileComments.ElementAt(i);
+                GameProfileComment newProfileComment = newProfileComments.ElementAt(i);
 
-            // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
-            if (oldVersion < 140)
-                newProfileComment.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldProfileComment.Timestamp);
-        }
-        
+                // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
+                if (oldVersion < 140)
+                    newProfileComment.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldProfileComment.Timestamp);
+            }
+
         IQueryable<dynamic>? oldUniquePlayLevelRelations = migration.OldRealm.DynamicApi.All("UniquePlayLevelRelation");
-        IQueryable<UniquePlayLevelRelation>? newUniquePlayLevelRelations = migration.NewRealm.All<UniquePlayLevelRelation>();
+        IQueryable<UniquePlayLevelRelation>? newUniquePlayLevelRelations =
+            migration.NewRealm.All<UniquePlayLevelRelation>();
 
-        for (int i = 0; i < newUniquePlayLevelRelations.Count(); i++)
-        {
-            dynamic oldUniquePlayLevelRelation = oldUniquePlayLevelRelations.ElementAt(i);
-            UniquePlayLevelRelation newUniquePlayLevelRelation = newUniquePlayLevelRelations.ElementAt(i);
-            
-            // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
-            if (oldVersion < 140)
-                newUniquePlayLevelRelation.Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(oldUniquePlayLevelRelation.Timestamp);
-        }
+        // only run all this if old version < 140, since thats the last time these were changed (update this accordingly)
+        if (oldVersion < 140)
+            for (int i = 0; i < newUniquePlayLevelRelations.Count(); i++)
+            {
+                dynamic oldUniquePlayLevelRelation = oldUniquePlayLevelRelations.ElementAt(i);
+                UniquePlayLevelRelation newUniquePlayLevelRelation = newUniquePlayLevelRelations.ElementAt(i);
+
+                // In version 140, we migrated from unix milliseconds timestamps to DateTimeOffsets
+                if (oldVersion < 140)
+                    newUniquePlayLevelRelation.Timestamp =
+                        DateTimeOffset.FromUnixTimeMilliseconds(oldUniquePlayLevelRelation.Timestamp);
+            }
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiUpdateUserRequest.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiUpdateUserRequest.cs
@@ -16,6 +16,8 @@ public class ApiUpdateUserRequest
     
     public string? EmailAddress { get; set; }
     
+    public bool? ShowModdedContent { get; set; }
+    
     public Visibility? LevelVisibility { get; set; }
     public Visibility? ProfileVisibility { get; set; }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiStatisticsResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/ApiStatisticsResponse.cs
@@ -4,6 +4,7 @@ namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response;
 public class ApiStatisticsResponse : IApiResponse
 {
     public required int TotalLevels { get; set; }
+    public required int ModdedLevels { get; set; }
     public required int TotalUsers { get; set; }
     public required int ActiveUsers { get; set; }
     public required int TotalPhotos { get; set; }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiAssetFlags.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiAssetFlags.cs
@@ -1,12 +1,11 @@
 using Refresh.GameServer.Types.Assets;
 
-namespace Refresh.GameServer.Configuration;
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Response.Data;
 
-public class ConfigAssetFlags
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiAssetFlags
 {
-    public ConfigAssetFlags() {}
-    
-    public ConfigAssetFlags(AssetFlags flags)
+    public ApiAssetFlags(AssetFlags flags)
     {
         this.Dangerous = (flags & AssetFlags.Dangerous) != 0;
         this.Media = (flags & AssetFlags.Media) != 0;
@@ -27,11 +26,4 @@ public class ConfigAssetFlags
     /// This asset will only ever be created by mods.
     /// </summary>
     public bool Modded { get; set; }
-    
-    public AssetFlags ToAssetFlags()
-    {
-        return (this.Dangerous ? AssetFlags.Dangerous : AssetFlags.None) |
-               (this.Modded ? AssetFlags.Modded : AssetFlags.None) |
-               (this.Media ? AssetFlags.Media : AssetFlags.None);
-    }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiGameAssetResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Data/ApiGameAssetResponse.cs
@@ -13,6 +13,7 @@ public class ApiGameAssetResponse : IApiResponse, IDataConvertableFrom<ApiGameAs
     public required GameAssetType AssetType { get; set; }
     public required IEnumerable<string> Dependencies { get; set; }
     public required IEnumerable<string> Dependents { get; set; }
+    public required ApiAssetFlags AssetFlags { get; set; }
     
     public static ApiGameAssetResponse? FromOld(GameAsset? old, DataContext dataContext)
     {
@@ -26,6 +27,7 @@ public class ApiGameAssetResponse : IApiResponse, IDataConvertableFrom<ApiGameAs
             AssetType = old.AssetType,
             Dependencies = dataContext.Database.GetAssetDependencies(old),
             Dependents = dataContext.Database.GetAssetDependents(old),
+            AssetFlags = new ApiAssetFlags(old.AssetFlags),
         };
     }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Levels/ApiGameLevelResponse.cs
@@ -52,6 +52,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
     public required bool IsCopyable { get; set; }
     public required float Score { get; set; }
     public required IEnumerable<Tag> Tags { get; set; }
+    public required bool Modded { get; set; }
 
     public static ApiGameLevelResponse? FromOld(GameLevel? level, DataContext dataContext)
     {
@@ -92,6 +93,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
             LevelComments = dataContext.Database.GetTotalCommentsForLevel(level),
             Reviews = dataContext.Database.GetTotalReviewsForLevel(level),
             Tags = dataContext.Database.GetTagsForLevel(level).Select(t => t.Tag),
+            Modded = level.Modded,
         };
     }
     

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
@@ -37,6 +37,8 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     public required bool ShouldResetPassword { get; set; }
     public required bool AllowIpAuthentication { get; set; }
     
+    public required bool ShowModdedContent { get; set; }
+    
     public required Visibility LevelVisibility { get; set; }
     public required Visibility ProfileVisibility { get; set; }
     
@@ -74,6 +76,7 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
             ActiveRoom = ApiGameRoomResponse.FromOld(dataContext.Match.RoomAccessor.GetRoomByUser(user), dataContext),
             LevelVisibility = user.LevelVisibility,
             ProfileVisibility = user.ProfileVisibility,
+            ShowModdedContent = user.ShowModdedContent,
         };
     }
 

--- a/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/InstanceApiEndpoints.cs
@@ -27,6 +27,7 @@ public class InstanceApiEndpoints : EndpointGroup
         return new ApiStatisticsResponse
         {
             TotalLevels = database.GetTotalLevelCount(),
+            ModdedLevels = database.GetModdedLevelCount(),
             TotalUsers = database.GetTotalUserCount(),
             ActiveUsers = database.GetActiveUserCount(),
             TotalPhotos = database.GetTotalPhotoCount(),

--- a/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/PublishEndpoints.cs
@@ -172,6 +172,12 @@ public class PublishEndpoints : EndpointGroup
         level.Publisher = dataContext.User;
 
         dataContext.Database.AddLevel(level);
+
+        // Update the modded status of the level
+        // NOTE: this wont do anything if the slot is uploaded before the level resource,
+        //       so we also do this same operation inside of ResourceEndpoints.UploadAsset to catch that case aswell
+        dataContext.Database.UpdateLevelModdedStatus(level);
+        
         dataContext.Database.CreateLevelUploadEvent(dataContext.User, level);
 
         context.Logger.LogInfo(BunkumCategory.UserContent, "User {0} (id: {1}) uploaded level id {2}", user.Username, user.UserId, level.LevelId);

--- a/Refresh.GameServer/Endpoints/Game/ResourceEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ResourceEndpoints.cs
@@ -14,6 +14,7 @@ using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Importing;
 using Refresh.GameServer.Time;
 using Refresh.GameServer.Types.Assets;
+using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Lists;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -95,6 +96,11 @@ public class ResourceEndpoints : EndpointGroup
         database.AddAssetToDatabase(gameAsset);
         
         database.IncrementUserFilesizeQuota(user, body.Length);
+
+        GameLevel? level = database.GetLevelByRootResource(hash);
+        // If there is a level with this root resource, update the modded status of the level
+        // This is catching the case where the level resource was uploaded after the slot was published.
+        if (level != null) database.UpdateLevelModdedStatus(level);
         
         context.Logger.LogInfo(BunkumCategory.UserContent, $"{user} uploaded a {gameAsset.AssetType} ({body.Length / 1024f:F1} KB)");
         return OK;

--- a/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
+++ b/Refresh.GameServer/Extensions/LevelEnumerableExtensions.cs
@@ -38,6 +38,9 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.ExcludeMyLevels && user != null)
             levels = levels.Where(l => l.Publisher != user);
 
+        if (user is { ShowModdedContent: false })
+            levels = levels.Where(l => !l.Modded);
+
         // Don't allow beta builds to use this filtering option
         // If the client specifies this option then it will filter out *all* levels.
         if (levelFilterSettings.GameVersion != TokenGame.BetaBuild)
@@ -81,6 +84,9 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.ExcludeMyLevels && user != null)
             levels = levels.Where(l => l.Publisher != user);
 
+        if (user is { ShowModdedContent: false })
+            levels = levels.Where(l => !l.Modded);
+        
         // Don't allow beta builds to use this filtering option
         // If the client specifies this option then it will filter out *all* levels.
         if (levelFilterSettings.GameVersion != TokenGame.BetaBuild)

--- a/Refresh.GameServer/Importing/Importer.cs
+++ b/Refresh.GameServer/Importing/Importer.cs
@@ -185,6 +185,10 @@ public abstract class Importer
     [Pure]
     protected (GameAssetType, GameAssetFormat) DetermineAssetType(Span<byte> data, TokenPlatform? tokenPlatform)
     {
+        // MATT is a special format constructed by the game when making a grief report. It does not follow standard serialization rules, so it's not caught by the below lines
+        if (MatchesMagic(data, "MATT"u8)) 
+            return (GameAssetType.GriefSongState, GameAssetFormat.Unknown);
+        
         GameAssetType? lbpAssetType = GameAssetTypeExtensions.LbpMagicToGameAssetType(data.Slice(0, 3));
         
         if (lbpAssetType != null)
@@ -197,10 +201,6 @@ public abstract class Importer
             this.Warn($"Unknown asset format for game asset [0x{Convert.ToHexString(data[..4])}] [str: {Encoding.ASCII.GetString(data[..4])}]");
             return (GameAssetType.Unknown, GameAssetFormat.Unknown);
         }
-        
-        // MATT is a special format constructed by the game when making a grief report. It does not follow standard serialization rules, so it's not caught by the above lines
-        if (MatchesMagic(data, "MATT"u8)) 
-            return (GameAssetType.GriefSongState, GameAssetFormat.Unknown);
         
         // Traditional files
         // Good reference for magics: https://en.wikipedia.org/wiki/List_of_file_signatures

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -23,6 +23,7 @@ using Refresh.GameServer.Services;
 using Refresh.GameServer.Storage;
 using Refresh.GameServer.Time;
 using Refresh.GameServer.Types.Data;
+using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.Levels.Categories;
 using Refresh.GameServer.Types.Roles;
 using Refresh.GameServer.Types.UserData;
@@ -197,10 +198,8 @@ public class RefreshGameServer : RefreshServer
 
     public void ImportAssets(bool force = false)
     {
-        using GameDatabaseContext context = this.GetContext();
-        
         AssetImporter importer = new();
-        importer.ImportFromDataStore(context, this._dataStore);
+        importer.ImportFromDataStore(this._databaseProvider, this._dataStore);
     }
 
     public void ImportImages()
@@ -211,6 +210,27 @@ public class RefreshGameServer : RefreshServer
         importer.ImportFromDataStore(context, this._dataStore);
     }
 
+    public void FlagModdedLevels()
+    {
+        using GameDatabaseContext context = this.GetContext();
+
+        // Iterate over all levels
+        GameLevel[] allLevels = context.GetAllUserLevels().ToArray();
+        Dictionary<GameLevel, bool> statuses = new(allLevels.Length);
+        int i = 0;
+        foreach (GameLevel level in allLevels)
+        {
+            bool modded = context.GetLevelModdedStatus(level);
+            
+            statuses[level] = modded;
+
+            i++;
+            this.Logger.LogInfo(RefreshContext.Worker, "[{3}/{4}] Marked level {0} ({1}) as {2}", level.Title, level.LevelId, modded ? "modded" : "vanilla", i, allLevels.Length);
+        }
+        
+        context.SetLevelModdedStatuses(statuses);
+    }
+    
     public void CreateUser(string username, string emailAddress)
     {
         using GameDatabaseContext context = this.GetContext();

--- a/Refresh.GameServer/Services/CommandService.cs
+++ b/Refresh.GameServer/Services/CommandService.cs
@@ -115,6 +115,16 @@ public class CommandService : EndpointService
                 database.SetUnescapeXmlSequences(user, false);
                 break;
             }
+            case "showmoddedcontent":
+            {
+                database.SetShowModdedContent(user, true);
+                break;
+            }
+            case "hidemoddedcontent":
+            {
+                database.SetShowModdedContent(user, false);
+                break;
+            }
             case "play":
             {
                 if (CommonPatterns.Sha1Regex().IsMatch(command.Arguments))

--- a/Refresh.GameServer/Types/Levels/GameLevel.cs
+++ b/Refresh.GameServer/Types/Levels/GameLevel.cs
@@ -49,6 +49,11 @@ public partial class GameLevel : IRealmObject, ISequentialId
     public DateTimeOffset? DateTeamPicked { get; set; }
     
     /// <summary>
+    /// Whether any asset in the dependency tree is considered "modded"
+    /// </summary>
+    public bool Modded { get; set; }
+    
+    /// <summary>
     /// The GUID of the background, this seems to only be used by LBP PSP
     /// </summary>
     public string? BackgroundGuid { get; set; }

--- a/Refresh.GameServer/Types/UserData/GameUser.cs
+++ b/Refresh.GameServer/Types/UserData/GameUser.cs
@@ -116,6 +116,11 @@ public partial class GameUser : IRealmObject, IRateLimitUser
         set => this._Role = (byte)value;
     }
 
+    /// <summary>
+    /// Whether or not modded content should be shown in level listings
+    /// </summary>
+    public bool ShowModdedContent { get; set; } = true;
+
     // ReSharper disable once InconsistentNaming
     internal byte _Role { get; set; }
 


### PR DESCRIPTION
Adds a flag to all levels to state whether they contain modded content of any kind. Also adds a user setting + command to hide all modded content from the game, if the user does not wish to see any modded content in level results.

This PR also fixes MATT asset uploads and optimizes our realm migrations.