### PR TITLE
Properly log user agent when patchwork version is invalid

### DIFF
--- a/.idea/.idea.Refresh/.idea/AndroidProjectSystem.xml
+++ b/.idea/.idea.Refresh/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="RiderAndroidProjectSystem" />
+  </component>
+</project>

--- a/Refresh.GameServer/Endpoints/Game/Handshake/AuthenticationEndpoints.cs
+++ b/Refresh.GameServer/Endpoints/Game/Handshake/AuthenticationEndpoints.cs
@@ -181,7 +181,7 @@ public class AuthenticationEndpoints : EndpointGroup
         if (game != TokenGame.LittleBigPlanetPSP && !context.IsPatchworkVersionValid(config.RequiredPatchworkMajorVersion, config.RequiredPatchworkMinorVersion))
         {
             database.AddLoginFailNotification("The server detected you are not using the latest version of Patchwork. Please update or install it.", user);
-            context.Logger.LogWarning(BunkumCategory.Authentication, $"{ticket.Username}'s Patchwork version is invalid: {context}");
+            context.Logger.LogWarning(BunkumCategory.Authentication, $"{ticket.Username}'s Patchwork version is invalid: {context.RequestHeaders["User-Agent"]}");
             return null;
         }
         


### PR DESCRIPTION
Typo missed in #776 