### PR TITLE
Fix typo in PresenceAuthenticationMiddleware

### DIFF
--- a/Refresh.GameServer/Middlewares/PresenceAuthenticationMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/PresenceAuthenticationMiddleware.cs
@@ -36,5 +36,7 @@ public class PresenceAuthenticationMiddleware : IMiddleware
             context.ResponseCode = Unauthorized;
             return;
         }
+
+        next();
     }
 }


### PR DESCRIPTION
Apparently I messed up when doing a simple refactor in review, and broke the authentication middleware. Currently, the presence server is unable to talk to `Refresh.GameServer`.