### PR TITLE
Fix being unable to comment under publisherless levels

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/CommentEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/CommentEndpoints.cs
@@ -88,7 +88,7 @@ public class CommentEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
 
-        if (!level.Publisher.Equals(user)) 
+        if (level.Publisher != null && !level.Publisher.Equals(user)) 
         {
             database.AddNotification("New comment", $"{user.Username} left a comment on your level: '{level.Title}!'", level.Publisher);
         }


### PR DESCRIPTION
This lets users comment under levels without a publisher, like story levels, while also conveniently fixing a warning.