### PR TITLE
Add API support for changing a level's author as an admin

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -65,6 +65,24 @@ public partial class GameDatabaseContext // Levels
         return level;
     }
 
+    public GameLevel UpdateLevelPublisher(GameLevel level, GameUser newAuthor)
+    {
+        // No need to change the level author if we haven't actually changed the author.
+        if (level.Publisher?.UserId == newAuthor.UserId)
+            return level;
+        
+        // this comment is not outdated.
+        this.Write(() =>
+        {
+            // Change the level's publisher, making sure we also unset OriginalPublisher
+            // if this level wasn't uploaded by an actual user originally.
+            level.Publisher = newAuthor;
+            level.OriginalPublisher = null;
+        });
+
+        return level;
+    }
+    
     public GameLevel? UpdateLevel(GameLevel newLevel, GameUser author)
     {
         if (newLevel.Title is { Length: > UgcLimits.TitleLimit })

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -67,11 +67,9 @@ public partial class GameDatabaseContext // Levels
 
     public GameLevel UpdateLevelPublisher(GameLevel level, GameUser newAuthor)
     {
-        // No need to change the level author if we haven't actually changed the author.
         if (level.Publisher?.UserId == newAuthor.UserId)
             return level;
         
-        // this comment is not outdated.
         this.Write(() =>
         {
             // Change the level's publisher, making sure we also unset OriginalPublisher

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
@@ -78,13 +78,17 @@ public class AdminLevelApiEndpoints : EndpointGroup
     [DocSummary("Changes the author of a level. The new author must be an existing user on the server..")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.ObjectIdParseErrorWhen)]
     public ApiOkResponse SetLevelAuthor(RequestContext context, GameDatabaseContext database, GameUser user, int id, ApiSetLevelAuthorRequest body)
     {
+        if (!ObjectId.TryParse(body.AuthorId, out ObjectId authorId))
+            return ApiValidationError.ObjectIdParseError;
+        
         GameLevel? level = database.GetLevelById(id);
         if (level == null)
             return ApiNotFoundError.LevelMissingError;
         
-        GameUser? newAuthor = database.GetUserByUsername(body.AuthorName);
+        GameUser? newAuthor = database.GetUserByObjectId(authorId);
         if (newAuthor == null)
             return ApiNotFoundError.UserMissingError;
 

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
@@ -2,6 +2,7 @@ using AttribDoc.Attributes;
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
 using Bunkum.Protocols.Http;
+using MongoDB.Bson;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes;
 using Refresh.GameServer.Endpoints.ApiV3.ApiTypes.Errors;
@@ -70,6 +71,24 @@ public class AdminLevelApiEndpoints : EndpointGroup
         if (level == null) return ApiNotFoundError.LevelMissingError;
         
         database.DeleteLevel(level);
+        return new ApiOkResponse();
+    }
+    
+    [ApiV3Endpoint("admin/levels/id/{id}/setAuthor", HttpMethods.Post), MinimumRole(GameUserRole.Curator)]
+    [DocSummary("Changes the author of a level. The new author must be an existing user on the server..")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    public ApiOkResponse SetLevelAuthor(RequestContext context, GameDatabaseContext database, GameUser user, int id, ApiSetLevelAuthorRequest body)
+    {
+        var level = database.GetLevelById(id);
+        if (level == null)
+            return ApiNotFoundError.LevelMissingError;
+        
+        var newAuthor = database.GetUserByUsername(body.AuthorName);
+        if (newAuthor == null)
+            return ApiNotFoundError.UserMissingError;
+
+        database.UpdateLevelPublisher(level, newAuthor);
         return new ApiOkResponse();
     }
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/Admin/AdminLevelApiEndpoints.cs
@@ -80,11 +80,11 @@ public class AdminLevelApiEndpoints : EndpointGroup
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     public ApiOkResponse SetLevelAuthor(RequestContext context, GameDatabaseContext database, GameUser user, int id, ApiSetLevelAuthorRequest body)
     {
-        var level = database.GetLevelById(id);
+        GameLevel? level = database.GetLevelById(id);
         if (level == null)
             return ApiNotFoundError.LevelMissingError;
         
-        var newAuthor = database.GetUserByUsername(body.AuthorName);
+        GameUser? newAuthor = database.GetUserByUsername(body.AuthorName);
         if (newAuthor == null)
             return ApiNotFoundError.UserMissingError;
 

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiSetLevelAuthorRequest.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiSetLevelAuthorRequest.cs
@@ -3,5 +3,5 @@ namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
 public sealed class ApiSetLevelAuthorRequest
 {
-    public string AuthorName { get; set; } = string.Empty;
+    public string AuthorId { get; set; } = string.Empty;
 }

--- a/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiSetLevelAuthorRequest.cs
+++ b/Refresh.GameServer/Endpoints/ApiV3/DataTypes/Request/ApiSetLevelAuthorRequest.cs
@@ -1,0 +1,7 @@
+namespace Refresh.GameServer.Endpoints.ApiV3.DataTypes.Request;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public sealed class ApiSetLevelAuthorRequest
+{
+    public string AuthorName { get; set; } = string.Empty;
+}


### PR DESCRIPTION
This merge request adds an admin endpoint for changing a level's author. You should be able to do this:

```
POST admin/levels/id/12345/setAuthor

{
    "authorName": "ritchie"
}
```

This would change the level with ID `12345`'s author to the user named `ritchie`. Both the level and user must actually exist in the database, otherwise you'll get a 404.

If you try to change the author of a level that has an `OriginalAuthor` value set on it, this value gets unset. This effectively addresses issue #409 .

I haven't actually tested this, I don't have a game patched and adding UI for this in refresh-web isn't my skillset. But it compiles. What could go wrong?