### PR TITLE
Fix bug where reviews would always contain your own level rating instead of that of the reviewer's

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/ReviewEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ReviewEndpoints.cs
@@ -80,7 +80,7 @@ public class ReviewEndpoints : EndpointGroup
     
     [GameEndpoint("reviewsBy/{username}", ContentType.Xml)]
     [AllowEmptyBody]
-    public Response GetReviewsForLevel(RequestContext context, GameDatabaseContext database, string username,
+    public Response GetReviewsByUser(RequestContext context, GameDatabaseContext database, string username,
         DataContext dataContext)
     {
         GameUser? user = database.GetUserByUsername(username);

--- a/Refresh.GameServer/Types/Reviews/SerializedGameReview.cs
+++ b/Refresh.GameServer/Types/Reviews/SerializedGameReview.cs
@@ -74,7 +74,7 @@ public class SerializedGameReview : IDataConvertableFrom<SerializedGameReview, G
             Deleted = false,
             DeletedBy = ReviewDeletedBy.None,
             Text = review.Content,
-            Thumb = dataContext.Database.GetRatingByUser(review.Level, dataContext.User!)?.ToDPad() ?? 0,
+            Thumb = dataContext.Database.GetRatingByUser(review.Level, review.Publisher)?.ToDPad() ?? 0,
             ThumbsUp = reviewRatings.PositiveRating,
             ThumbsDown = reviewRatings.NegativeRating,
             YourThumb = (int) userRatingType,


### PR DESCRIPTION
Fixes issue #656 and additionally also corrects a method's name (see the changes below)