### PR TITLE
Move controller requirement tracking

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -34,7 +34,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 162;
+    protected override ulong SchemaVersion => 163;
 
     protected override string Filename => "refreshGameServer.realm";
     
@@ -242,7 +242,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         IQueryable<dynamic>? oldLevels = migration.OldRealm.DynamicApi.All("GameLevel");
         IQueryable<GameLevel>? newLevels = migration.NewRealm.All<GameLevel>();
 
-        if (oldVersion < 149)
+        if (oldVersion < 163)
             for (int i = 0; i < newLevels.Count(); i++)
             {
                 dynamic oldLevel = oldLevels.ElementAt(i);
@@ -353,6 +353,13 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
                 if (oldVersion >= 148 && oldVersion < 149)
                 {
                     newLevel.IsModded = oldLevel.Modded;
+                }
+
+                // From version 163 on, the move controller requirement of levels gets saved.
+                // There is no way to know which of the already uploaded levels require one, unless they get manually updated in-game.
+                if (oldVersion < 163)
+                {
+                    newLevel.RequiresMoveController = false;
                 }
             }
 

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Request/GameLevelRequest.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Request/GameLevelRequest.cs
@@ -45,6 +45,7 @@ public class GameLevelRequest
     [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
     [XmlElement("isSubLevel")] public bool IsSubLevel { get; set; }
     [XmlElement("shareable")] public int IsCopyable { get; set; }
+    [XmlElement("moveRequired")] public bool RequiresMoveController { get; set; }
     
     [XmlElement("backgroundGUID")] public string? BackgroundGuid { get; set; }
     
@@ -73,6 +74,7 @@ public class GameLevelRequest
             IsLocked = this.IsLocked,
             IsSubLevel = this.IsSubLevel,
             IsCopyable = this.IsCopyable == 1,
+            RequiresMoveController = this.RequiresMoveController,
             BackgroundGuid = this.BackgroundGuid,
         };
 }

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -72,6 +72,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
     [XmlElement("isSubLevel")] public bool IsSubLevel { get; set; }
     [XmlElement("shareable")] public int IsCopyable { get; set; }
+    [XmlElement("moveRequired")] public bool RequiresMoveController { get; set; }
     [XmlElement("backgroundGUID")] public string? BackgroundGuid { get; set; }
     [XmlElement("links")] public string? Links { get; set; }
     [XmlElement("averageRating")] public double AverageStarRating { get; set; }
@@ -134,6 +135,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             IsLocked = false,
             IsSubLevel = false,
             IsCopyable = 0,
+            RequiresMoveController = false,
             PublishDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             UpdateDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             EnforceMinMaxPlayers = false,
@@ -175,6 +177,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             IsCopyable = old.IsCopyable ? 1 : 0,
             IsLocked = old.IsLocked,
             IsSubLevel = old.IsSubLevel,
+            RequiresMoveController = old.RequiresMoveController,
             BackgroundGuid = old.BackgroundGuid,
             Links = "",
             AverageStarRating = old.CalculateAverageStarRating(dataContext.Database),
@@ -284,6 +287,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             IsLocked = false,
             IsSubLevel = false,
             IsCopyable = 0,
+            RequiresMoveController = false,
             BackgroundGuid = null,
             Links = null,
             AverageStarRating = 0,

--- a/Refresh.GameServer/Types/Levels/GameLevel.cs
+++ b/Refresh.GameServer/Types/Levels/GameLevel.cs
@@ -2,12 +2,9 @@ using System.Xml.Serialization;
 using Realms;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Database;
-using Refresh.GameServer.Types.Comments;
 using Refresh.GameServer.Types.UserData;
 using Refresh.GameServer.Types.Levels.SkillRewards;
-using Refresh.GameServer.Types.Relations;
 using Refresh.GameServer.Types.Reviews;
-using Refresh.GameServer.Types.UserData.Leaderboard;
 using Refresh.GameServer.Workers;
 
 namespace Refresh.GameServer.Types.Levels;
@@ -88,6 +85,7 @@ public partial class GameLevel : IRealmObject, ISequentialId
     public bool IsLocked { get; set; }
     public bool IsSubLevel { get; set; }
     public bool IsCopyable { get; set; }
+    public bool RequiresMoveController { get; set; }
     
     /// <summary>
     /// The score, used for Cool Levels.

--- a/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.GameServer/Types/Levels/GameMinimalLevelResponse.cs
@@ -45,6 +45,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
     [XmlElement("isSubLevel")] public bool IsSubLevel { get; set; }
     [XmlElement("shareable")] public int IsCopyable { get; set; }
+    [XmlElement("moveRequired")] public bool RequiresMoveController { get; set; }
     [XmlElement("tags")] public string Tags { get; set; } = "";
  
     private GameMinimalLevelResponse() {}
@@ -98,6 +99,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
             IsLocked = level.IsLocked,
             IsSubLevel = level.IsSubLevel,
             IsCopyable = level.IsCopyable,
+            RequiresMoveController = level.RequiresMoveController,
             PlayerCount = dataContext.Match.GetPlayerCountForLevel(RoomSlotType.Online, level.LevelId),
             Tags = level.Tags,
         };
@@ -138,6 +140,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
             IsLocked = false,
             IsSubLevel = false,
             IsCopyable = 0,
+            RequiresMoveController = false,
             Tags = string.Empty, 
             TeamPicked = false, 
             Handle = SerializedUserHandle.FromUser(old.Publisher, dataContext),


### PR DESCRIPTION
This implements getting, saving and returning to the game whether a level "requires" a move controller to play, closing issue #680 