### PR TITLE
Ability to properly disable dive-in

### DIFF
--- a/Refresh.Core/Configuration/GameServerConfig.cs
+++ b/Refresh.Core/Configuration/GameServerConfig.cs
@@ -10,7 +10,7 @@ namespace Refresh.Core.Configuration;
 [SuppressMessage("ReSharper", "RedundantDefaultMemberInitializer")]
 public class GameServerConfig : Config
 {
-    public override int CurrentConfigVersion => 24;
+    public override int CurrentConfigVersion => 25;
     public override int Version { get; set; } = 0;
     
     protected override void Migrate(int oldVer, dynamic oldConfig)
@@ -121,4 +121,5 @@ public class GameServerConfig : Config
     public string[] HmacDigestKeys = ["CustomServerDigest"];
 
     public bool PermitShowingOnlineUsers { get; set; } = true;
+    public bool EnableDiveIn { get; set; } = true;
 }

--- a/Refresh.Core/Types/Matching/MatchMethods/FindRoomMethod.cs
+++ b/Refresh.Core/Types/Matching/MatchMethods/FindRoomMethod.cs
@@ -12,11 +12,17 @@ namespace Refresh.Core.Types.Matching.MatchMethods;
 
 public class FindRoomMethod : IMatchMethod
 {
-    public IEnumerable<string> MethodNames => new[] { "FindBestRoom" };
+    public IEnumerable<string> MethodNames => ["FindBestRoom"];
 
     public Response Execute(DataContext dataContext, SerializedRoomData body, GameServerConfig gameServerConfig)
     {
         SerializedStatusCodeMatchResponse status = new(OK);
+
+        if (!gameServerConfig.EnableDiveIn)
+        {
+            status.StatusCode = Unauthorized;
+            return new Response(new List<object> {status}, ContentType.Json, status.StatusCode);
+        }
         
         GameRoom? usersRoom = dataContext.Match.RoomAccessor.GetRoomByUser(dataContext.User!, dataContext.Platform, dataContext.Game);
         if (usersRoom == null) return BadRequest; // user should already have a room.

--- a/Refresh.Interfaces.Game/Endpoints/Handshake/MetadataEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Handshake/MetadataEndpoints.cs
@@ -62,15 +62,7 @@ public class MetadataEndpoints : EndpointGroup
     [MinimumRole(GameUserRole.Restricted)]
     public string NetworkSettings(RequestContext context, GameServerConfig config)
     {
-        bool created = NetworkSettingsFile.IsValueCreated;
-        
         string? networkSettings = NetworkSettingsFile.Value;
-        
-        // Only log this warning once
-        if(!created && networkSettings == null)
-            context.Logger.LogWarning(BunkumCategory.Request, "network_settings.nws file is missing! " +
-                                                              "We've defaulted to one with sane defaults, but it may be relevant to write your own if you are an advanced user. " +
-                                                              "If everything works the way you like, you can safely ignore this warning.");
 
         // EnableHackChecks being false fixes the "There was a problem with the level you were playing on that forced a return to your Pod." error that LBP3 tends to show in the pod.
         // AlexDB
@@ -79,7 +71,7 @@ public class MetadataEndpoints : EndpointGroup
         //  - Part of the check for enabling LBP1 Playlists
         //  - Adds "Mm Picks" and "Lucky Dip" search options on LBP1
         // OverheatingThreshholdDisallowMidgameJoin is set to >1.0 so that it never triggers
-        // EnableCommunityDecorations, EnablePlayedFilter, EnableDiveIn enable various game features
+        // ShowLevelBoos, EnableCommunityDecorations, EnablePlayedFilter enable various game features
         // DisableDLCPublishCheck disables the game's DLC publish check.
         networkSettings ??= $"""
                             AllowOnlineCreate true
@@ -92,7 +84,7 @@ public class MetadataEndpoints : EndpointGroup
                             OverheatingThresholdDisallowMidgameJoin 2.0
                             EnableCommunityDecorations true
                             EnablePlayedFilter true
-                            EnableDiveIn true
+                            EnableDiveIn {(config.EnableDiveIn ? "true" : "false")}
                             EnableHackChecks false
                             DisableDLCPublishCheck true
                             AlexDB true


### PR DESCRIPTION
Setting `EnableDiveIn` in network_settings.nws seems to have no effect in LBP2 but I think that should be fine.