### PR TITLE
Show photos taken in levels

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Photos.cs
@@ -108,12 +108,22 @@ public partial class GameDatabaseContext // Photos
             .Count(p => p.Subjects.FirstOrDefault(s => Equals(s.User, user)) != null);
 
     [Pure]
-    public DatabaseList<GamePhoto> GetPhotosInLevel(GameLevel level, int count, int skip) =>
-        new(this.GamePhotos.Where(p => p.LevelId == level.LevelId), skip, count);
+    public DatabaseList<GamePhoto> GetPhotosInLevel(GameLevel level, int count, int skip)
+        => new(this.GamePhotos
+            .Where(p => p.Level == level)
+            .OrderByDescending(p => p.TakenAt), skip, count);
     
     [Pure]
     public int GetTotalPhotosInLevel(GameLevel level)
-        => this.GamePhotos.Count(p => p.LevelId == level.LevelId);
+        => this.GamePhotos.Count(p => p.Level == level);
+
+    public DatabaseList<GamePhoto> GetPhotosInLevelByUser(GameLevel level, GameUser user, int count, int skip) 
+        => new(this.GamePhotos
+            .Where(p => p.Level == level && p.Publisher == user)
+            .OrderByDescending(p => p.TakenAt), skip, count);
+
+    public int GetTotalPhotosInLevelByUser(GameLevel level, GameUser user)
+        => this.GamePhotos.Count(p => p.Level == level && p.Publisher == user);
     
     public void DeletePhotosPostedByUser(GameUser user)
     {

--- a/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.GameServer/Endpoints/Game/DataTypes/Response/GameLevelResponse.cs
@@ -80,6 +80,8 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlElement("reviewsEnabled")] public bool ReviewsEnabled { get; set; } = true;
     [XmlElement("commentCount")] public int CommentCount { get; set; } = 0;
     [XmlElement("commentsEnabled")] public bool CommentsEnabled { get; set; } = true;
+    [XmlElement("photoCount")] public int PhotoCount { get; set; }
+    [XmlElement("authorPhotoCount")] public int PublisherPhotoCount { get; set; }
     [XmlElement("tags")] public string Tags { get; set; } = "";
     
     /// <summary>
@@ -131,6 +133,8 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             ReviewCount = 0,
             CommentsEnabled = false,
             CommentCount = 0,
+            PhotoCount = 0,
+            PublisherPhotoCount = 0,
             IsLocked = false,
             IsSubLevel = false,
             IsCopyable = 0,
@@ -180,6 +184,8 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             AverageStarRating = old.CalculateAverageStarRating(dataContext.Database),
             ReviewCount = old.Reviews.Count,
             CommentCount = dataContext.Database.GetTotalCommentsForLevel(old),
+            PhotoCount = dataContext.Database.GetTotalPhotosInLevel(old),
+            PublisherPhotoCount = old.Publisher == null ? 0 : dataContext.Database.GetTotalPhotosInLevelByUser(old, old.Publisher),
             Tags = string.Join(',', dataContext.Database.GetTagsForLevel(old).Select(t => t.Tag.ToLbpString())) ,
             Type = old.SlotType.ToGameType(),
         };
@@ -292,6 +298,8 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             ReviewsEnabled = true,
             CommentCount = 0,
             CommentsEnabled = true,
+            PhotoCount = 0,
+            PublisherPhotoCount = 0,
             Tags = string.Empty,
         };
     }

--- a/Refresh.GameServer/Endpoints/Game/PhotoEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/PhotoEndpoints.cs
@@ -96,19 +96,27 @@ public class PhotoEndpoints : EndpointGroup
         => GetPhotos(context, database, dataContext, database.GetPhotosByUser);
 
     [GameEndpoint("photos/{slotType}/{levelId}", ContentType.Xml)]
-    public Response GetPhotosOnLevel(RequestContext context, DataContext dataContext, string slotType, int levelId)
+    public SerializedPhotoList? GetPhotosOnLevel(RequestContext context, DataContext dataContext, string slotType, int levelId)
     {
         GameLevel? level = dataContext.Database.GetLevelByIdAndType(slotType, levelId);
-        if (level == null)
-            return NotFound;
-        
+        if (level == null) 
+            return null;
+
         (int skip, int count) = context.GetPageData();
+        
+        // if the game specifies whose photos to get which are uploaded for this level
+        string? username = context.QueryString.Get("by");
+        GameUser? user = dataContext.Database.GetUserByUsername(username);
+        
+        DatabaseList<GamePhoto> photos;
+        
+        if (user != null)
+            photos = dataContext.Database.GetPhotosInLevelByUser(level, user, count, skip);
+        else
+            photos = dataContext.Database.GetPhotosInLevel(level, count, skip);
 
         // count not used ingame
-        IEnumerable<SerializedPhoto> photos = dataContext.Database.GetPhotosInLevel(level, count, skip).Items
-            .Select(photo => SerializedPhoto.FromGamePhoto(photo, dataContext));
-
-        return new Response(new SerializedPhotoList(photos), ContentType.Xml);
+        return new SerializedPhotoList(photos.Items.Select(photo => SerializedPhoto.FromGamePhoto(photo, dataContext)));
     }
 
     [GameEndpoint("photo/{id}", ContentType.Xml)]


### PR DESCRIPTION
In-game, show all photos taken in a level aswell as photos taken by the level publisher. These photos get sorted by most recently taken first; and instead of comparing level IDs to get them, compare their level references instead to prevent photos from showing under levels they were not taken in.