### PR TITLE
Include user's own review in GameLevelResponse, update level rating alongside review

### DIFF
--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -78,6 +78,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlElement("sizeOfResources")] public int SizeOfResourcesInBytes { get; set; }
     [XmlElement("reviewCount")] public int ReviewCount { get; set; }
     [XmlElement("reviewsEnabled")] public bool ReviewsEnabled { get; set; } = true;
+    [XmlElement("yourReview")] public SerializedGameReview? YourReview { get; set; }
     [XmlElement("commentCount")] public int CommentCount { get; set; } = 0;
     [XmlElement("commentsEnabled")] public bool CommentsEnabled { get; set; } = true;
     [XmlElement("tags")] public string Tags { get; set; } = "";
@@ -211,6 +212,8 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
 
             response.YourRating = rating?.ToDPad() ?? (int)RatingType.Neutral;
             response.YourStarRating = rating?.ToLBP1() ?? 0;
+            
+            response.YourReview = SerializedGameReview.FromOld(dataContext.Database.GetReviewByLevelAndUser(old, dataContext.User), dataContext);
 
             // this is technically invalid, but specifying this for all games ensures they all have the capacity to review if played.
             // we don't store the game's version in play relations, so this is the best we can do

--- a/Refresh.GameServer/Endpoints/Game/ReviewEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/ReviewEndpoints.cs
@@ -124,6 +124,9 @@ public class ReviewEndpoints : EndpointGroup
             Content = body.Text,
         }, level);
 
+        // Update the user's rating
+        database.RateLevel(level, user, (RatingType)body.Thumb);
+
         return OK;
     }
     


### PR DESCRIPTION
Include the user's review in GameLevelResponse to let the game be able to autofill the user's review if they go edit it. This PR also implements updating the user's level rating when they upload/update their review.