### PR TITLE
Prepare for upcoming RPCN ticket changes

### DIFF
--- a/Refresh.GameServer/Extensions/TicketExtensions.cs
+++ b/Refresh.GameServer/Extensions/TicketExtensions.cs
@@ -1,0 +1,31 @@
+using Bunkum.Core;
+using NPTicket;
+using Refresh.GameServer.Authentication;
+
+namespace Refresh.GameServer.Extensions;
+
+public static class TicketExtensions
+{
+    public static TokenPlatform? DeterminePlatform(this Ticket ticket)
+    {
+        if (ticket.SignatureIdentifier == "RPCN" || ticket.IssuerId == 0x33333333)
+            return TokenPlatform.RPCS3;
+
+        if (ticket.IssuerId == 0x100)
+            return TokenPlatform.PS3;
+
+        return null;
+    }
+
+    public static TokenGame? DetermineGame(this Ticket ticket, RequestContext context)
+    {
+        TokenGame? game = null;
+
+        // check if we're connecting from a beta build
+        bool parsedBeta = byte.TryParse(context.QueryString.Get("beta"), out byte isBeta);
+        if (parsedBeta && isBeta == 1) game = TokenGame.BetaBuild;
+
+        game ??= TokenGameUtility.FromTitleId(ticket.TitleId);
+        return game;
+    }
+}


### PR DESCRIPTION
Uses the `SignatureIdentifier` to match RPCN tickets instead of the now-deprectaed `IssuerId` of `0x33333333` to verify ticket. The old method is kept as a fallback for ease of mind purposes.

https://discord.com/channels/272035812277878785/738838647176036393/1283019875538829354