### PR TITLE
Add solution configuration for Postgres implementation development

### DIFF
--- a/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.Relations.cs
@@ -493,7 +493,13 @@ public partial class GameDatabaseContext // Relations
     public int GetTotalRatingsForLevelComment(GameLevelComment comment, RatingType type) =>
         this.LevelCommentRelations.Count(r => r.Comment == comment && r._RatingType == (int)type);
 
-    private bool RateComment<TComment, TCommentRelation>(GameUser user, TComment comment, RatingType ratingType, RealmDbSet<TCommentRelation> list)
+    private bool RateComment<TComment, TCommentRelation>(GameUser user, TComment comment, RatingType ratingType,
+        #if !POSTGRES
+        RealmDbSet<TCommentRelation> list
+        #else
+        DbSet<TCommentRelation> list
+        #endif
+        )
         where TComment : class, IGameComment
         where TCommentRelation : class, ICommentRelation<TComment>, new()
     {

--- a/Refresh.GameServer/Database/GameDatabaseContext.cs
+++ b/Refresh.GameServer/Database/GameDatabaseContext.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using Realms;
-using Bunkum.RealmDatabase;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Time;
 using Refresh.GameServer.Types;
@@ -22,12 +20,18 @@ using Refresh.GameServer.Types.UserData.Leaderboard;
 namespace Refresh.GameServer.Database;
 
 [SuppressMessage("ReSharper", "InconsistentlySynchronizedField")]
-public partial class GameDatabaseContext : RealmDatabaseContext
+public partial class GameDatabaseContext :
+    #if !POSTGRES
+    RealmDatabaseContext
+    #else
+    DbContext, IDatabaseContext
+    #endif
 {
     private static readonly object IdLock = new();
 
     private readonly IDateTimeProvider _time;
     
+    #if !POSTGRES
     private RealmDbSet<GameUser> GameUsers => new(this._realm);
     private RealmDbSet<Token> Tokens => new(this._realm);
     private RealmDbSet<GameLevel> GameLevels => new(this._realm);
@@ -63,6 +67,43 @@ public partial class GameDatabaseContext : RealmDatabaseContext
     private RealmDbSet<SubPlaylistRelation> SubPlaylistRelations => new(this._realm);
     private RealmDbSet<FavouritePlaylistRelation> FavouritePlaylistRelations => new(this._realm);
     private RealmDbSet<GameUserVerifiedIpRelation> GameUserVerifiedIpRelations => new(this._realm);
+    #else
+    private DbSet<GameUser> GameUsers { get; set; }
+    private DbSet<Token> Tokens { get; set; }
+    private DbSet<GameLevel> GameLevels { get; set; }
+    private DbSet<GameProfileComment> GameProfileComments { get; set; }
+    private DbSet<GameLevelComment> GameLevelComments { get; set; }
+    private DbSet<ProfileCommentRelation> ProfileCommentRelations { get; set; }
+    private DbSet<LevelCommentRelation> LevelCommentRelations { get; set; }
+    private DbSet<FavouriteLevelRelation> FavouriteLevelRelations { get; set; }
+    private DbSet<QueueLevelRelation> QueueLevelRelations { get; set; }
+    private DbSet<FavouriteUserRelation> FavouriteUserRelations { get; set; }
+    private DbSet<PlayLevelRelation> PlayLevelRelations { get; set; }
+    private DbSet<UniquePlayLevelRelation> UniquePlayLevelRelations { get; set; }
+    private DbSet<RateLevelRelation> RateLevelRelations { get; set; }
+    private DbSet<Event> Events { get; set; }
+    private DbSet<GameSubmittedScore> GameSubmittedScores { get; set; }
+    private DbSet<GameAsset> GameAssets { get; set; }
+    private DbSet<GameNotification> GameNotifications { get; set; }
+    private DbSet<GamePhoto> GamePhotos { get; set; }
+    private DbSet<GameIpVerificationRequest> GameIpVerificationRequests { get; set; }
+    private DbSet<GameAnnouncement> GameAnnouncements { get; set; }
+    private DbSet<QueuedRegistration> QueuedRegistrations { get; set; }
+    private DbSet<EmailVerificationCode> EmailVerificationCodes { get; set; }
+    private DbSet<RequestStatistics> RequestStatistics { get; set; }
+    private DbSet<SequentialIdStorage> SequentialIdStorage { get; set; }
+    private DbSet<GameContest> GameContests { get; set; }
+    private DbSet<AssetDependencyRelation> AssetDependencyRelations { get; set; }
+    private DbSet<GameReview> GameReviews { get; set; }
+    private DbSet<DisallowedUser> DisallowedUsers { get; set; }
+    private DbSet<RateReviewRelation> RateReviewRelations { get; set; }
+    private DbSet<TagLevelRelation> TagLevelRelations { get; set; }
+    private DbSet<GamePlaylist> GamePlaylists { get; set; }
+    private DbSet<LevelPlaylistRelation> LevelPlaylistRelations { get; set; }
+    private DbSet<SubPlaylistRelation> SubPlaylistRelations { get; set; }
+    private DbSet<FavouritePlaylistRelation> FavouritePlaylistRelations { get; set; }
+    private DbSet<GameUserVerifiedIpRelation> GameUserVerifiedIpRelations { get; set; }
+    #endif
     
     internal GameDatabaseContext(IDateTimeProvider time)
     {
@@ -136,6 +177,7 @@ public partial class GameDatabaseContext : RealmDatabaseContext
     private void AddSequentialObject<T>(T obj) where T : IRealmObject, ISequentialId 
         => this.AddSequentialObject(obj, null, null);
 
+    #if !POSTGRES
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void Write(Action callback)
     {
@@ -149,9 +191,24 @@ public partial class GameDatabaseContext : RealmDatabaseContext
         
         this._realm.Write(callback);
     }
+    #else
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Write(Action callback)
+    {
+        callback();
+        this.SaveChanges();
+    }
+    #endif
 
+    #if !POSTGRES
     private void RemoveAll<T>() where T : IRealmObject
     {
         this._realm.RemoveAll<T>();
     }
+    #else
+    private void RemoveAll<TClass>() where TClass : class
+    {
+        this.RemoveRange(this.Set<TClass>());
+    }
+    #endif
 }

--- a/Refresh.GameServer/Database/GameDatabaseProvider.cs
+++ b/Refresh.GameServer/Database/GameDatabaseProvider.cs
@@ -1,10 +1,8 @@
-using Realms;
 using Refresh.GameServer.Authentication;
 using Refresh.GameServer.Types;
 using Refresh.GameServer.Types.Comments;
 using Refresh.GameServer.Types.Levels;
 using Refresh.GameServer.Types.UserData;
-using Bunkum.RealmDatabase;
 using Refresh.GameServer.Time;
 using Refresh.GameServer.Types.Activity;
 using Refresh.GameServer.Types.Assets;
@@ -18,9 +16,18 @@ using Refresh.GameServer.Types.UserData.Leaderboard;
 using Refresh.GameServer.Types.Photos;
 using Refresh.GameServer.Types.Playlists;
 
+#if !POSTGRES
+using Bunkum.RealmDatabase;
+#endif
+
 namespace Refresh.GameServer.Database;
 
-public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
+public class GameDatabaseProvider : 
+#if !POSTGRES
+    RealmDatabaseProvider<GameDatabaseContext>
+#else
+    IDatabaseProvider<GameDatabaseContext>
+#endif
 {
     private readonly IDateTimeProvider _time;
     
@@ -33,7 +40,16 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
     {
         this._time = time;
     }
+    
+    #if POSTGRES
+    public void Initialize()
+    {
+        using GameDatabaseContext context = this.GetContext();
+        context.Database.Migrate();
+    }
+    #endif
 
+    #if !POSTGRES
     protected override ulong SchemaVersion => 164;
 
     protected override string Filename => "refreshGameServer.realm";
@@ -89,18 +105,28 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         typeof(SubPlaylistRelation),
         typeof(FavouritePlaylistRelation),
     ];
+    #endif
 
+    #if POSTGRES
+    public void Warmup()
+    #else
     public override void Warmup()
+    #endif
     {
         using GameDatabaseContext context = this.GetContext();
         _ = context.GetTotalLevelCount();
     }
 
+    #if POSTGRES
+    public GameDatabaseContext GetContext()
+    #else
     protected override GameDatabaseContext CreateContext()
+    #endif
     {
         return new GameDatabaseContext(this._time);
     }
 
+    #if !POSTGRES
     protected override void Migrate(Migration migration, ulong oldVersion)
     {
         IQueryable<dynamic>? oldUsers = migration.OldRealm.DynamicApi.All("GameUser");
@@ -718,5 +744,11 @@ public class GameDatabaseProvider : RealmDatabaseProvider<GameDatabaseContext>
         //         dynamic oldSubPlaylistRelation = oldSubPlaylistRelations.ElementAt(i);
         //         SubPlaylistRelation newSubPlaylistRelation = newSubPlaylistRelations.ElementAt(i);
         //     }
+    }
+    #endif
+    
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
     }
 }

--- a/Refresh.GameServer/Database/RealmDbSet.cs
+++ b/Refresh.GameServer/Database/RealmDbSet.cs
@@ -1,7 +1,8 @@
+#if !POSTGRES
+
 using System.Collections;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Realms;
 
 namespace Refresh.GameServer.Database;
 
@@ -55,3 +56,5 @@ public class RealmDbSet<T> : IQueryable<T> where T : IRealmObject
         this._realm.RemoveRange(this._realm.All<T>().Where(predicate));
     }
 }
+
+#endif

--- a/Refresh.GameServer/Extensions/DbSetExtensions.cs
+++ b/Refresh.GameServer/Extensions/DbSetExtensions.cs
@@ -1,0 +1,22 @@
+﻿#if POSTGRES
+using Microsoft.EntityFrameworkCore;
+
+namespace Refresh.GameServer.Extensions;
+
+
+public static class DbSetExtensions
+{
+    public static void RemoveRange<TClass>(this DbSet<TClass> set, Func<TClass, bool> predicate) where TClass : class
+    {
+        set.RemoveRange(set.Where(predicate));
+    }
+    
+    [Obsolete("Remove update parameter when postgres is removed")]
+    public static void AddRange<TClass>(this DbSet<TClass> set, IEnumerable<TClass> range, bool update) where TClass : class
+    {
+        set.AddRange(range);
+        _ = update;
+    }
+}
+
+#endif

--- a/Refresh.GameServer/Extensions/RealmObjectExtensions.cs
+++ b/Refresh.GameServer/Extensions/RealmObjectExtensions.cs
@@ -1,8 +1,10 @@
+#if !POSTGRES
 using System.Diagnostics;
 using System.Reflection;
 using Realms;
 
 namespace Refresh.GameServer.Extensions;
+
 
 public static class RealmObjectExtensions
 {
@@ -32,3 +34,5 @@ public static class RealmObjectExtensions
         return clone;
     }
 }
+
+#endif

--- a/Refresh.GameServer/GlobalUsings.cs
+++ b/Refresh.GameServer/GlobalUsings.cs
@@ -3,3 +3,15 @@
 global using static System.Net.HttpStatusCode;
 global using Newtonsoft.Json;
 global using Newtonsoft.Json.Serialization;
+
+global using Refresh.GameServer.Extensions;
+
+#if !POSTGRES
+global using Realms;
+global using Bunkum.RealmDatabase;
+#endif
+
+#if POSTGRES
+global using Bunkum.Core.Database;
+global using Microsoft.EntityFrameworkCore;
+#endif

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Configurations>Debug;Release;DebugLocalBunkum</Configurations>
+        <Configurations>Debug;Release;DebugLocalBunkum;DebugPostgres</Configurations>
         <Platforms>AnyCPU</Platforms>
         <ServerGarbageCollection>true</ServerGarbageCollection>
     </PropertyGroup>
@@ -12,6 +12,11 @@
     <PropertyGroup Condition=" '$(Configuration)' == 'DebugLocalBunkum' ">
       <DefineConstants>TRACE;DEBUG</DefineConstants>
       <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'DebugPostgres' ">
+        <DefineConstants>TRACE;DEBUG;POSTGRES</DefineConstants>
+        <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
 
     <ItemGroup>
@@ -53,10 +58,8 @@
 
     <ItemGroup Condition="'$(Configuration)'!='DebugLocalBunkum'">
         <PackageReference Include="Bunkum" Version="4.8.1" />
-        <PackageReference Include="Bunkum.RealmDatabase" Version="4.8.1" />
         <PackageReference Include="Bunkum.AutoDiscover" Version="4.8.1" />
         <PackageReference Include="Bunkum.HealthChecks" Version="4.8.1" />
-        <PackageReference Include="Bunkum.HealthChecks.RealmDatabase" Version="4.8.1" />
         <PackageReference Include="Bunkum.Protocols.Http" Version="4.8.1" />
     </ItemGroup>
 
@@ -70,10 +73,24 @@
       <PackageReference Include="MailKit" Version="4.11.0" />
       <PackageReference Include="NPTicket" Version="3.1.1" />
       <PackageReference Include="Pfim" Version="0.11.3" />
-      <PackageReference Include="Realm" Version="20.1.0" />
       <PackageReference Include="SharpZipLib" Version="1.4.2" />
       <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
       <PackageReference Include="EasyHotReload" Version="1.0.0" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="'$(Configuration)'!='DebugPostgres'">
+        <PackageReference Include="Bunkum.RealmDatabase" Version="4.8.1" />
+        <PackageReference Include="Bunkum.HealthChecks.RealmDatabase" Version="4.8.1" />
+        <PackageReference Include="Realm" Version="20.1.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)'=='DebugPostgres'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.GameServer/Refresh.GameServer.csproj
+++ b/Refresh.GameServer/Refresh.GameServer.csproj
@@ -91,6 +91,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="MongoDB.Bson" Version="3.2.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresh.sln
+++ b/Refresh.sln
@@ -18,6 +18,7 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 		DebugLocalBunkum|Any CPU = DebugLocalBunkum|Any CPU
+		DebugPostgres|Any CPU = DebugPostgres|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -29,30 +30,40 @@ Global
 		{622EB919-5FD2-45FE-B006-4EE5C7849FDF}.DebugLocalBunkum|Any CPU.Build.0 = DebugLocalBunkum|Any CPU
 		{622EB919-5FD2-45FE-B006-4EE5C7849FDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{622EB919-5FD2-45FE-B006-4EE5C7849FDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{622EB919-5FD2-45FE-B006-4EE5C7849FDF}.DebugPostgres|Any CPU.ActiveCfg = DebugPostgres|Any CPU
+		{622EB919-5FD2-45FE-B006-4EE5C7849FDF}.DebugPostgres|Any CPU.Build.0 = DebugPostgres|Any CPU
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.DebugLocalBunkum|Any CPU.ActiveCfg = DebugLocalBunkum|Any CPU
 		{8DC15128-D9C9-498B-AD3B-537C50966C91}.DebugLocalBunkum|Any CPU.Build.0 = DebugLocalBunkum|Any CPU
+		{8DC15128-D9C9-498B-AD3B-537C50966C91}.DebugPostgres|Any CPU.ActiveCfg = DebugPostgres|Any CPU
+		{8DC15128-D9C9-498B-AD3B-537C50966C91}.DebugPostgres|Any CPU.Build.0 = DebugPostgres|Any CPU
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.DebugLocalBunkum|Any CPU.ActiveCfg = Debug|Any CPU
 		{A3D76B31-8732-4134-907B-F36773DF70D3}.DebugLocalBunkum|Any CPU.Build.0 = Debug|Any CPU
+		{A3D76B31-8732-4134-907B-F36773DF70D3}.DebugPostgres|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3D76B31-8732-4134-907B-F36773DF70D3}.DebugPostgres|Any CPU.Build.0 = Debug|Any CPU
 		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.DebugLocalBunkum|Any CPU.ActiveCfg = Debug|Any CPU
 		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.DebugLocalBunkum|Any CPU.Build.0 = Debug|Any CPU
+		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.DebugPostgres|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E0D28A4-3F63-4C3A-B12C-9AE2823ECE8E}.DebugPostgres|Any CPU.Build.0 = Debug|Any CPU
 		{833B3104-122C-45A6-BCBA-B6ED02A4C82E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{833B3104-122C-45A6-BCBA-B6ED02A4C82E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{833B3104-122C-45A6-BCBA-B6ED02A4C82E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{833B3104-122C-45A6-BCBA-B6ED02A4C82E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{833B3104-122C-45A6-BCBA-B6ED02A4C82E}.DebugLocalBunkum|Any CPU.ActiveCfg = Debug|Any CPU
 		{833B3104-122C-45A6-BCBA-B6ED02A4C82E}.DebugLocalBunkum|Any CPU.Build.0 = Debug|Any CPU
+		{833B3104-122C-45A6-BCBA-B6ED02A4C82E}.DebugPostgres|Any CPU.ActiveCfg = Debug|Any CPU
+		{833B3104-122C-45A6-BCBA-B6ED02A4C82E}.DebugPostgres|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection

--- a/RefreshTests.GameServer/RefreshTests.GameServer.csproj
+++ b/RefreshTests.GameServer/RefreshTests.GameServer.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         
         <IsTestProject>true</IsTestProject>
-        <Configurations>Debug;Release;DebugLocalBunkum</Configurations>
+        <Configurations>Debug;Release;DebugLocalBunkum;DebugPostgres</Configurations>
         <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
 


### PR DESCRIPTION
This introduces a new `DebugPostgres` configuration in the solution to facilitate working on Postgres on the main development branch. The idea is that this can be worked on iteratively, while not having the branch rot like the previous two efforts of working on Postgres.

I also did some work as an example on how Realm and Postgres should co-exist, leveraging ifdefs and `global using`s to prevent too much ifdef spam at the top of files. Unfortunately I do have to duplicate the list of `DbSet`s in `GameDatabaseContext`. I tried defining `DbSet` as `RealmDbSet<T>` to mitigate this but C#'s preprocessor can't handle generics.

## The key component here is that changes on this branch are not required to compile.
That sounds weird I know, but this PR is certainly **not** a full implementation, merely a couple steps in that direction. This is so relatively small PRs can be made. Obviously, changes should make sense but we're not going to have this compiling in one commit.

Most of the current database code seems to compile, with the exclusion being calls to `AddSequentialObject`, and objects that inherit `IRealmObject` (that interface doesn't exist)

Aside from those concerns, this should hopefully be the last attempt to get Postgres kicked off.