### PR TITLE
Update project name for the fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,13 @@ jobs:
 
       - name: Download Refresh Website artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: ng.yml
           workflow_conclusion: success
           name: "Refresh Website"
-          repo: LittleBigRefresh/refresh-web
+          repo: LittleBigBonsai/refresh-web
           branch: legacy
           if_no_artifact_found: fail
           path: "Refresh.GameServer/bin/Release/net8.0/linux-x64/publish/web"


### PR DESCRIPTION
This PR updates the obvious references to LittleBigRefresh I could find, so that it points to our own repos, this includes one of the github actions pipelines.