### PR TITLE
Clarify regstration queue message

### DIFF
--- a/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/AuthenticationApiEndpoints.cs
@@ -269,9 +269,11 @@ public class AuthenticationApiEndpoints : EndpointGroup
         {
             database.AddRegistrationToQueue(body.Username, body.EmailAddress, passwordBcrypt);
             return new ApiAuthenticationError(
-                "Your account has been put into the registration queue, but it is not yet activated. " +
-                "To complete registration, patch your games to our servers and start playing within the next hour and your new account will be activated. " +
-                "You will be unable to sign in until you are patched and playing. For more instructions on patching, please visit https://docs.littlebigrefresh.com", true);
+                "Your account has been registered, but it is not yet activated. " +
+                "To complete registration, patch your games to our servers and access online features in-game within an hour of making your registration, and your new account will be activated. " +
+                "You may be unable to access online features until you beat the first chapter of the game's story mode, so please complete that if you haven't. " +
+                "If you are unable to activate your account within an hour, your registration is cancelled and you will have to register again. " +
+                "You will be unable to sign in on the website until your account is fully activated. For more instructions on patching, please visit https://docs.littlebigrefresh.com", true);
         }
 
         GameUser user = database.CreateUser(body.Username, body.EmailAddress, true);


### PR DESCRIPTION
People aren't grasping the wording we currently have, there are many wrong interpretations of the current wording, so I've tried to clear up some of the common misunderstandings people have.
- The phrasing of a "queue" implies to some the need to wait. Lets not use that wording when it comes to describing the system. Lets just call it "account activation", since to a layperson, the extra details about how "its not *actually* an account yet" aren't necessary to know. All they need to know is that they cannot log in on the site until their account is activated.
- We weren't explicit enough that you need to access online features, not just "start playing", which doesn't *always* work, since the game won't autoconnect some of the time.
- Some people misunderstood "within the next hour", so that phrasing has been changed to "within an hour of making your registration".
- People often questioned what happens after the hour, so clarification has been added.
- A very frequent question is "why are the buttons greyed out", so I added a blurb explaining to complete the first chapter of the story mode, which is required to access the online features on all the LBP games we support. 

This last part is *maybe* pushing the line towards "faq entry" however I feel its common enough to warrant being in the message here.

Some more things to consider
- We should have a site-friendly version of the #faq channel visible from more places. It's technically [on our docs page](https://docs.littlebigrefresh.com/faq.html), but it's not the most pleasant to use right now due to broken channel links on the site.