### PR TITLE
Implement moving levels while decorating earth

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -5,7 +5,6 @@ using Realms;
 using Refresh.Common.Constants;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
-using Refresh.GameServer.Endpoints.Game.DataTypes.Request;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
@@ -145,22 +144,15 @@ public partial class GameDatabaseContext // Levels
         return level;
     }
 
-    public GameLevel? UpdateLevelLocation(GameLevelRequest levelRequest, GameUser author)
+    public GameLevel? UpdateLevelLocation(GameLevel level, GameLocation location)
     {
-        // Verify if this level can be updated
-        GameLevel? Level = this.GetLevelById(levelRequest.LevelId);
-        if (Level == null) return null;
-
-        Debug.Assert(Level.Publisher != null);
-        if (Level.Publisher.UserId != author.UserId) return null;
-
         this.Write(() =>
         {
-            Level.LocationX = levelRequest.Location.X;
-            Level.LocationY = levelRequest.Location.Y;
+            level.LocationX = location.X;
+            level.LocationY = location.Y;
         });
 
-        return Level;
+        return level;
     }
 
     public void DeleteLevel(GameLevel level)

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -5,9 +5,11 @@ using Realms;
 using Refresh.Common.Constants;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
+using Refresh.GameServer.Endpoints.Game.DataTypes.Request;
 using Refresh.GameServer.Endpoints.Game.Levels.FilterSettings;
 using Refresh.GameServer.Extensions;
 using Refresh.GameServer.Services;
+using Refresh.GameServer.Types;
 using Refresh.GameServer.Types.Activity;
 using Refresh.GameServer.Types.Assets;
 using Refresh.GameServer.Types.Levels;
@@ -141,6 +143,24 @@ public partial class GameDatabaseContext // Levels
         });
 
         return level;
+    }
+
+    public GameLevel? UpdateLevelLocation(GameLevelRequest levelRequest, GameUser author)
+    {
+        // Verify if this level can be updated
+        GameLevel? Level = this.GetLevelById(levelRequest.LevelId);
+        if (Level == null) return null;
+
+        Debug.Assert(Level.Publisher != null);
+        if (Level.Publisher.UserId != author.UserId) return null;
+
+        this.Write(() =>
+        {
+            Level.LocationX = levelRequest.Location.X;
+            Level.LocationY = levelRequest.Location.Y;
+        });
+
+        return Level;
     }
 
     public void DeleteLevel(GameLevel level)

--- a/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
@@ -126,15 +126,15 @@ public class UserEndpoints : EndpointGroup
             }
         }
 
-        if(data.Levels != null)
+        if (data.Levels != null)
         {
             int failedLevelUpdates = 0;
 
             // Since you can only update level's locations through this endpoint, update their locations
-            foreach(GameLevelRequest LevelRequest in data.Levels)
+            foreach (GameLevelRequest LevelRequest in data.Levels)
             {
                 // Incase there is no location data provided for this level for some reason
-                if(LevelRequest.Location == null) 
+                if (LevelRequest.Location == null) 
                 {
                     failedLevelUpdates++;
                     continue;
@@ -157,7 +157,7 @@ public class UserEndpoints : EndpointGroup
                 database.UpdateLevelLocation(Level, LevelRequest.Location);
             }
 
-            if(failedLevelUpdates > 0) database.AddErrorNotification("Level update failed", $"Failed to update {failedLevelUpdates} out of {data.Levels.Count} level locations.", user);
+            if (failedLevelUpdates > 0) database.AddErrorNotification("Level update failed", $"Failed to update {failedLevelUpdates} out of {data.Levels.Count} level locations.", user);
         }
         
         if (data.PlanetsHash != null && !dataStore.ExistsInStore(data.PlanetsHash))

--- a/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
@@ -64,8 +64,6 @@ public class UserEndpoints : EndpointGroup
     public string? UpdateUser(RequestContext context, GameDatabaseContext database, GameUser user, string body, IDataStore dataStore, Token token, GuidCheckerService guidChecker)
     {
         SerializedUpdateData? data = null;
-
-        context.Logger.LogInfo(BunkumCategory.UserContent, body);
         
         // This stupid shit is caused by LBP sending two different root elements for this endpoint
         // LBP is just fantastic man

--- a/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/UserEndpoints.cs
@@ -7,6 +7,7 @@ using Bunkum.Protocols.Http;
 using Refresh.Common.Constants;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
+using Refresh.GameServer.Endpoints.Game.DataTypes.Request;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Services;
 using Refresh.GameServer.Types.Data;
@@ -63,6 +64,8 @@ public class UserEndpoints : EndpointGroup
     public string? UpdateUser(RequestContext context, GameDatabaseContext database, GameUser user, string body, IDataStore dataStore, Token token, GuidCheckerService guidChecker)
     {
         SerializedUpdateData? data = null;
+
+        context.Logger.LogInfo(BunkumCategory.UserContent, body);
         
         // This stupid shit is caused by LBP sending two different root elements for this endpoint
         // LBP is just fantastic man
@@ -121,6 +124,15 @@ public class UserEndpoints : EndpointGroup
                     database.AddErrorNotification("Profile update failed", "Your avatar failed to update because the asset was missing on the server.", user);
                     return null;
                 } 
+            }
+        }
+
+        if(data.Levels != null)
+        {
+            // since you can only update level's locations through this endpoint, update their locations
+            foreach(GameLevelRequest Level in data.Levels)
+            {
+                database.UpdateLevelLocation(Level, user);
             }
         }
         

--- a/Refresh.GameServer/Types/UserData/SerializedUpdateData.cs
+++ b/Refresh.GameServer/Types/UserData/SerializedUpdateData.cs
@@ -1,7 +1,6 @@
 using System.Xml.Serialization;
 using Realms;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Request;
-using Refresh.GameServer.Types.Levels;
 
 namespace Refresh.GameServer.Types.UserData;
 

--- a/Refresh.GameServer/Types/UserData/SerializedUpdateData.cs
+++ b/Refresh.GameServer/Types/UserData/SerializedUpdateData.cs
@@ -1,5 +1,7 @@
 using System.Xml.Serialization;
 using Realms;
+using Refresh.GameServer.Endpoints.Game.DataTypes.Request;
+using Refresh.GameServer.Types.Levels;
 
 namespace Refresh.GameServer.Types.UserData;
 
@@ -32,4 +34,7 @@ public class SerializedUpdateData
 
     [XmlElement("meh2")]
     public string? MehFaceHash { get; set; }
+
+    [XmlArray("slots")]
+    public List<GameLevelRequest>? Levels { get; set; }
 }


### PR DESCRIPTION
Implements the ability to move around levels while decorating your earth using the "Sticker & Decoration Edit Tool", which is very practical when you want to move multiple levels quickly without going through each level individually.