### PR TITLE
Level and user sorting improvements

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Levels.cs
@@ -205,23 +205,35 @@ public partial class GameDatabaseContext // Levels
     [Pure]
     public DatabaseList<GameLevel> GetLevelsByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor)
     {
+        IEnumerable<GameLevel> levels;
+
         if (user.Username == SystemUsers.DeletedUserName)
         {
-            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.Publisher == null), skip, count);
+            levels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+                .FilterByLevelFilterSettings(accessor, levelFilterSettings)
+                .Where(l => l.Publisher == null);
         }
-
-        if (user.Username == SystemUsers.UnknownUserName)
+        else if (user.Username == SystemUsers.UnknownUserName)
         {
-            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(null, levelFilterSettings).Where(l => l.IsReUpload && string.IsNullOrEmpty(l.OriginalPublisher)), skip, count);
+            levels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+                .FilterByLevelFilterSettings(null, levelFilterSettings)
+                .Where(l => l.IsReUpload && string.IsNullOrEmpty(l.OriginalPublisher));
         }
-        
-        if (user.Username.StartsWith(SystemUsers.SystemPrefix))
+        else if (user.Username.StartsWith(SystemUsers.SystemPrefix))
         {
             string withoutPrefix = user.Username[1..];
-            return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.OriginalPublisher == withoutPrefix), skip, count);
+            levels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+                .FilterByLevelFilterSettings(accessor, levelFilterSettings)
+                .Where(l => l.OriginalPublisher == withoutPrefix);
+        }
+        else
+        {
+            levels = this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
+                .FilterByLevelFilterSettings(accessor, levelFilterSettings)
+                .Where(l => l.Publisher == user);
         }
         
-        return new DatabaseList<GameLevel>(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion).FilterByLevelFilterSettings(accessor, levelFilterSettings).Where(l => l.Publisher == user), skip, count);
+        return new(levels.OrderByDescending(l => l.UpdateDate), skip, count);
     }
     
     public int GetTotalLevelsByUser(GameUser user) => this.GameLevels.Count(l => l.Publisher == user);

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -23,11 +23,11 @@ public partial class GameDatabaseContext // Relations
     public DatabaseList<GameLevel> GetLevelsFavouritedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor) 
         => new(this.FavouriteLevelRelations
         .Where(r => r.User == user)
+        .OrderByDescending(r => r.Timestamp)
         .AsEnumerable()
         .Select(r => r.Level)
         .FilterByLevelFilterSettings(accessor, levelFilterSettings)
-        .FilterByGameVersion(levelFilterSettings.GameVersion)
-        .OrderByDescending(l => l.PublishDate), skip, count);
+        .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     
     public int GetTotalLevelsFavouritedByUser(GameUser user) 
         => this.FavouriteLevelRelations
@@ -88,6 +88,7 @@ public partial class GameDatabaseContext // Relations
     [Pure]
     public IEnumerable<GameUser> GetUsersFavouritedByUser(GameUser user, int count, int skip) => this.FavouriteUserRelations
         .Where(r => r.UserFavouriting == user)
+        .OrderByDescending(r => r.Timestamp)
         .AsEnumerable()
         .Select(r => r.UserToFavourite)
         .Skip(skip)
@@ -152,11 +153,11 @@ public partial class GameDatabaseContext // Relations
     public DatabaseList<GameLevel> GetLevelsQueuedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor)
         => new(this.QueueLevelRelations
         .Where(r => r.User == user)
+        .OrderByDescending(r => r.Timestamp)
         .AsEnumerable()
         .Select(r => r.Level)
         .FilterByLevelFilterSettings(accessor, levelFilterSettings)
-        .FilterByGameVersion(levelFilterSettings.GameVersion)
-        .OrderByDescending(l => l.PublishDate), skip, count);
+        .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     
     [Pure]
     public int GetTotalLevelsQueuedByUser(GameUser user) 

--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -41,6 +41,7 @@ public partial class GameDatabaseContext // Relations
         {
             Level = level,
             User = user,
+            Timestamp = this._time.Now,
         };
         this.Write(() => this.FavouriteLevelRelations.Add(relation));
 
@@ -108,6 +109,7 @@ public partial class GameDatabaseContext // Relations
         {
             UserToFavourite = userToFavourite,
             UserFavouriting = userFavouriting,
+            Timestamp = this._time.Now,
         };
         
         this.Write(() => this.FavouriteUserRelations.Add(relation));
@@ -169,6 +171,7 @@ public partial class GameDatabaseContext // Relations
         {
             Level = level,
             User = user,
+            Timestamp = this._time.Now,
         };
         this.Write(() => this.QueueLevelRelations.Add(relation));
 
@@ -213,7 +216,10 @@ public partial class GameDatabaseContext // Relations
         {
             RateReviewRelation relation = this.RateReviewRelations.First(r => r.Review == review && r.User == user);
             
-            this.Write(() => relation.RatingType = ratingType);
+            this.Write(() => {
+                relation.RatingType = ratingType;
+                relation.Timestamp = this._time.Now;
+            });
 
             return;
         }
@@ -223,6 +229,7 @@ public partial class GameDatabaseContext // Relations
             RatingType = ratingType,
             Review = review,
             User = user,
+            Timestamp = this._time.Now,
         };
 
         this.Write(() =>
@@ -528,6 +535,7 @@ public partial class GameDatabaseContext // Relations
                 Tag = tag,
                 User = user,
                 Level = level,
+                Timestamp = this._time.Now,
             });
         });
     }

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -34,7 +34,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 163;
+    protected override ulong SchemaVersion => 164;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -34,7 +34,7 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         this._time = time;
     }
 
-    protected override ulong SchemaVersion => 162;
+    protected override ulong SchemaVersion => 163;
 
     protected override string Filename => "refreshGameServer.realm";
     

--- a/Refresh.GameServer/Types/Relations/FavouriteLevelRelation.cs
+++ b/Refresh.GameServer/Types/Relations/FavouriteLevelRelation.cs
@@ -9,4 +9,5 @@ public partial class FavouriteLevelRelation : IRealmObject
 {
     public GameLevel Level { get; set; }
     public GameUser User { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Relations/FavouriteUserRelation.cs
+++ b/Refresh.GameServer/Types/Relations/FavouriteUserRelation.cs
@@ -8,4 +8,5 @@ public partial class FavouriteUserRelation : IRealmObject
 {
     public GameUser UserToFavourite { get; set; }
     public GameUser UserFavouriting { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Relations/QueueLevelRelation.cs
+++ b/Refresh.GameServer/Types/Relations/QueueLevelRelation.cs
@@ -10,4 +10,5 @@ public partial class QueueLevelRelation : IRealmObject
 {
     public GameLevel Level { get; set; }
     public GameUser User { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Relations/RateReviewRelation.cs
+++ b/Refresh.GameServer/Types/Relations/RateReviewRelation.cs
@@ -20,4 +20,5 @@ public partial class RateReviewRelation : IRealmObject
     
     // for the purposes of checking if a positive/negative rating on a review has already been submitted by the user
     public GameUser User { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.GameServer/Types/Relations/TagLevelRelation.cs
+++ b/Refresh.GameServer/Types/Relations/TagLevelRelation.cs
@@ -17,4 +17,5 @@ public partial class TagLevelRelation : IRealmObject
     
     public GameUser User { get; set; }
     public GameLevel Level { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
 }


### PR DESCRIPTION
This one adds timestamps to certain relations to then use some of them to sort hearted levels, queued levels and hearted users by newest first. Also took the opportunity to have levels by users get sorted by most recently updated first. 