### PR TITLE
Various minor fixes and features

### DIFF
--- a/Refresh.GameServer/Database/Activity/GameDatabaseContext.Activity.cs
+++ b/Refresh.GameServer/Database/Activity/GameDatabaseContext.Activity.cs
@@ -16,7 +16,7 @@ public partial class GameDatabaseContext // Activity
 
         if (parameters.User != null)
         {
-            List<ObjectId?> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User, 1000, 0).Select(f => (ObjectId?)f.UserId).ToList();
+            List<ObjectId?> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User).Select(f => (ObjectId?)f.UserId).ToList();
             List<ObjectId?> userFriends = this.GetUsersMutuals(parameters.User).Select(u => (ObjectId?)u.UserId).ToList();
 
             query = query.Where(e =>
@@ -64,7 +64,7 @@ public partial class GameDatabaseContext // Activity
 
         if (parameters is { ExcludeFavouriteUsers: true, User: not null })
         {
-            List<GameUser> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User, 1000, 0).ToList();
+            List<GameUser> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User).ToList();
             
             query = query.Where(e => favouriteUsers.All(r => r.UserId != e.User.UserId && (e.StoredDataType != EventDataType.User || r.UserId != e.StoredObjectId))); 
         }

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -90,19 +90,18 @@ public partial class GameDatabaseContext // Levels
         {
             foreach (SerializedLevelLocation location in locations)
             {
-                // You can't update the locations of developer levels
-                if (location.Type == "user")
-                {
-                    GameLevel? level = levelsByUser.FirstOrDefault(l => l.LevelId == location.LevelId);
+                // This gets the level to update while also verifying whether the user may even update its location
+                GameLevel? level = levelsByUser.FirstOrDefault(l => l.LevelId == location.LevelId);
 
-                    if (level != null)
-                    {
-                        level.LocationX = location.Location.X;
-                        level.LocationY = location.Location.Y;
-                    }
+                if (level != null)
+                {
+                    level.LocationX = location.Location.X;
+                    level.LocationY = location.Location.Y;
                 }
-                
-                failedUpdates++;
+                else 
+                {
+                    failedUpdates++;
+                }
             }
         });
 

--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -231,29 +231,41 @@ public partial class GameDatabaseContext // Levels
     
     private IQueryable<GameLevel> GetLevelsByGameVersion(TokenGame gameVersion) 
         => this.GameLevels
-            .Where(l => l.StoryId == 0) // Filter out any user levels
+            .Where(l => l.StoryId == 0) // Filter out any developer levels
             .FilterByGameVersion(gameVersion);
 
     [Pure]
     public DatabaseList<GameLevel> GetLevelsByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor)
     {
+        IEnumerable<GameLevel> levels;
+
         if (user.Username == SystemUsers.DeletedUserName)
         {
-            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.Publisher == null), skip, count);
+            levels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+                .FilterByLevelFilterSettings(accessor, levelFilterSettings)
+                .Where(l => l.Publisher == null);
         }
-
-        if (user.Username == SystemUsers.UnknownUserName)
+        else if (user.Username == SystemUsers.UnknownUserName)
         {
-            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(null, levelFilterSettings).Where(l => l.IsReUpload && string.IsNullOrEmpty(l.OriginalPublisher)), skip, count);
+            levels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+                .FilterByLevelFilterSettings(null, levelFilterSettings)
+                .Where(l => l.IsReUpload && string.IsNullOrEmpty(l.OriginalPublisher));
         }
-        
-        if (user.Username.StartsWith(SystemUsers.SystemPrefix))
+        else if (user.Username.StartsWith(SystemUsers.SystemPrefix))
         {
             string withoutPrefix = user.Username[1..];
-            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.OriginalPublisher == withoutPrefix), skip, count);
+            levels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+                .FilterByLevelFilterSettings(accessor, levelFilterSettings)
+                .Where(l => l.OriginalPublisher == withoutPrefix);
+        }
+        else
+        {
+            levels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+                .FilterByLevelFilterSettings(accessor, levelFilterSettings)
+                .Where(l => l.Publisher == user);
         }
         
-        return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.Publisher == user), skip, count);
+        return new(levels.OrderByDescending(l => l.UpdateDate), skip, count);
     }
     
     public int GetTotalLevelsByUser(GameUser user) => this.GameLevels.Count(l => l.Publisher == user);

--- a/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Notifications.cs
@@ -32,6 +32,11 @@ public partial class GameDatabaseContext // Notifications
         this.AddNotification(title, text, user, "exclamation-circle");
     }
 
+    public void AddWarnNotification(string title, string text, GameUser user)
+    {
+        this.AddNotification(title, text, user, "warning");
+    }
+
     public void AddPublishFailNotification(string reason, GameLevel body, GameUser user)
     {
         this.AddErrorNotification("Publish failed", $"The level '{body.Title}' failed to publish. {reason}", user);

--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -108,12 +108,24 @@ public partial class GameDatabaseContext // Photos
             .Count(p => p.Subjects.FirstOrDefault(s => Equals(s.User, user)) != null);
 
     [Pure]
-    public DatabaseList<GamePhoto> GetPhotosInLevel(GameLevel level, int count, int skip) =>
-        new(this.GamePhotos.Where(p => p.LevelId == level.LevelId), skip, count);
+    public DatabaseList<GamePhoto> GetPhotosInLevel(GameLevel level, int count, int skip)
+        => new(this.GamePhotos
+            .Where(p => p.Level == level)
+            .OrderByDescending(p => p.TakenAt), skip, count);
     
     [Pure]
     public int GetTotalPhotosInLevel(GameLevel level)
-        => this.GamePhotos.Count(p => p.LevelId == level.LevelId);
+        => this.GamePhotos.Count(p => p.Level == level);
+    
+    [Pure]
+    public DatabaseList<GamePhoto> GetPhotosInLevelByUser(GameLevel level, GameUser user, int count, int skip) 
+        => new(this.GamePhotos
+            .Where(p => p.Level == level && p.Publisher == user)
+            .OrderByDescending(p => p.TakenAt), skip, count);
+    
+    [Pure]
+    public int GetTotalPhotosInLevelByUser(GameLevel level, GameUser user)
+        => this.GamePhotos.Count(p => p.Level == level && p.Publisher == user);
     
     public void DeletePhotosPostedByUser(GameUser user)
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Users.cs
@@ -91,10 +91,10 @@ public partial class GameDatabaseContext // Users
             if (data.Description != null)
                 user.Description = data.Description;
 
-            if (data.Location != null)
+            if (data.UserLocation != null)
             {
-                user.LocationX = data.Location.X;
-                user.LocationY = data.Location.Y;
+                user.LocationX = data.UserLocation.X;
+                user.LocationY = data.UserLocation.Y;
             }
 
             if (data.PlanetsHash != null)

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -34,7 +34,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 162;
+    protected override ulong SchemaVersion => 163;
 
     protected override string Filename => "refreshGameServer.realm";
     
@@ -353,6 +353,14 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
                 if (oldVersion >= 148 && oldVersion < 149)
                 {
                     newLevel.IsModded = oldLevel.Modded;
+                }
+
+                // From version 163 on we track whether a level requires a move controller to play or not.
+                // We don't know what previous levels require one, so just set this to false;
+                // updating a level will update this information anyway.
+                if (oldVersion < 163)
+                {
+                    newLevel.RequiresMoveController = false;
                 }
             }
 

--- a/Refresh.GameServer/Endpoints/Game/CommentEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/CommentEndpoints.cs
@@ -88,7 +88,7 @@ public class CommentEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
 
-        if (!level.Publisher.Equals(user)) 
+        if (level.Publisher != null && !level.Publisher.Equals(user)) 
         {
             database.AddNotification("New comment", $"{user.Username} left a comment on your level: '{level.Title}!'", level.Publisher);
         }

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Request/GameLevelRequest.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Request/GameLevelRequest.cs
@@ -45,6 +45,7 @@ public class GameLevelRequest
     [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
     [XmlElement("isSubLevel")] public bool IsSubLevel { get; set; }
     [XmlElement("shareable")] public int IsCopyable { get; set; }
+    [XmlElement("moveRequired")] public bool RequiresMoveController { get; set; }
     
     [XmlElement("backgroundGUID")] public string? BackgroundGuid { get; set; }
     
@@ -73,6 +74,7 @@ public class GameLevelRequest
             IsLocked = this.IsLocked,
             IsSubLevel = this.IsSubLevel,
             IsCopyable = this.IsCopyable == 1,
+            RequiresMoveController = this.RequiresMoveController,
             BackgroundGuid = this.BackgroundGuid,
         };
 }

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -41,6 +41,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlElement("sameScreenGame")] public required bool SameScreenGame { get; set; }
 
     [XmlAttribute("type")] public string? Type { get; set; } = GameSlotType.User.ToGameType();
+    [XmlElement("leveltype")] public required string LevelType { get; set; }
 
     [XmlElement("npHandle")] public SerializedUserHandle Handle { get; set; } = null!;
     
@@ -67,11 +68,10 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlElement("resource")] public List<string> XmlResources { get; set; } = new();
     [XmlElement("playerCount")] public int PlayerCount { get; set; }
     
-    [XmlElement("leveltype")] public required string LevelType { get; set; }
-    
     [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
     [XmlElement("isSubLevel")] public bool IsSubLevel { get; set; }
     [XmlElement("shareable")] public int IsCopyable { get; set; }
+    [XmlElement("moveRequired")] public bool RequiresMoveController { get; set; }
     [XmlElement("backgroundGUID")] public string? BackgroundGuid { get; set; }
     [XmlElement("links")] public string? Links { get; set; }
     [XmlElement("averageRating")] public double AverageStarRating { get; set; }
@@ -80,6 +80,8 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlElement("reviewsEnabled")] public bool ReviewsEnabled { get; set; } = true;
     [XmlElement("commentCount")] public int CommentCount { get; set; } = 0;
     [XmlElement("commentsEnabled")] public bool CommentsEnabled { get; set; } = true;
+    [XmlElement("photoCount")] public int PhotoCount { get; set; }
+    [XmlElement("authorPhotoCount")] public int PublisherPhotoCount { get; set; }
     [XmlElement("tags")] public string Tags { get; set; } = "";
     
     /// <summary>
@@ -131,9 +133,12 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             ReviewCount = 0,
             CommentsEnabled = false,
             CommentCount = 0,
+            PhotoCount = 0,
+            PublisherPhotoCount = 0,
             IsLocked = false,
             IsSubLevel = false,
             IsCopyable = 0,
+            RequiresMoveController = false,
             PublishDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             UpdateDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             EnforceMinMaxPlayers = false,
@@ -175,11 +180,14 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             IsCopyable = old.IsCopyable ? 1 : 0,
             IsLocked = old.IsLocked,
             IsSubLevel = old.IsSubLevel,
+            RequiresMoveController = old.RequiresMoveController,
             BackgroundGuid = old.BackgroundGuid,
             Links = "",
             AverageStarRating = old.CalculateAverageStarRating(dataContext.Database),
             ReviewCount = old.Reviews.Count,
             CommentCount = dataContext.Database.GetTotalCommentsForLevel(old),
+            PhotoCount = dataContext.Database.GetTotalPhotosInLevel(old),
+            PublisherPhotoCount = old.Publisher == null ? 0 : dataContext.Database.GetTotalPhotosInLevelByUser(old, old.Publisher),
             Tags = string.Join(',', dataContext.Database.GetTagsForLevel(old).Select(t => t.Tag.ToLbpString())) ,
             Type = old.SlotType.ToGameType(),
         };
@@ -207,7 +215,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         
         if (dataContext.User != null)
         {
-            RatingType? rating = dataContext.Database.GetRatingByUser(old, dataContext.User);
+            RatingType? rating = dataContext.Database.GetLevelRatingByUser(old, dataContext.User);
 
             response.YourRating = rating?.ToDPad() ?? (int)RatingType.Neutral;
             response.YourStarRating = rating?.ToLBP1() ?? 0;
@@ -284,6 +292,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             IsLocked = false,
             IsSubLevel = false,
             IsCopyable = 0,
+            RequiresMoveController = false,
             BackgroundGuid = null,
             Links = null,
             AverageStarRating = 0,
@@ -292,6 +301,8 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             ReviewsEnabled = true,
             CommentCount = 0,
             CommentsEnabled = true,
+            PhotoCount = 0,
+            PublisherPhotoCount = 0,
             Tags = string.Empty,
         };
     }

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -78,6 +78,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlElement("sizeOfResources")] public int SizeOfResourcesInBytes { get; set; }
     [XmlElement("reviewCount")] public int ReviewCount { get; set; }
     [XmlElement("reviewsEnabled")] public bool ReviewsEnabled { get; set; } = true;
+    [XmlElement("yourReview")] public SerializedGameReview? YourReview { get; set; }
     [XmlElement("commentCount")] public int CommentCount { get; set; } = 0;
     [XmlElement("commentsEnabled")] public bool CommentsEnabled { get; set; } = true;
     [XmlElement("photoCount")] public int PhotoCount { get; set; }
@@ -219,6 +220,8 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
 
             response.YourRating = rating?.ToDPad() ?? (int)RatingType.Neutral;
             response.YourStarRating = rating?.ToLBP1() ?? 0;
+
+            response.YourReview = SerializedGameReview.FromOld(dataContext.Database.GetReviewByLevelAndUser(old, dataContext.User), dataContext);
 
             // this is technically invalid, but specifying this for all games ensures they all have the capacity to review if played.
             // we don't store the game's version in play relations, so this is the best we can do

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -154,7 +154,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
                 response.Handle.IconHash = old.PspIconHash;
 
                 //Fill out PSP favourite users
-                List<GameUser> users = dataContext.Database.GetUsersFavouritedByUser(old).ToList();
+                List<GameUser> users = dataContext.Database.GetUsersFavouritedByUser(old, 20, 0).Items.ToList();
                 response.FavouriteUsers = new SerializedMinimalFavouriteUserList(users.Select(u => SerializedUserHandle.FromUser(u, dataContext)).ToList(), users.Count);
 
                 //Fill out PSP favourite levels

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameUserResponse.cs
@@ -154,15 +154,15 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
                 response.Handle.IconHash = old.PspIconHash;
 
                 //Fill out PSP favourite users
-                List<GameUser> users = dataContext.Database.GetUsersFavouritedByUser(old, 20, 0).ToList();
+                List<GameUser> users = dataContext.Database.GetUsersFavouritedByUser(old).ToList();
                 response.FavouriteUsers = new SerializedMinimalFavouriteUserList(users.Select(u => SerializedUserHandle.FromUser(u, dataContext)).ToList(), users.Count);
 
                 //Fill out PSP favourite levels
-                List<GameMinimalLevelResponse> favouriteLevels = dataContext.Database
+                List<SerializedMinimalLevelResponse> favouriteLevels = dataContext.Database
                     .GetLevelsFavouritedByUser(old, 20, 0, new LevelFilterSettings(dataContext.Game), dataContext.User)
                     .Items
                     .Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetPSP)
-                    .Select(l => GameMinimalLevelResponse.FromOld(l, dataContext)).ToList()!;
+                    .Select(l => SerializedMinimalLevelResponse.FromOld(l, dataContext)).ToList()!;
                 response.FavouriteLevels = new SerializedMinimalFavouriteLevelList(new SerializedMinimalLevelList(favouriteLevels, favouriteLevels.Count, favouriteLevels.Count));
                 break;
             }

--- a/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Levels/LevelEndpoints.cs
@@ -34,13 +34,13 @@ public class LevelEndpoints : EndpointGroup
     {
         if (overrideService.UserHasOverrides(user))
         {
-            List<GameMinimalLevelResponse> overrides = [];
+            List<SerializedMinimalLevelResponse> overrides = [];
             
             if (overrideService.GetIdOverridesForUser(token, database, out IEnumerable<GameLevel> levelOverrides))
-                overrides.AddRange(levelOverrides.Select(l => GameMinimalLevelResponse.FromOld(l, dataContext))!);
+                overrides.AddRange(levelOverrides.Select(l => SerializedMinimalLevelResponse.FromOld(l, dataContext))!);
             
             if (overrideService.GetHashOverrideForUser(token, out string hashOverride))
-                overrides.Add(GameMinimalLevelResponse.FromHash(hashOverride, dataContext));
+                overrides.Add(SerializedMinimalLevelResponse.FromHash(hashOverride, dataContext));
             
             return new SerializedMinimalLevelList(overrides, overrides.Count, overrides.Count);
         }
@@ -54,7 +54,7 @@ public class LevelEndpoints : EndpointGroup
             {
                 Total = 1,
                 NextPageStart = 1,
-                Items = [GameMinimalLevelResponse.FromHash(hash, dataContext)],
+                Items = [SerializedMinimalLevelResponse.FromHash(hash, dataContext)],
             };
         }
         
@@ -66,8 +66,8 @@ public class LevelEndpoints : EndpointGroup
 
         if (levels == null) return null;
         
-        IEnumerable<GameMinimalLevelResponse> slots = levels.Items
-            .Select(l => GameMinimalLevelResponse.FromOld(l, dataContext)!);
+        IEnumerable<SerializedMinimalLevelResponse> slots = levels.Items
+            .Select(l => SerializedMinimalLevelResponse.FromOld(l, dataContext)!);
 
         int injectedAmount = 0;
         
@@ -81,7 +81,7 @@ public class LevelEndpoints : EndpointGroup
             if (playlist != null)
             {
                 DatabaseList<GamePlaylist> playlists = database.GetPlaylistsInPlaylist(playlist, skip, count);
-                slots = GameMinimalLevelResponse.FromOldList(playlists.Items, dataContext).Concat(slots);
+                slots = SerializedMinimalLevelResponse.FromOldList(playlists.Items, dataContext).Concat(slots);
 
                 // While this does technically return more slot results than the game is expecting,
                 // because we tell the game exactly what the "next page index" is (its not based on count sent),
@@ -194,7 +194,7 @@ public class LevelEndpoints : EndpointGroup
             .Fetch(context, skip, count, dataContext, new LevelFilterSettings(context, token.TokenGame), user);
         
         return new SerializedMinimalLevelResultsList(levels?.Items
-            .Select(l => GameMinimalLevelResponse.FromOld(l, dataContext))!, levels?.TotalItems ?? 0, skip + count);
+            .Select(l => SerializedMinimalLevelResponse.FromOld(l, dataContext))!, levels?.TotalItems ?? 0, skip + count);
     }
 
     #region Quirk workarounds

--- a/Refresh.GameServer/Endpoints/Game/Playlists/Lbp1PlaylistEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Playlists/Lbp1PlaylistEndpoints.cs
@@ -73,11 +73,11 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
         DatabaseList<GameLevel> levels = dataContext.Database.GetLevelsInPlaylist(playlist, dataContext.Game, skip, count);                    
 
         // Concat together the playlist's sub-playlists and levels 
-        IEnumerable<GameMinimalLevelResponse> slots =
-            GameMinimalLevelResponse.FromOldList(subPlaylists.Items, dataContext) // the sub-playlists
-                .Concat(GameMinimalLevelResponse.FromOldList(levels.Items, dataContext)); // the sub-levels
+        IEnumerable<SerializedMinimalLevelResponse> slots =
+            SerializedMinimalLevelResponse.FromOldList(subPlaylists.Items, dataContext) // the sub-playlists
+                .Concat(SerializedMinimalLevelResponse.FromOldList(levels.Items, dataContext)); // the sub-levels
         
-        // Convert the GameLevelResponse list down to a GameMinimalLevelResponse
+        // Convert the GameLevelResponse list down to a SerializedMinimalLevelResponse
         return new SerializedMinimalLevelList(
             slots,
             subPlaylists.TotalItems + levels.TotalItems,
@@ -131,7 +131,7 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
 
         // Return the serialized playlists 
         return new SerializedMinimalLevelList(
-            GameMinimalLevelResponse.FromOldList(playlists.Items, dataContext), 
+            SerializedMinimalLevelResponse.FromOldList(playlists.Items, dataContext), 
             playlists.TotalItems, 
             skip
         );

--- a/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/RelationEndpoints.cs
@@ -1,10 +1,8 @@
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
 using Bunkum.Core.Responses;
-using Bunkum.Core.Storage;
 using Bunkum.Listener.Protocol;
 using Bunkum.Protocols.Http;
-using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.Game.DataTypes.Response;
 using Refresh.GameServer.Extensions;
@@ -92,10 +90,9 @@ public class RelationEndpoints : EndpointGroup
         if (user == null) return null;
 
         (int skip, int count) = context.GetPageData();
-        List<GameUser> users = database.GetUsersFavouritedByUser(user, count, skip)
-            .ToList();
+        DatabaseList<GameUser> users = database.GetUsersFavouritedByUser(user, count, skip);
 
-        return new SerializedFavouriteUserList(GameUserResponse.FromOldList(users, dataContext).ToList(), users.Count, skip + count);
+        return new SerializedFavouriteUserList(GameUserResponse.FromOldList(users.Items, dataContext).ToList(), users.TotalItems, users.NextPageIndex);
     }
 
     [GameEndpoint("lolcatftw/add/{slotType}/{id}", HttpMethods.Post)]

--- a/Refresh.GameServer/FodyWeavers.xsd
+++ b/Refresh.GameServer/FodyWeavers.xsd
@@ -5,51 +5,7 @@
     <xs:complexType>
       <xs:all>
         <xs:element name="Realm" minOccurs="0" maxOccurs="1">
-          <xs:complexType>
-            <xs:attribute name="DisableAnalytics" type="xs:boolean">
-              <xs:annotation>
-                <xs:documentation>THIS IS DEPRECATED - USE `AnalyticsCollection` INSTEAD. Disables anonymized
-        usage information from being sent on build. Read more about what data is being collected and
-        why here: https://github.com/realm/realm-dotnet/blob/main/Realm/Realm.Weaver/Analytics.cs</xs:documentation>
-              </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="AnalyticsCollection">
-              <xs:annotation>
-                <xs:documentation>Controls what anonymized usage information is being sent on build. Read more
-        about what data is being collected and why here:
-        https://github.com/realm/realm-dotnet/blob/main/Realm/Realm.Weaver/Analytics/Analytics.cs</xs:documentation>
-              </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="Full">
-                    <xs:annotation>
-                      <xs:documentation>Analytics collection will run normally. This is the default behavior
-              and we hope you don't change it as the anonymized data collected is critical for
-              making the right decisions about the future of the Realm SDK.</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                  <xs:enumeration value="DryRun">
-                    <xs:annotation>
-                      <xs:documentation>Analytics collection will run but will not send it to the server. This
-              is useful in combination with `AnalyticsLogPath` if you want to review the data being
-              sent.</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                  <xs:enumeration value="Disabled">
-                    <xs:annotation>
-                      <xs:documentation>Analytics collection is disabled. No data will be sent on build.</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                </xs:restriction>
-              </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="AnalyticsLogPath" type="xs:string">
-              <xs:annotation>
-                <xs:documentation>Controls where the payload for the anonymized metrics collection will be
-        stored. This can be useful if you want to review the data being collected by Realm. </xs:documentation>
-              </xs:annotation>
-            </xs:attribute>
-          </xs:complexType>
+          <xs:complexType></xs:complexType>
         </xs:element>
       </xs:all>
       <xs:attribute name="VerifyAssembly" type="xs:boolean">

--- a/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
+++ b/Refresh.GameServer/Types/Levels/Categories/SerializedCategory.cs
@@ -53,8 +53,8 @@ public class SerializedCategory
         LevelFilterSettings filterSettings = new(context, dataContext.Token!.TokenGame);
         DatabaseList<GameLevel> categoryLevels = levelCategory.Fetch(context, skip, count, dataContext, filterSettings, dataContext.User);
         
-        IEnumerable<GameMinimalLevelResponse> levels = categoryLevels?.Items
-            .Select(l => GameMinimalLevelResponse.FromOld(l, dataContext)) ?? Array.Empty<GameMinimalLevelResponse>();
+        IEnumerable<SerializedMinimalLevelResponse> levels = categoryLevels?.Items
+            .Select(l => SerializedMinimalLevelResponse.FromOld(l, dataContext)) ?? Array.Empty<SerializedMinimalLevelResponse>();
 
         category.Levels = new SerializedMinimalLevelList(levels, categoryLevels?.TotalItems ?? 0, skip + count);
 

--- a/Refresh.GameServer/Types/Levels/GameLevel.cs
+++ b/Refresh.GameServer/Types/Levels/GameLevel.cs
@@ -2,12 +2,9 @@ using System.Xml.Serialization;
 using Realms;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
-using Refresh.GameServer.Types.Comments;
 using Refresh.GameServer.Types.UserData;
 using Refresh.GameServer.Types.Levels.SkillRewards;
-using Refresh.GameServer.Types.Relations;
 using Refresh.GameServer.Types.Reviews;
-using Refresh.GameServer.Types.UserData.Leaderboard;
 using Refresh.GameServer.Workers;
 
 namespace Refresh.GameServer.Types.Levels;
@@ -88,6 +85,7 @@ public partial class GameLevel : IRealmObject, ISequentialId
     public bool IsLocked { get; set; }
     public bool IsSubLevel { get; set; }
     public bool IsCopyable { get; set; }
+    public bool RequiresMoveController { get; set; }
     
     /// <summary>
     /// The score, used for Cool Levels.

--- a/Refresh.GameServer/Types/Levels/SerializedLevelLocation.cs
+++ b/Refresh.GameServer/Types/Levels/SerializedLevelLocation.cs
@@ -1,0 +1,14 @@
+using System.Xml.Serialization;
+
+namespace Refresh.GameServer.Types.Levels;
+
+#nullable disable
+
+[XmlRoot("slot")]
+[XmlType("slot")]
+public class SerializedLevelLocation
+{
+    [XmlAttribute("type")] public string Type { get; set; } = "user";
+    [XmlElement("id")] public int LevelId { get; set; }
+    [XmlElement("location")] public GameLocation Location { get; set; }
+}

--- a/Refresh.GameServer/Types/Levels/SerializedMinimalLevelResponse.cs
+++ b/Refresh.GameServer/Types/Levels/SerializedMinimalLevelResponse.cs
@@ -9,7 +9,7 @@ using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Levels;
 
-public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelResponse, GameLevel>, IDataConvertableFrom<GameMinimalLevelResponse, GamePlaylist>, IDataConvertableFrom<GameMinimalLevelResponse, GameLevelResponse>
+public class SerializedMinimalLevelResponse : IDataConvertableFrom<SerializedMinimalLevelResponse, GameLevel>, IDataConvertableFrom<SerializedMinimalLevelResponse, GamePlaylist>, IDataConvertableFrom<SerializedMinimalLevelResponse, GameLevelResponse>
 {
     //NOTE: THIS MUST BE AT THE TOP OF THE XML RESPONSE OR ELSE LBP PSP WILL CRASH
     [XmlElement("id")] public required int LevelId { get; set; }
@@ -23,6 +23,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     [XmlElement("location")] public required GameLocation Location { get; set; } = GameLocation.Zero;
     [XmlElement("npHandle")] public required SerializedUserHandle? Handle { get; set; }
     [XmlAttribute("type")] public required string? Type { get; set; }
+    [XmlElement("leveltype")] public required string LevelType { get; set; }
     [XmlElement("mmpick")] public required bool TeamPicked { get; set; }
     [XmlElement("minPlayers")] public required int MinPlayers { get; set; }
     [XmlElement("maxPlayers")] public required int MaxPlayers { get; set; }
@@ -45,9 +46,10 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
     [XmlElement("isSubLevel")] public bool IsSubLevel { get; set; }
     [XmlElement("shareable")] public int IsCopyable { get; set; }
+    [XmlElement("moveRequired")] public bool RequiresMoveController { get; set; }
     [XmlElement("tags")] public string Tags { get; set; } = "";
  
-    private GameMinimalLevelResponse() {}
+    private SerializedMinimalLevelResponse() {}
     
     /// <summary>
     /// Constructs a placeholder level response from a root level hash
@@ -55,60 +57,63 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     /// <param name="hash"></param>
     /// <param name="dataContext"></param>
     /// <returns></returns>
-    public static GameMinimalLevelResponse FromHash(string hash, DataContext dataContext)
+    public static SerializedMinimalLevelResponse FromHash(string hash, DataContext dataContext)
     {
         return FromOld(GameLevelResponse.FromHash(hash, dataContext), dataContext)!;
     }
 
-    public static GameMinimalLevelResponse? FromOld(GameLevel? level, DataContext dataContext)
+    public static SerializedMinimalLevelResponse? FromOld(GameLevel? old, DataContext dataContext)
     {
-        if(level == null) return null;
-        return FromOld(GameLevelResponse.FromOld(level, dataContext), dataContext);
+        if(old == null) return null;
+        return FromOld(GameLevelResponse.FromOld(old, dataContext), dataContext);
     }
 
 
-    public static GameMinimalLevelResponse? FromOld(GameLevelResponse? level, DataContext dataContext)
+    public static SerializedMinimalLevelResponse? FromOld(GameLevelResponse? old, DataContext dataContext)
     {
-        if(level == null) return null;
+        if (old == null)
+            return null;
 
-        return new GameMinimalLevelResponse
+        return new SerializedMinimalLevelResponse
         {
-            Title = level.Title,
-            IsAdventure = level.IsAdventure,
-            IconHash = dataContext.Database.GetAssetFromHash(level.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? level.IconHash,
-            GameVersion = level.GameVersion,
-            RootResource = level.RootResource,
-            Description = level.Description,
-            Location = level.Location,
-            LevelId = level.LevelId,
-            Handle = level.Handle,
-            Type = level.Type,
-            TeamPicked = level.TeamPicked,
-            YayCount = level.YayCount,
-            BooCount = level.BooCount,
-            HeartCount = level.HeartCount,
-            MaxPlayers = level.MaxPlayers,
-            MinPlayers = level.MinPlayers,
-            TotalPlayCount = level.TotalPlayCount,
-            UniquePlayCount = level.UniquePlayCount,
-            YourStarRating = level.YourStarRating,
-            YourRating = level.YourRating,
-            AverageStarRating = level.AverageStarRating,
-            CommentCount = level.CommentCount,
-            IsLocked = level.IsLocked,
-            IsSubLevel = level.IsSubLevel,
-            IsCopyable = level.IsCopyable,
-            PlayerCount = dataContext.Match.GetPlayerCountForLevel(RoomSlotType.Online, level.LevelId),
-            Tags = level.Tags,
+            Title = old.Title,
+            IsAdventure = old.IsAdventure,
+            IconHash = dataContext.Database.GetAssetFromHash(old.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? old.IconHash,
+            GameVersion = old.GameVersion,
+            RootResource = old.RootResource,
+            Description = old.Description,
+            Location = old.Location,
+            LevelId = old.LevelId,
+            Handle = old.Handle,
+            Type = old.Type,
+            LevelType = old.LevelType,
+            TeamPicked = old.TeamPicked,
+            YayCount = old.YayCount,
+            BooCount = old.BooCount,
+            HeartCount = old.HeartCount,
+            MaxPlayers = old.MaxPlayers,
+            MinPlayers = old.MinPlayers,
+            TotalPlayCount = old.TotalPlayCount,
+            UniquePlayCount = old.UniquePlayCount,
+            YourStarRating = old.YourStarRating,
+            YourRating = old.YourRating,
+            AverageStarRating = old.AverageStarRating,
+            CommentCount = old.CommentCount,
+            IsLocked = old.IsLocked,
+            IsSubLevel = old.IsSubLevel,
+            IsCopyable = old.IsCopyable,
+            RequiresMoveController = old.RequiresMoveController,
+            PlayerCount = dataContext.Match.GetPlayerCountForLevel(RoomSlotType.Online, old.LevelId),
+            Tags = old.Tags,
         };
     }
     
-    public static GameMinimalLevelResponse? FromOld(GamePlaylist? old, DataContext dataContext)
+    public static SerializedMinimalLevelResponse? FromOld(GamePlaylist? old, DataContext dataContext)
     {
         if (old == null)
             return null;
         
-        return new GameMinimalLevelResponse
+        return new SerializedMinimalLevelResponse
         {
             LevelId = old.PlaylistId,
             IsAdventure = false,
@@ -116,6 +121,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
             IconHash = dataContext.GetIconFromHash(old.IconHash),
             Description = old.Description,
             Type = GameSlotType.Playlist.ToGameType(),
+            LevelType = GameSlotType.Playlist.ToGameType(),
             Location = new GameLocation(old.LocationX, old.LocationY),
             // Playlists are only ever serialized like this in LBP1-like builds, so we can assume LBP1
             GameVersion = TokenGame.LittleBigPlanet1.ToSerializedGame(),
@@ -138,17 +144,18 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
             IsLocked = false,
             IsSubLevel = false,
             IsCopyable = 0,
+            RequiresMoveController = false,
             Tags = string.Empty, 
             TeamPicked = false, 
             Handle = SerializedUserHandle.FromUser(old.Publisher, dataContext),
         };
     }
 
-    public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GameLevel> oldList,
+    public static IEnumerable<SerializedMinimalLevelResponse> FromOldList(IEnumerable<GameLevel> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
-    public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GameLevelResponse> oldList,
+    public static IEnumerable<SerializedMinimalLevelResponse> FromOldList(IEnumerable<GameLevelResponse> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
-    public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GamePlaylist> oldList, 
+    public static IEnumerable<SerializedMinimalLevelResponse> FromOldList(IEnumerable<GamePlaylist> oldList, 
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 
 }

--- a/Refresh.GameServer/Types/Lists/SerializedMinimalFavouriteLevelList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedMinimalFavouriteLevelList.cs
@@ -7,7 +7,7 @@ namespace Refresh.GameServer.Types.Lists;
 
 [XmlRoot("favouriteSlots")]
 [XmlType("favouriteSlots")]
-public class SerializedMinimalFavouriteLevelList : SerializedList<GameMinimalLevelResponse>
+public class SerializedMinimalFavouriteLevelList : SerializedList<SerializedMinimalLevelResponse>
 {
     public SerializedMinimalFavouriteLevelList() {}
     
@@ -19,5 +19,5 @@ public class SerializedMinimalFavouriteLevelList : SerializedList<GameMinimalLev
     }
     
     [XmlElement("slot")]
-    public override List<GameMinimalLevelResponse> Items { get; set; }
+    public override List<SerializedMinimalLevelResponse> Items { get; set; }
 }

--- a/Refresh.GameServer/Types/Lists/SerializedMinimalLevelList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedMinimalLevelList.cs
@@ -7,11 +7,11 @@ namespace Refresh.GameServer.Types.Lists;
 
 [XmlRoot("slots")]
 [XmlType("slots")]
-public class SerializedMinimalLevelList : SerializedList<GameMinimalLevelResponse>
+public class SerializedMinimalLevelList : SerializedList<SerializedMinimalLevelResponse>
 {
     public SerializedMinimalLevelList() {}
     
-    public SerializedMinimalLevelList(IEnumerable<GameMinimalLevelResponse> list, int total, int skip)
+    public SerializedMinimalLevelList(IEnumerable<SerializedMinimalLevelResponse> list, int total, int skip)
     {
         this.Total = total;
         this.Items = list.ToList();
@@ -19,5 +19,5 @@ public class SerializedMinimalLevelList : SerializedList<GameMinimalLevelRespons
     }
 
     [XmlElement("slot")]
-    public override List<GameMinimalLevelResponse> Items { get; set; }
+    public override List<SerializedMinimalLevelResponse> Items { get; set; }
 }

--- a/Refresh.GameServer/Types/Lists/SerializedMinimalLevelResultsList.cs
+++ b/Refresh.GameServer/Types/Lists/SerializedMinimalLevelResultsList.cs
@@ -9,7 +9,7 @@ public class SerializedMinimalLevelResultsList : SerializedMinimalLevelList
 {
     public SerializedMinimalLevelResultsList() {}
     
-    public SerializedMinimalLevelResultsList(IEnumerable<GameMinimalLevelResponse>? list, int total, int skip)
+    public SerializedMinimalLevelResultsList(IEnumerable<SerializedMinimalLevelResponse>? list, int total, int skip)
     {
         this.Total = total;
         this.Items = list?.ToList() ?? [];

--- a/Refresh.GameServer/Types/Relations/FavouriteLevelRelation.cs
+++ b/Refresh.GameServer/Types/Relations/FavouriteLevelRelation.cs
@@ -9,4 +9,5 @@ public partial class FavouriteLevelRelation : IRealmObject
 {
     public GameLevel Level { get; set; }
     public GameUser User { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Relations/FavouriteUserRelation.cs
+++ b/Refresh.GameServer/Types/Relations/FavouriteUserRelation.cs
@@ -8,4 +8,5 @@ public partial class FavouriteUserRelation : IRealmObject
 {
     public GameUser UserToFavourite { get; set; }
     public GameUser UserFavouriting { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Relations/QueueLevelRelation.cs
+++ b/Refresh.GameServer/Types/Relations/QueueLevelRelation.cs
@@ -10,4 +10,5 @@ public partial class QueueLevelRelation : IRealmObject
 {
     public GameLevel Level { get; set; }
     public GameUser User { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Relations/RateReviewRelation.cs
+++ b/Refresh.GameServer/Types/Relations/RateReviewRelation.cs
@@ -5,6 +5,8 @@ using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Relations;
 
+#nullable disable
+
 public partial class RateReviewRelation : IRealmObject
 {
     // we could just reuse RatingType from GameLevel rating logic
@@ -20,4 +22,5 @@ public partial class RateReviewRelation : IRealmObject
     
     // for the purposes of checking if a positive/negative rating on a review has already been submitted by the user
     public GameUser User { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Relations/TagLevelRelation.cs
+++ b/Refresh.GameServer/Types/Relations/TagLevelRelation.cs
@@ -4,6 +4,8 @@ using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Relations;
 
+#nullable disable
+
 public partial class TagLevelRelation : IRealmObject
 {
     [Ignored]
@@ -17,4 +19,5 @@ public partial class TagLevelRelation : IRealmObject
     
     public GameUser User { get; set; }
     public GameLevel Level { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Reviews/SerializedGameReview.cs
+++ b/Refresh.GameServer/Types/Reviews/SerializedGameReview.cs
@@ -1,10 +1,7 @@
 using System.Xml.Serialization;
-using Refresh.GameServer.Database;
 using Refresh.GameServer.Endpoints.ApiV3.DataTypes;
 using Refresh.GameServer.Types.Data;
 using Refresh.GameServer.Types.Levels;
-using Refresh.GameServer.Types.Relations;
-using Refresh.GameServer.Types.UserData;
 
 namespace Refresh.GameServer.Types.Reviews;
 
@@ -16,7 +13,7 @@ public class SerializedGameReview : IDataConvertableFrom<SerializedGameReview, G
     public int Id { get; set; }
     
     [XmlElement("slot_id")]
-    public GameReviewSlot Slot { get; set; }
+    public SerializedReviewSlot Slot { get; set; }
     
     [XmlElement("reviewer")]
     public string Reviewer { get; set; }
@@ -63,7 +60,7 @@ public class SerializedGameReview : IDataConvertableFrom<SerializedGameReview, G
         return new SerializedGameReview
         {
             Id = review.ReviewId,
-            Slot = new GameReviewSlot
+            Slot = new SerializedReviewSlot
             {
                 SlotType = review.Level.SlotType.ToGameType(),
                 SlotId = review.Level.LevelId,
@@ -74,7 +71,7 @@ public class SerializedGameReview : IDataConvertableFrom<SerializedGameReview, G
             Deleted = false,
             DeletedBy = ReviewDeletedBy.None,
             Text = review.Content,
-            Thumb = dataContext.Database.GetRatingByUser(review.Level, review.Publisher)?.ToDPad() ?? 0,
+            Thumb = dataContext.Database.GetLevelRatingByUser(review.Level, review.Publisher)?.ToDPad() ?? 0,
             ThumbsUp = reviewRatings.PositiveRating,
             ThumbsDown = reviewRatings.NegativeRating,
             YourThumb = (int) userRatingType,

--- a/Refresh.GameServer/Types/Reviews/SerializedReviewSlot.cs
+++ b/Refresh.GameServer/Types/Reviews/SerializedReviewSlot.cs
@@ -1,13 +1,12 @@
 using System.Xml.Serialization;
-using Refresh.GameServer.Types.Matching;
 
 namespace Refresh.GameServer.Types.Reviews;
 
 [XmlRoot("slot")]
-public class GameReviewSlot 
+public class SerializedReviewSlot 
 {
     [XmlAttribute("type")]
-    public string SlotType { get; set; }
+    public string SlotType { get; set; } = "user";
 
     [XmlText]
     public int SlotId { get; set; }

--- a/Refresh.GameServer/Types/UserData/SerializedUpdateData.cs
+++ b/Refresh.GameServer/Types/UserData/SerializedUpdateData.cs
@@ -1,5 +1,6 @@
 using System.Xml.Serialization;
 using Realms;
+using Refresh.GameServer.Types.Levels;
 
 namespace Refresh.GameServer.Types.UserData;
 
@@ -16,7 +17,10 @@ public class SerializedUpdateData
     public string? Description { get; set; }
     
     [XmlElement("location")]
-    public GameLocation? Location { get; set; }
+    public GameLocation? UserLocation { get; set; }
+
+    [XmlArray("slots")]
+    public List<SerializedLevelLocation>? LevelLocations { get; set; }
     
     [XmlElement("planets")]
     public string? PlanetsHash { get; set; }

--- a/RefreshTests.GameServer/Tests/Levels/ReviewEndpointsTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ReviewEndpointsTests.cs
@@ -23,8 +23,8 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/dpadrate/user/{level.LevelId}?rating={(sbyte)RatingType.Boo}", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Boo));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Boo));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]
@@ -43,8 +43,8 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/dpadrate/user/{level.LevelId}?rating={(sbyte)RatingType.Neutral}", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Neutral));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Neutral));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]
@@ -63,8 +63,8 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/dpadrate/user/{level.LevelId}?rating={(sbyte)RatingType.Yay}", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Yay));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Yay));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]
@@ -83,14 +83,14 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/dpadrate/user/{level.LevelId}?rating={(sbyte)RatingType.Yay}", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Yay));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Yay));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
         
         message = client.PostAsync($"/lbp/dpadrate/user/{level.LevelId}?rating={(sbyte)RatingType.Neutral}", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Neutral));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Neutral));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]
@@ -140,8 +140,8 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/rate/user/{level.LevelId}?rating=1", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Boo));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Boo));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]
@@ -160,8 +160,8 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/rate/user/{level.LevelId}?rating=2", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Boo));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Boo));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]
@@ -180,8 +180,8 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/rate/user/{level.LevelId}?rating=3", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Neutral));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Neutral));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]
@@ -200,8 +200,8 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/rate/user/{level.LevelId}?rating=4", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Yay));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Yay));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]
@@ -220,8 +220,8 @@ public class ReviewEndpointsTests : GameServerTest
         HttpResponseMessage message = client.PostAsync($"/lbp/rate/user/{level.LevelId}?rating=5", new ByteArrayContent(Array.Empty<byte>())).Result;
         Assert.That(message.StatusCode, Is.EqualTo(OK));
         context.Database.Refresh();
-        Assert.That(context.Database.GetRatingByUser(level, user1), Is.EqualTo(RatingType.Yay));
-        Assert.That(context.Database.GetRatingByUser(level, user2), Is.EqualTo(null));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user1), Is.EqualTo(RatingType.Yay));
+        Assert.That(context.Database.GetLevelRatingByUser(level, user2), Is.EqualTo(null));
     } 
     
     [Test]


### PR DESCRIPTION
This PR contains multiple, mostly game-related fixes and features, those being:
- Track whether a level requires a move controller to play
- Include a level's LevelType in GameMinimalLevelResponse (which I renamed to SerializedMinimalLevelResponse for consistency) to fix that bug where versus/cutscene levels only show their badges under certain circumstances
- Sort queued levels, hearted levels and hearted users by recency, a user's levels by most recently updated (to help expose new content and make setting up level links a lot easier), a user's reviews by newest and reviews for a level by ratio (most liked to most disliked)
- Show photos taken in a level under that level (also those by a certain user if specified)
- Include your own review in GameLevelResponse, this lets the game replace the "Write your own review!" button with your review in a seperate area, aswell as auto-completes your review if you go edit it
- The ability to update your levels' locations while decorating your planets
- The ability to comment under levels which dont have a publisher set (story levels for example)
- Renamed some other classes and methods for consistency and fixed/supressed a few warnings
- Some minor optimizations