### PR TITLE
Make tests run a full database, fix many tests

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,0 +1,25 @@
+﻿name: DebugPostgres Test
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  debug-postgres-tests:
+    name: Run DebugPostgres Tests
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Run tests with DebugPostgres
+        run: dotnet test --configuration DebugPostgres --verbosity normal

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -23,3 +23,7 @@ jobs:
 
       - name: Run tests with DebugPostgres
         run: dotnet test --configuration DebugPostgres --verbosity normal
+        continue-on-error: true
+        
+      - name: Allow failures
+        run: "true"

--- a/Refresh.Core/Importing/AssetImporter.cs
+++ b/Refresh.Core/Importing/AssetImporter.cs
@@ -40,7 +40,7 @@ public class AssetImporter : Importer
         {
             tasks[i] = Task.Factory.StartNew(() =>
             {
-                GameDatabaseContext database = databaseProvider.GetContext();
+                using GameDatabaseContext database = databaseProvider.GetContext();
 
                 List<GameAsset> assets = new(assetHashes.Length / taskCount);
 

--- a/Refresh.Database/Extensions/QueryableExtensions.cs
+++ b/Refresh.Database/Extensions/QueryableExtensions.cs
@@ -18,6 +18,16 @@ public static class QueryableExtensions
     {
         return queryable.AsEnumerable();
     }
+    
+    public static IEnumerable<T> ToArrayIfPostgres<T>(this IQueryable<T> queryable)
+    {
+        return queryable;
+    }
+    
+    public static IEnumerable<T> ToArrayIfPostgres<T>(this IEnumerable<T> queryable)
+    {
+        return queryable;
+    }
 #else
     public static IQueryable<T> AsEnumerableIfRealm<T>(this IQueryable<T> queryable)
     {
@@ -27,6 +37,16 @@ public static class QueryableExtensions
     public static IEnumerable<T> AsEnumerableIfRealm<T>(this IEnumerable<T> queryable)
     {
         return queryable;
+    }
+
+    public static IEnumerable<T> ToArrayIfPostgres<T>(this IQueryable<T> queryable)
+    {
+        return queryable.ToArray();
+    }
+    
+    public static IEnumerable<T> ToArrayIfPostgres<T>(this IEnumerable<T> queryable)
+    {
+        return queryable.ToArray();
     }
 #endif
 }

--- a/Refresh.Database/Extensions/QueryableExtensions.cs
+++ b/Refresh.Database/Extensions/QueryableExtensions.cs
@@ -13,8 +13,18 @@ public static class QueryableExtensions
     {
         return queryable.AsEnumerable();
     }
+    
+    public static IEnumerable<T> AsEnumerableIfRealm<T>(this IEnumerable<T> queryable)
+    {
+        return queryable.AsEnumerable();
+    }
 #else
     public static IQueryable<T> AsEnumerableIfRealm<T>(this IQueryable<T> queryable)
+    {
+        return queryable;
+    }
+    
+    public static IEnumerable<T> AsEnumerableIfRealm<T>(this IEnumerable<T> queryable)
     {
         return queryable;
     }

--- a/Refresh.Database/GameDatabaseContext.ActivityWrite.cs
+++ b/Refresh.Database/GameDatabaseContext.ActivityWrite.cs
@@ -224,14 +224,14 @@ public partial class GameDatabaseContext // ActivityWrite
     /// <summary>
     /// Creates a new UserFirstLogin event from a <see cref='GameUser'/>, and adds it to the event list.
     /// </summary>
-    public Event CreateUserFirstLoginEvent(GameUser userFrom, GameUser user)
+    public Event CreateUserFirstLoginEvent(GameUser user)
     {
         Event e = new()
         {
             EventType = EventType.UserFirstLogin,
             StoredDataType = EventDataType.User,
             Timestamp = this._time.Now,
-            User = userFrom,
+            User = user,
             StoredObjectId = user.UserId,
         };
 

--- a/Refresh.Database/GameDatabaseContext.Comments.cs
+++ b/Refresh.Database/GameDatabaseContext.Comments.cs
@@ -36,7 +36,7 @@ public partial class GameDatabaseContext // Comments
         this.GameProfileCommentsIncluded
             .Where(c => c.Profile == profile)
             .OrderByDescending(c => c.Timestamp)
-            .AsEnumerable()
+            .AsEnumerableIfRealm()
             .Skip(skip)
             .Take(count);
     
@@ -72,7 +72,7 @@ public partial class GameDatabaseContext // Comments
         this.GameLevelCommentsIncluded
             .Where(c => c.Level == level)
             .OrderByDescending(c => c.Timestamp)
-            .AsEnumerable()
+            .AsEnumerableIfRealm()
             .Skip(skip)
             .Take(count);
     

--- a/Refresh.Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.Database/GameDatabaseContext.Leaderboard.cs
@@ -21,7 +21,7 @@ public partial class GameDatabaseContext // Leaderboard
             Score = score.Score,
             ScoreType = score.ScoreType,
             Level = level,
-            Players = { user },
+            PlayerIdsRaw = [ user.UserId.ToString() ],
             ScoreSubmitted = this._time.Now,
             Game = game,
             Platform = platform,
@@ -45,11 +45,8 @@ public partial class GameDatabaseContext // Leaderboard
            )
         {
             // Notify the last #1 users that they've been overtaken
-            foreach (GameUser? player in rankTwo.score.Players)
+            foreach (GameUser player in this.GetPlayersFromScore(rankTwo.score).ToArray())
             {
-                if (player == null)
-                    continue;
-                
                 this.AddNotification("Score overtaken", 
                     $"Your #1 score on {level.Title} has been overtaken by {user.Username}!", 
                     player, "medal");   
@@ -69,7 +66,7 @@ public partial class GameDatabaseContext // Leaderboard
             .AsEnumerable();
 
         if (!showDuplicates)
-            scores = scores.DistinctBy(s => s.Players[0]);
+            scores = scores.DistinctBy(s => s.PlayerIds[0]);
 
         return new DatabaseList<GameSubmittedScore>(scores, skip, count);
     }
@@ -85,7 +82,7 @@ public partial class GameDatabaseContext // Leaderboard
             .AsEnumerable()
             .ToList();
 
-        scores = scores.DistinctBy(s => s.Players[0])
+        scores = scores.DistinctBy(s => s.PlayerIds[0])
             .ToList();
 
         return scores.Select((s, i) => new ScoreWithRank(s, i + 1))
@@ -95,15 +92,17 @@ public partial class GameDatabaseContext // Leaderboard
     
     public IEnumerable<ScoreWithRank> GetLevelTopScoresByFriends(GameUser user, GameLevel level, int count, byte type)
     {
-        IEnumerable<GameUser> mutuals = this.GetUsersMutuals(user);
+        IEnumerable<ObjectId> mutuals = this.GetUsersMutuals(user)
+            .AsEnumerableIfRealm()
+            .Select(u => u.UserId);
         
         IEnumerable<GameSubmittedScore> scores = this.GameSubmittedScores
             .Where(s => s.ScoreType == type && s.Level == level)
             .OrderByDescending(s => s.Score)
-            .AsEnumerable()
-            .DistinctBy(s => s.Players[0].UserId)
+            .AsEnumerableIfRealm()
+            .DistinctBy(s => s.PlayerIds[0])
             //TODO: THIS CALL IS EXTREMELY INEFFECIENT!!! once we are in postgres land, figure out a way to do this effeciently
-            .Where(s => s.Players.Any(p => p.UserId == user.UserId || mutuals.Contains(p)))
+            .Where(s => s.PlayerIds.Any(p => p == user.UserId || mutuals.Contains(p)))
             .Take(10)
             .ToList();
 
@@ -146,8 +145,9 @@ public partial class GameDatabaseContext // Leaderboard
             // Realm doesn't support .Contains on IList<T>. Yes, really.
             // This means we are forced to iterate over EVERY SCORE.
             // I can't wait for Postgres.
-            .AsEnumerable()
-            .Where(s => s.Players.Contains(user));
+            .AsEnumerableIfRealm()
+            .Where(s => s.PlayerIdsRaw.Contains(user.UserId.ToString()))
+            .ToArrayIfPostgres();
         
         this.Write(() =>
         {
@@ -160,5 +160,17 @@ public partial class GameDatabaseContext // Leaderboard
                 this.GameSubmittedScores.Remove(score);
             }
         });
+    }
+
+    public IEnumerable<GameUser> GetPlayersFromScore(GameSubmittedScore score)
+    {
+        IEnumerable<ObjectId> playerIds = score.PlayerIds.Select(p => p);
+        return this.GameUsers
+            .Where(u => playerIds.Contains(u.UserId));
+    }
+    
+    public GameUser? GetSubmittingPlayerFromScore(GameSubmittedScore score)
+    {
+        return this.GetUserByUuid(score.PlayerIdsRaw.FirstOrDefault());
     }
 }

--- a/Refresh.Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.Database/GameDatabaseContext.Leaderboard.cs
@@ -21,7 +21,11 @@ public partial class GameDatabaseContext // Leaderboard
             Score = score.Score,
             ScoreType = score.ScoreType,
             Level = level,
+#if POSTGRES
             PlayerIdsRaw = [ user.UserId.ToString() ],
+#else
+            Players = { user },
+#endif
             ScoreSubmitted = this._time.Now,
             Game = game,
             Platform = platform,
@@ -166,6 +170,7 @@ public partial class GameDatabaseContext // Leaderboard
     {
         IEnumerable<ObjectId> playerIds = score.PlayerIds.Select(p => p);
         return this.GameUsers
+            .AsEnumerableIfRealm()
             .Where(u => playerIds.Contains(u.UserId));
     }
     

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -16,6 +16,7 @@ namespace Refresh.Database;
 public partial class GameDatabaseContext // Levels
 {
     private IQueryable<GameLevel> GameLevelsIncluded => this.GameLevels
+        .AsNoTracking()
         .Include(l => l.Publisher)
         .Include(l => l.Reviews);
     

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -16,7 +16,6 @@ namespace Refresh.Database;
 public partial class GameDatabaseContext // Levels
 {
     private IQueryable<GameLevel> GameLevelsIncluded => this.GameLevels
-        .AsNoTracking()
         .Include(l => l.Publisher)
         .Include(l => l.Reviews);
     

--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -77,7 +77,7 @@ public partial class GameDatabaseContext // Relations
 
     [Pure]
     private bool IsUserFavouritedByUser(GameUser userToFavourite, GameUser userFavouriting) => this.FavouriteUserRelations
-        .FirstOrDefault(r => r.UserToFavourite == userToFavourite && r.UserFavouriting == userFavouriting) != null;
+        .Any(r => r.UserToFavourite == userToFavourite && r.UserFavouriting == userFavouriting);
 
     [Pure]
     public bool AreUsersMutual(GameUser user1, GameUser user2) =>
@@ -87,7 +87,8 @@ public partial class GameDatabaseContext // Relations
     [Pure]
     public IEnumerable<GameUser> GetUsersMutuals(GameUser user)
     {
-        return this.GetUsersFavouritedByUser(user, 1000, 0).AsEnumerable()
+        return this.GetUsersFavouritedByUser(user, 1000, 0)
+            .ToArray()
             .Where(u => this.IsUserFavouritedByUser(user, u));
     }
     
@@ -95,7 +96,7 @@ public partial class GameDatabaseContext // Relations
     public IEnumerable<GameUser> GetUsersFavouritedByUser(GameUser user, int count, int skip) => this.FavouriteUserRelationsIncluded
         .Where(r => r.UserFavouriting == user)
         .OrderByDescending(r => r.Timestamp)
-        .AsEnumerable()
+        .AsEnumerableIfRealm()
         .Select(r => r.UserToFavourite)
         .Skip(skip)
         .Take(count);

--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -12,17 +12,20 @@ namespace Refresh.Database;
 public partial class GameDatabaseContext // Relations
 {
     #region Favouriting Levels
+    private IQueryable<FavouriteLevelRelation> FavouriteLevelRelationsIncluded => this.FavouriteLevelRelations
+        .Include(r => r.Level)
+        .Include(r => r.Level.Publisher)
+        .Include(r => r.Level.Reviews);
+    
     [Pure]
     public bool IsLevelFavouritedByUser(GameLevel level, GameUser user) => this.FavouriteLevelRelations
         .FirstOrDefault(r => r.Level == level && r.User == user) != null;
 
     [Pure]
     public DatabaseList<GameLevel> GetLevelsFavouritedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor) 
-        => new(this.FavouriteLevelRelations
+        => new(this.FavouriteLevelRelationsIncluded
         .Where(r => r.User == user)
         .OrderByDescending(r => r.Timestamp)
-        .Include(r => r.Level.Publisher)
-        .Include(r => r.Level.Reviews)
         .AsEnumerableIfRealm()
         .Select(r => r.Level)
         .FilterByLevelFilterSettings(accessor, levelFilterSettings)
@@ -68,6 +71,10 @@ public partial class GameDatabaseContext // Relations
 
     #region Favouriting Users
 
+    private IQueryable<FavouriteUserRelation> FavouriteUserRelationsIncluded => this.FavouriteUserRelations
+        .Include(r => r.UserFavouriting)
+        .Include(r => r.UserToFavourite);
+
     [Pure]
     private bool IsUserFavouritedByUser(GameUser userToFavourite, GameUser userFavouriting) => this.FavouriteUserRelations
         .FirstOrDefault(r => r.UserToFavourite == userToFavourite && r.UserFavouriting == userFavouriting) != null;
@@ -85,7 +92,7 @@ public partial class GameDatabaseContext // Relations
     }
     
     [Pure]
-    public IEnumerable<GameUser> GetUsersFavouritedByUser(GameUser user, int count, int skip) => this.FavouriteUserRelations
+    public IEnumerable<GameUser> GetUsersFavouritedByUser(GameUser user, int count, int skip) => this.FavouriteUserRelationsIncluded
         .Where(r => r.UserFavouriting == user)
         .OrderByDescending(r => r.Timestamp)
         .AsEnumerable()
@@ -144,17 +151,21 @@ public partial class GameDatabaseContext // Relations
     #endregion
 
     #region Queueing
+
+    private IQueryable<QueueLevelRelation> QueueLevelRelationsIncluded => this.QueueLevelRelations
+        .Include(r => r.Level)
+        .Include(r => r.Level.Publisher)
+        .Include(r => r.Level.Reviews);
+    
     [Pure]
     public bool IsLevelQueuedByUser(GameLevel level, GameUser user) => this.QueueLevelRelations
         .FirstOrDefault(r => r.Level == level && r.User == user) != null;
 
     [Pure]
     public DatabaseList<GameLevel> GetLevelsQueuedByUser(GameUser user, int count, int skip, LevelFilterSettings levelFilterSettings, GameUser? accessor)
-        => new(this.QueueLevelRelations
+        => new(this.QueueLevelRelationsIncluded
         .Where(r => r.User == user)
         .OrderByDescending(r => r.Timestamp)
-        .Include(r => r.Level.Publisher)
-        .Include(r => r.Level.Reviews)
         .AsEnumerableIfRealm()
         .Select(r => r.Level)
         .FilterByLevelFilterSettings(accessor, levelFilterSettings)
@@ -200,6 +211,26 @@ public partial class GameDatabaseContext // Relations
     #endregion
 
     #region Rating and Reviewing
+
+    public IQueryable<RateReviewRelation> RateReviewRelationsIncluded => this.RateReviewRelations
+        .Include(r => r.Review)
+        .Include(r => r.Review.Level)
+        .Include(r => r.Review.Level.Publisher)
+        .Include(r => r.Review.Level.Reviews)
+        .Include(r => r.Review.Publisher)
+        .Include(r => r.User);
+
+    public IQueryable<RateLevelRelation> RateLevelRelationsIncluded => this.RateLevelRelations
+        .Include(r => r.User)
+        .Include(r => r.Level)
+        .Include(r => r.Level.Publisher)
+        .Include(r => r.Level.Reviews);
+
+    public IQueryable<GameReview> GameReviewsIncluded => this.GameReviews
+        .Include(r => r.Level)
+        .Include(r => r.Level.Publisher)
+        .Include(r => r.Level.Reviews)
+        .Include(r => r.Publisher);
 
     public void RateReview(GameReview review, RatingType ratingType, GameUser user)
     {
@@ -273,19 +304,19 @@ public partial class GameDatabaseContext // Relations
     }
 
     public GameReview? GetReviewByUserForLevel(GameUser user, GameLevel level)
-        => this.GameReviews.FirstOrDefault(gameReview => gameReview.Publisher == user && gameReview.Level == level);
+        => this.GameReviewsIncluded.FirstOrDefault(gameReview => gameReview.Publisher == user && gameReview.Level == level);
 
     public bool ReviewRatingExistsByUser(GameUser user, GameReview review)
         => this.RateReviewRelations.Any(relation => relation.Review == review && relation.User == user);
 
     public RateReviewRelation? GetRateReviewRelationForReview(GameUser user, GameReview review)
-        => this.RateReviewRelations.FirstOrDefault(relation => relation.User == user && relation.Review == review);
+        => this.RateReviewRelationsIncluded.FirstOrDefault(relation => relation.User == user && relation.Review == review);
     
     public bool ReviewRatingExists(GameUser user, GameReview review, RatingType rating)
         => this.RateReviewRelations.Any(r => r.Review == review && r.User == user && r._ReviewRatingType == (int)rating);
 
     private RateLevelRelation? GetRateRelationByUser(GameLevel level, GameUser user)
-        => this.RateLevelRelations.FirstOrDefault(r => r.User == user && r.Level == level);
+        => this.RateLevelRelationsIncluded.FirstOrDefault(r => r.User == user && r.Level == level);
 
     /// <summary>
     /// Get a user's rating on a particular level.
@@ -372,7 +403,7 @@ public partial class GameDatabaseContext // Relations
     }
 
     public DatabaseList<GameReview> GetReviewsByUser(GameUser user, int count, int skip)
-        => new(this.GameReviews
+        => new(this.GameReviewsIncluded
             .Where(r => r.Publisher == user)
             .OrderByDescending(r => r.PostedAt), skip, count);
 
@@ -386,11 +417,11 @@ public partial class GameDatabaseContext // Relations
     
     public GameReview? GetReviewByLevelAndUser(GameLevel level, GameUser user)
     {
-        return level.Reviews.FirstOrDefault(r => r.Publisher.UserId == user.UserId);
+        return this.GameReviewsIncluded.FirstOrDefault(r => r.Level == level && r.Publisher.UserId == user.UserId);
     }
 
     public DatabaseList<GameReview> GetReviewsForLevel(GameLevel level, int count, int skip)
-        => new(this.GameReviews
+        => new(this.GameReviewsIncluded
             .Where(r => r.Level == level)
             .AsEnumerable()
             // Sort reviews from most liked to most disliked
@@ -402,6 +433,18 @@ public partial class GameDatabaseContext // Relations
     #endregion
 
     #region Playing
+    
+    private IQueryable<PlayLevelRelation> PlayLevelRelationsIncluded => this.PlayLevelRelations
+        .Include(r => r.User)
+        .Include(r => r.Level)
+        .Include(r => r.Level.Publisher)
+        .Include(r => r.Level.Reviews);
+    
+    private IQueryable<UniquePlayLevelRelation> UniquePlayLevelRelationsIncluded => this.UniquePlayLevelRelations
+        .Include(r => r.User)
+        .Include(r => r.Level)
+        .Include(r => r.Level.Publisher)
+        .Include(r => r.Level.Reviews);
     
     public void PlayLevel(GameLevel level, GameUser user, int count)
     {
@@ -440,10 +483,10 @@ public partial class GameDatabaseContext // Relations
             .FirstOrDefault(r => r.Level == level && r.User == user) != null;
     
     public IEnumerable<PlayLevelRelation> GetAllPlaysForLevel(GameLevel level) =>
-        this.PlayLevelRelations.Where(r => r.Level == level);
+        this.PlayLevelRelationsIncluded.Where(r => r.Level == level);
     
     public IEnumerable<PlayLevelRelation> GetAllPlaysForLevelByUser(GameLevel level, GameUser user) =>
-        this.PlayLevelRelations.Where(r => r.Level == level && r.User == user);
+        this.PlayLevelRelationsIncluded.Where(r => r.Level == level && r.User == user);
     
     public int GetTotalPlaysForLevel(GameLevel level) =>
         this.GetAllPlaysForLevel(level).Sum(playLevelRelation => playLevelRelation.Count);
@@ -461,10 +504,22 @@ public partial class GameDatabaseContext // Relations
 
     #region Comments
 
-    private ProfileCommentRelation? GetProfileCommentRelationByUser(GameProfileComment comment, GameUser user) => this.ProfileCommentRelations
+    private IQueryable<ProfileCommentRelation> ProfileCommentRelationsIncluded => this.ProfileCommentRelations
+        .Include(r => r.User)
+        .Include(r => r.Comment)
+        .Include(r => r.Comment.Author)
+        .Include(r => r.Comment.Profile);
+
+    private IQueryable<LevelCommentRelation> LevelCommentRelationsIncluded => this.LevelCommentRelations
+        .Include(r => r.User)
+        .Include(r => r.Comment)
+        .Include(r => r.Comment.Author)
+        .Include(r => r.Comment.Level);
+
+    private ProfileCommentRelation? GetProfileCommentRelationByUser(GameProfileComment comment, GameUser user) => this.ProfileCommentRelationsIncluded
         .FirstOrDefault(r => r.Comment == comment && r.User == user);
     
-    private LevelCommentRelation? GetLevelCommentRelationByUser(GameLevelComment comment, GameUser user) => this.LevelCommentRelations
+    private LevelCommentRelation? GetLevelCommentRelationByUser(GameLevelComment comment, GameUser user) => this.LevelCommentRelationsIncluded
         .FirstOrDefault(r => r.Comment == comment && r.User == user);
     
     /// <summary>
@@ -547,6 +602,11 @@ public partial class GameDatabaseContext // Relations
 
     #region Tags
 
+    private IQueryable<TagLevelRelation> TagLevelRelationsIncluded => this.TagLevelRelations
+        .Include(r => r.User)
+        .Include(r => r.Level)
+        .Include(r => r.Level.Publisher);
+
     public void AddTagRelation(GameUser user, GameLevel level, Tag tag)
     {
         this.Write(() =>
@@ -566,10 +626,10 @@ public partial class GameDatabaseContext // Relations
 
     public IEnumerable<TagLevelRelation> GetTagsForLevel(GameLevel level)
     {
-        IQueryable<TagLevelRelation> levelTags = this.TagLevelRelations.Where(t => t.Level == level);
+        IQueryable<TagLevelRelation> levelTags = this.TagLevelRelationsIncluded.Where(t => t.Level == level);
  
         IOrderedEnumerable<TagLevelRelation> tags = levelTags
-            .AsEnumerable()
+            .AsEnumerable() // TODO: optimize for postgres when realm is deleted
             .DistinctBy(t => t._Tag)
             .OrderByDescending(t => levelTags.Count(levelTag => levelTag._Tag == t._Tag));
 

--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -417,7 +417,10 @@ public partial class GameDatabaseContext // Relations
     
     public GameReview? GetReviewByLevelAndUser(GameLevel level, GameUser user)
     {
-        return this.GameReviewsIncluded.FirstOrDefault(r => r.Level == level && r.Publisher.UserId == user.UserId);
+        return this.GameReviewsIncluded
+            .Where(r => r.Level == level)
+            .AsEnumerableIfRealm()
+            .FirstOrDefault(r => r.Publisher.UserId == user.UserId);
     }
 
     public DatabaseList<GameReview> GetReviewsForLevel(GameLevel level, int count, int skip)

--- a/Refresh.Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.Database/GameDatabaseContext.Tokens.cs
@@ -55,7 +55,7 @@ public partial class GameDatabaseContext // Tokens
         
         if (user.LastLoginDate == DateTimeOffset.MinValue)
         {
-            this.CreateUserFirstLoginEvent(user, user);
+            this.CreateUserFirstLoginEvent(user);
         }
 
         this.Write(() =>

--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -329,7 +329,7 @@ public partial class GameDatabaseContext // Users
             
             foreach (GameSubmittedScore score in this.GameSubmittedScores.ToList())
             {
-                if (!score.Players.Contains(user)) continue;
+                if (!score.PlayerIds.Contains(user.UserId)) continue;
                 this.GameSubmittedScores.Remove(score);
             }
             

--- a/Refresh.Database/GameDatabaseContext.cs
+++ b/Refresh.Database/GameDatabaseContext.cs
@@ -236,9 +236,10 @@ public partial class GameDatabaseContext :
     {
         callback();
         this.SaveChanges();
+        Debug.Assert(!this.ChangeTracker.HasChanges());
     }
 
-    private void AddSequentialObject<TEntity>(TEntity entity)
+    private void AddSequentialObject<TEntity>(TEntity entity) where TEntity : class
     {
         // causes compiler warning without this for some reason even tho no nullable attribute???
         // in a #nullable-enabled class???
@@ -246,16 +247,17 @@ public partial class GameDatabaseContext :
         Debug.Assert(entity != null);
         this.Write(() =>
         {
-            this.Add(entity);
+            this.Set<TEntity>().Add(entity);
         });
     }
     
-    private void AddSequentialObject<TEntity>(TEntity entity, Action callback)
+    private void AddSequentialObject<TEntity>(TEntity entity, Action callback) where TEntity : class
     {
         this.AddSequentialObject(entity);
         callback();
     }
     
+    [Obsolete("IList shouldn't be used on an entity")]
     private void AddSequentialObject<TEntity>(TEntity entity, IList<TEntity> list)
     {
         Debug.Assert(entity != null);

--- a/Refresh.Database/GameDatabaseProvider.cs
+++ b/Refresh.Database/GameDatabaseProvider.cs
@@ -45,7 +45,7 @@ public class GameDatabaseProvider :
         context.Database.Migrate();
     }
     
-    public void Dispose()
+    public virtual void Dispose()
     {
         GC.SuppressFinalize(this);
     }

--- a/Refresh.Database/Migrations/20250612191349_Tweaks.cs
+++ b/Refresh.Database/Migrations/20250612191349_Tweaks.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250612191349_Tweaks")]
+    public partial class Tweaks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Events_GameUsers_UserId1",
+                table: "Events");
+
+            migrationBuilder.RenameColumn(
+                name: "UserId1",
+                table: "Events",
+                newName: "UserId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Events_UserId1",
+                table: "Events",
+                newName: "IX_Events_UserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Events_GameUsers_UserId",
+                table: "Events",
+                column: "UserId",
+                principalTable: "GameUsers",
+                principalColumn: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Events_GameUsers_UserId",
+                table: "Events");
+
+            migrationBuilder.RenameColumn(
+                name: "UserId",
+                table: "Events",
+                newName: "UserId1");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Events_UserId",
+                table: "Events",
+                newName: "IX_Events_UserId1");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Events_GameUsers_UserId1",
+                table: "Events",
+                column: "UserId1",
+                principalTable: "GameUsers",
+                principalColumn: "UserId");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/20250612193751_DropSequentialIds.cs
+++ b/Refresh.Database/Migrations/20250612193751_DropSequentialIds.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250612193751_DropSequentialIds")]
+    public partial class DropSequentialIds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SequentialId",
+                table: "GameReviews");
+
+            migrationBuilder.DropColumn(
+                name: "SequentialId",
+                table: "GamePlaylists");
+
+            migrationBuilder.DropColumn(
+                name: "SequentialId",
+                table: "GamePhotos");
+
+            migrationBuilder.DropColumn(
+                name: "SequentialId",
+                table: "GameLevels");
+
+            migrationBuilder.DropColumn(
+                name: "SequentialId",
+                table: "GameChallenges");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SequentialId",
+                table: "GameReviews",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SequentialId",
+                table: "GamePlaylists",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SequentialId",
+                table: "GamePhotos",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SequentialId",
+                table: "GameLevels",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SequentialId",
+                table: "GameChallenges",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/Refresh.Database/Migrations/20250612200425_AddDedicatedKeyToGamePhoto.cs
+++ b/Refresh.Database/Migrations/20250612200425_AddDedicatedKeyToGamePhoto.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250612200425_AddDedicatedKeyToGamePhoto")]
+    public partial class AddDedicatedKeyToGamePhoto : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_GamePhotos_GameLevels_LevelId",
+                table: "GamePhotos");
+
+            migrationBuilder.DropIndex(
+                name: "IX_GamePhotos_LevelId",
+                table: "GamePhotos");
+
+            migrationBuilder.AddColumn<int>(
+                name: "LevelIdKey",
+                table: "GamePhotos",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GamePhotos_LevelIdKey",
+                table: "GamePhotos",
+                column: "LevelIdKey");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_GamePhotos_GameLevels_LevelIdKey",
+                table: "GamePhotos",
+                column: "LevelIdKey",
+                principalTable: "GameLevels",
+                principalColumn: "LevelId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_GamePhotos_GameLevels_LevelIdKey",
+                table: "GamePhotos");
+
+            migrationBuilder.DropIndex(
+                name: "IX_GamePhotos_LevelIdKey",
+                table: "GamePhotos");
+
+            migrationBuilder.DropColumn(
+                name: "LevelIdKey",
+                table: "GamePhotos");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GamePhotos_LevelId",
+                table: "GamePhotos",
+                column: "LevelId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_GamePhotos_GameLevels_LevelId",
+                table: "GamePhotos",
+                column: "LevelId",
+                principalTable: "GameLevels",
+                principalColumn: "LevelId",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Refresh.Database/Migrations/20250612204324_AddRawPlayerIdRepresentationToScore.cs
+++ b/Refresh.Database/Migrations/20250612204324_AddRawPlayerIdRepresentationToScore.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250612204324_AddRawPlayerIdRepresentationToScore")]
+    public partial class AddRawPlayerIdRepresentationToScore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_GameUsers_GameSubmittedScores_GameSubmittedScoreScoreId",
+                table: "GameUsers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_GameUsers_GameSubmittedScoreScoreId",
+                table: "GameUsers");
+
+            migrationBuilder.DropColumn(
+                name: "GameSubmittedScoreScoreId",
+                table: "GameUsers");
+
+            migrationBuilder.AddColumn<List<string>>(
+                name: "PlayerIdsRaw",
+                table: "GameSubmittedScores",
+                type: "text[]",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PlayerIdsRaw",
+                table: "GameSubmittedScores");
+
+            migrationBuilder.AddColumn<string>(
+                name: "GameSubmittedScoreScoreId",
+                table: "GameUsers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameUsers_GameSubmittedScoreScoreId",
+                table: "GameUsers",
+                column: "GameSubmittedScoreScoreId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_GameUsers_GameSubmittedScores_GameSubmittedScoreScoreId",
+                table: "GameUsers",
+                column: "GameSubmittedScoreScoreId",
+                principalTable: "GameSubmittedScores",
+                principalColumn: "ScoreId");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -512,6 +512,9 @@ namespace Refresh.Database.Migrations
                     b.Property<int?>("LevelId")
                         .HasColumnType("integer");
 
+                    b.PrimitiveCollection<List<string>>("PlayerIdsRaw")
+                        .HasColumnType("text[]");
+
                     b.Property<int>("Score")
                         .HasColumnType("integer");
 
@@ -596,6 +599,9 @@ namespace Refresh.Database.Migrations
                     b.Property<int>("LevelId")
                         .HasColumnType("integer");
 
+                    b.Property<int?>("LevelIdKey")
+                        .HasColumnType("integer");
+
                     b.Property<string>("LevelName")
                         .HasColumnType("text");
 
@@ -664,7 +670,7 @@ namespace Refresh.Database.Migrations
 
                     b.HasIndex("LargeAssetAssetHash");
 
-                    b.HasIndex("LevelId");
+                    b.HasIndex("LevelIdKey");
 
                     b.HasIndex("MediumAssetAssetHash");
 
@@ -1188,9 +1194,6 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("ForceMatch")
                         .HasColumnType("text");
 
-                    b.Property<string>("GameSubmittedScoreScoreId")
-                        .HasColumnType("text");
-
                     b.Property<string>("IconHash")
                         .IsRequired()
                         .HasColumnType("text");
@@ -1273,8 +1276,6 @@ namespace Refresh.Database.Migrations
                         .HasColumnType("smallint");
 
                     b.HasKey("UserId");
-
-                    b.HasIndex("GameSubmittedScoreScoreId");
 
                     b.HasIndex("Username", "EmailAddress", "PasswordBcrypt");
 
@@ -1464,9 +1465,7 @@ namespace Refresh.Database.Migrations
 
                     b.HasOne("Refresh.Database.Models.Levels.GameLevel", "Level")
                         .WithMany()
-                        .HasForeignKey("LevelId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .HasForeignKey("LevelIdKey");
 
                     b.HasOne("Refresh.Database.Models.Assets.GameAsset", "MediumAsset")
                         .WithMany()
@@ -1816,23 +1815,11 @@ namespace Refresh.Database.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("Refresh.Database.Models.Users.GameUser", b =>
-                {
-                    b.HasOne("Refresh.Database.Models.Levels.Scores.GameSubmittedScore", null)
-                        .WithMany("Players")
-                        .HasForeignKey("GameSubmittedScoreScoreId");
-                });
-
             modelBuilder.Entity("Refresh.Database.Models.Levels.GameLevel", b =>
                 {
                     b.Navigation("Reviews");
 
                     b.Navigation("SkillRewards");
-                });
-
-            modelBuilder.Entity("Refresh.Database.Models.Levels.Scores.GameSubmittedScore", b =>
-                {
-                    b.Navigation("Players");
                 });
 
             modelBuilder.Entity("Refresh.Database.Models.Users.GameUser", b =>

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -40,7 +40,7 @@ namespace Refresh.Database.Migrations
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("UserId1")
+                    b.Property<string>("UserId")
                         .HasColumnType("text");
 
                     b.Property<int>("_EventType")
@@ -51,7 +51,7 @@ namespace Refresh.Database.Migrations
 
                     b.HasKey("EventId");
 
-                    b.HasIndex("UserId1");
+                    b.HasIndex("UserId");
 
                     b.ToTable("Events");
                 });
@@ -227,9 +227,6 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("PublisherUserId")
                         .HasColumnType("text");
 
-                    b.Property<int>("SequentialId")
-                        .HasColumnType("integer");
-
                     b.HasKey("ReviewId");
 
                     b.HasIndex("LevelId");
@@ -318,9 +315,6 @@ namespace Refresh.Database.Migrations
 
                     b.Property<string>("PublisherUserId")
                         .HasColumnType("text");
-
-                    b.Property<int>("SequentialId")
-                        .HasColumnType("integer");
 
                     b.Property<int>("StartCheckpointUid")
                         .HasColumnType("integer");
@@ -454,9 +448,6 @@ namespace Refresh.Database.Migrations
 
                     b.Property<float>("Score")
                         .HasColumnType("real");
-
-                    b.Property<int>("SequentialId")
-                        .HasColumnType("integer");
 
                     b.Property<int>("StoryId")
                         .HasColumnType("integer");
@@ -623,9 +614,6 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("PublisherUserId")
                         .HasColumnType("text");
 
-                    b.Property<int>("SequentialId")
-                        .HasColumnType("integer");
-
                     b.Property<string>("SmallAssetAssetHash")
                         .HasColumnType("text");
 
@@ -730,9 +718,6 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("PublisherId")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<int>("SequentialId")
-                        .HasColumnType("integer");
 
                     b.HasKey("PlaylistId");
 
@@ -1324,7 +1309,7 @@ namespace Refresh.Database.Migrations
                 {
                     b.HasOne("Refresh.Database.Models.Users.GameUser", "User")
                         .WithMany()
-                        .HasForeignKey("UserId1");
+                        .HasForeignKey("UserId");
 
                     b.Navigation("User");
                 });

--- a/Refresh.Database/Models/Activity/Event.cs
+++ b/Refresh.Database/Models/Activity/Event.cs
@@ -10,21 +10,15 @@ namespace Refresh.Database.Models.Activity;
 /// <summary>
 /// An action performed by a user.
 /// </summary>
-[Serializable]
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
-[JsonObject(MemberSerialization.OptOut, ItemNullValueHandling = NullValueHandling.Ignore)]
-[XmlRoot("event")]
-[XmlType("event")]
 public partial class Event : IRealmObject
 {
     /// <summary>
     /// The ID of the event.
     /// </summary>
-    [XmlIgnore]
     public ObjectId EventId { get; set; } = ObjectId.GenerateNewId();
     
     [Ignored, NotMapped]
-    [XmlAttribute("type")]
     public EventType EventType
     {
         get => (EventType)this._EventType;
@@ -37,15 +31,11 @@ public partial class Event : IRealmObject
     /// <summary>
     /// The user in question that created this event.
     /// </summary>
-    [XmlIgnore] [JsonIgnore] public GameUser User { get; set; }
-
-    [XmlIgnore] public string UserId => this.User.UserId.ToString(); 
+    public GameUser User { get; set; }
     
     /// <summary>
     /// Should this event be shown to other users on the server?
     /// </summary>
-    [XmlIgnore]
-    [JsonIgnore]
     public bool IsPrivate { get; set; }
     
     [XmlElement("timestamp")]
@@ -55,7 +45,6 @@ public partial class Event : IRealmObject
     /// The type of data that this event is referencing.
     /// </summary>
     [Ignored, NotMapped]
-    [XmlIgnore]
     public EventDataType StoredDataType
     {
         get => (EventDataType)this._StoredDataType;
@@ -68,12 +57,10 @@ public partial class Event : IRealmObject
     /// <summary>
     /// The sequential ID of the object this event is referencing. If null, use <see cref="StoredObjectId"/>.
     /// </summary>
-    [XmlIgnore]
     public int? StoredSequentialId { get; set; }
     
     /// <summary>
     /// The ObjectId of the object this event is referencing. If null, use <see cref="StoredSequentialId"/>.
     /// </summary>
-    [XmlIgnore]
     public ObjectId? StoredObjectId { get; set; }
 }

--- a/Refresh.Database/Models/Comments/GameReview.cs
+++ b/Refresh.Database/Models/Comments/GameReview.cs
@@ -19,7 +19,7 @@ public partial class GameReview : IRealmObject, ISequentialId
     
     public string Content { get; set; }
     
-    public int SequentialId
+    [NotMapped] public int SequentialId
     {
         get => this.ReviewId;
         set => this.ReviewId = value;

--- a/Refresh.Database/Models/Levels/Challenges/GameChallenge.cs
+++ b/Refresh.Database/Models/Levels/Challenges/GameChallenge.cs
@@ -40,7 +40,7 @@ public partial class GameChallenge : IRealmObject, ISequentialId
     public DateTimeOffset LastUpdateDate { get; set; }
     public DateTimeOffset ExpirationDate { get; set; }
 
-    public int SequentialId
+    [NotMapped] public int SequentialId
     {
         get => this.ChallengeId;
         set => this.ChallengeId = value;

--- a/Refresh.Database/Models/Levels/GameLevel.cs
+++ b/Refresh.Database/Models/Levels/GameLevel.cs
@@ -135,7 +135,7 @@ public partial class GameLevel : IRealmObject, ISequentialId
     }
     #endif
     
-    public int SequentialId
+    [NotMapped] public int SequentialId
     {
         get => this.LevelId;
         set => this.LevelId = value;

--- a/Refresh.Database/Models/Levels/Scores/GameSubmittedScore.cs
+++ b/Refresh.Database/Models/Levels/Scores/GameSubmittedScore.cs
@@ -32,9 +32,16 @@ public partial class GameSubmittedScore : IRealmObject // TODO: Rename to GameSc
     }
 
     public GameLevel Level { get; set; }
-    public IList<GameUser> Players { get; }
     public DateTimeOffset ScoreSubmitted { get; set; }
     
     [Indexed] public int Score { get; set; }
     [Indexed] public byte ScoreType { get; set; }
+    
+    #if !POSTGRES
+    public IList<GameUser> Players { get; }
+    #else
+    public List<string> PlayerIdsRaw { get; set; } = [];
+    [NotMapped] public List<ObjectId> PlayerIds => PlayerIdsRaw.Select(ObjectId.Parse).ToList();
+    // set => PlayerIdsRaw = value.Select(v => v.ToString()).ToList();
+#endif
 }

--- a/Refresh.Database/Models/Levels/Scores/GameSubmittedScore.cs
+++ b/Refresh.Database/Models/Levels/Scores/GameSubmittedScore.cs
@@ -37,9 +37,11 @@ public partial class GameSubmittedScore : IRealmObject // TODO: Rename to GameSc
     [Indexed] public int Score { get; set; }
     [Indexed] public byte ScoreType { get; set; }
     
-    #if !POSTGRES
+#if !POSTGRES
     public IList<GameUser> Players { get; }
-    #else
+    [Ignored] public List<ObjectId> PlayerIds => Players.Select(r => r.UserId).ToList();
+    [Ignored] public List<string> PlayerIdsRaw => Players.Select(r => r.UserId.ToString()).ToList();
+#else
     public List<string> PlayerIdsRaw { get; set; } = [];
     [NotMapped] public List<ObjectId> PlayerIds => PlayerIdsRaw.Select(ObjectId.Parse).ToList();
     // set => PlayerIdsRaw = value.Select(v => v.ToString()).ToList();

--- a/Refresh.Database/Models/Photos/GamePhoto.cs
+++ b/Refresh.Database/Models/Photos/GamePhoto.cs
@@ -21,7 +21,7 @@ public partial class GamePhoto : IRealmObject, ISequentialId
     #nullable restore
     [ForeignKey(nameof(LevelIdKey))]
     public GameLevel? Level { get; set; }
-    public int? LevelIdKey { get; set; }
+    [Ignored] public int? LevelIdKey { get; set; }
     #nullable disable
     
     public string LevelName { get; set; }

--- a/Refresh.Database/Models/Photos/GamePhoto.cs
+++ b/Refresh.Database/Models/Photos/GamePhoto.cs
@@ -147,7 +147,7 @@ public partial class GamePhoto : IRealmObject, ISequentialId
     
     #endregion
     
-    [JsonIgnore] public int SequentialId
+    [JsonIgnore] [NotMapped] public int SequentialId
     {
         get => this.PhotoId;
         set => this.PhotoId = value;

--- a/Refresh.Database/Models/Photos/GamePhoto.cs
+++ b/Refresh.Database/Models/Photos/GamePhoto.cs
@@ -19,7 +19,9 @@ public partial class GamePhoto : IRealmObject, ISequentialId
     
     public GameUser Publisher { get; set; }
     #nullable restore
+    [ForeignKey(nameof(LevelIdKey))]
     public GameLevel? Level { get; set; }
+    public int? LevelIdKey { get; set; }
     #nullable disable
     
     public string LevelName { get; set; }

--- a/Refresh.Database/Models/Playlists/GamePlaylist.cs
+++ b/Refresh.Database/Models/Playlists/GamePlaylist.cs
@@ -61,7 +61,7 @@ public partial class GamePlaylist : IRealmObject, ISequentialId
     /// </summary>
     public bool IsRoot { get; set; }
     
-    public int SequentialId
+    [NotMapped] public int SequentialId
     {
         get => this.PlaylistId;
         set => this.PlaylistId = value;

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameScoreResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameScoreResponse.cs
@@ -26,7 +26,7 @@ public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameSc
         {
             ScoreId = old.ScoreId.ToString()!,
             Level = ApiGameLevelResponse.FromOld(old.Level, dataContext)!,
-            Players = ApiGameUserResponse.FromOldList(old.Players, dataContext),
+            Players = ApiGameUserResponse.FromOldList(dataContext.Database.GetPlayersFromScore(old), dataContext),
             ScoreSubmitted = old.ScoreSubmitted,
             Score = old.Score,
             ScoreType = old.ScoreType,

--- a/Refresh.Interfaces.APIv3/Extensions/DatabaseListExtensions.cs
+++ b/Refresh.Interfaces.APIv3/Extensions/DatabaseListExtensions.cs
@@ -11,7 +11,7 @@ public static class DatabaseListExtensions
         where TNewObject : class, IDataConvertableFrom<TNewObject, TOldObject>
         where TOldObject : class
     {
-        DatabaseList<TNewObject> newList = new(oldList.TotalItems, oldList.NextPageIndex, TNewObject.FromOldList(oldList.Items, dataContext));
+        DatabaseList<TNewObject> newList = new(oldList.TotalItems, oldList.NextPageIndex, TNewObject.FromOldList(oldList.Items.ToArray(), dataContext));
         return newList;
     }
 }

--- a/Refresh.Interfaces.Game/Endpoints/CategoryEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/CategoryEndpoints.cs
@@ -58,7 +58,7 @@ public class CategoryEndpoints : EndpointGroup
         
         return new SerializedCategoryResultsList
         (
-            levels.Items.Select(l => GameMinimalLevelResponse.FromOld(l, dataContext))!,
+            levels.Items.ToArray().Select(l => GameMinimalLevelResponse.FromOld(l, dataContext))!,
             levels.TotalItems,
             levels.NextPageIndex
         );

--- a/Refresh.Interfaces.Game/Endpoints/CommentEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/CommentEndpoints.cs
@@ -53,7 +53,7 @@ public class CommentEndpoints : EndpointGroup
         
         (int skip, int count) = context.GetPageData();
 
-        return new SerializedCommentList(SerializedComment.FromOldList(database.GetProfileComments(profile, count, skip), dataContext));
+        return new SerializedCommentList(SerializedComment.FromOldList(database.GetProfileComments(profile, count, skip).ToArray(), dataContext));
     }
 
     [GameEndpoint("deleteUserComment/{username}", HttpMethods.Post)]
@@ -115,7 +115,7 @@ public class CommentEndpoints : EndpointGroup
 
         (int skip, int count) = context.GetPageData();
 
-        return new SerializedCommentList(SerializedComment.FromOldList(database.GetLevelComments(level, count, skip), dataContext));
+        return new SerializedCommentList(SerializedComment.FromOldList(database.GetLevelComments(level, count, skip).ToArray(), dataContext));
     }
 
     [GameEndpoint("deleteComment/{slotType}/{id}", HttpMethods.Post)]

--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
@@ -170,7 +170,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             BackgroundGuid = old.BackgroundGuid,
             Links = "",
             AverageStarRating = old.CalculateAverageStarRating(dataContext.Database),
-            ReviewCount = old.Reviews.Count,
+            ReviewCount = dataContext.Database.GetTotalReviewsForLevel(old),
             CommentCount = dataContext.Database.GetTotalCommentsForLevel(old),
             PhotoCount = dataContext.Database.GetTotalPhotosInLevel(old),
             PublisherPhotoCount = old.Publisher == null ? 0 : dataContext.Database.GetTotalPhotosInLevelByUser(old, old.Publisher),

--- a/Refresh.Interfaces.Game/Endpoints/Levels/LevelEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/LevelEndpoints.cs
@@ -66,7 +66,7 @@ public class LevelEndpoints : EndpointGroup
 
         if (levels == null) return null;
         
-        IEnumerable<GameMinimalLevelResponse> slots = levels.Items
+        IEnumerable<GameMinimalLevelResponse> slots = levels.Items.ToArray()
             .Select(l => GameMinimalLevelResponse.FromOld(l, dataContext)!);
 
         int injectedAmount = 0;

--- a/Refresh.Interfaces.Game/Endpoints/PhotoEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/PhotoEndpoints.cs
@@ -81,7 +81,9 @@ public class PhotoEndpoints : EndpointGroup
         (int skip, int count) = context.GetPageData();
 
         // count not used ingame
-        IEnumerable<SerializedPhoto> photos = photoGetter.Invoke(user, count, skip).Items
+        IEnumerable<SerializedPhoto> photos = photoGetter.Invoke(user, count, skip)
+            .Items
+            .ToArray()
             .Select(photo => PhotoExtensions.FromGamePhoto(photo, dataContext));
 
         return new Response(new SerializedPhotoList(photos), ContentType.Xml);

--- a/Refresh.Interfaces.Game/Types/Comments/SerializedComment.cs
+++ b/Refresh.Interfaces.Game/Types/Comments/SerializedComment.cs
@@ -6,7 +6,7 @@ namespace Refresh.Interfaces.Game.Types.Comments;
 
 [XmlRoot("comment")]
 [XmlType("comment")]
-public class SerializedComment : IDataConvertableFrom<SerializedComment, Database.Models.Comments.GameProfileComment>, IDataConvertableFrom<SerializedComment, Database.Models.Comments.GameLevelComment>
+public class SerializedComment : IDataConvertableFrom<SerializedComment, GameProfileComment>, IDataConvertableFrom<SerializedComment, GameLevelComment>
 {
     [XmlElement("id")] public required int CommentId { get; set; }
     
@@ -33,7 +33,7 @@ public class SerializedComment : IDataConvertableFrom<SerializedComment, Databas
             Handle = comment.Author.Username,
         };
 
-    public static SerializedComment? FromOld(Database.Models.Comments.GameProfileComment? old, DataContext dataContext)
+    public static SerializedComment? FromOld(GameProfileComment? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -44,7 +44,7 @@ public class SerializedComment : IDataConvertableFrom<SerializedComment, Databas
         return comment;
     }
     
-    public static SerializedComment? FromOld(Database.Models.Comments.GameLevelComment? old, DataContext dataContext)
+    public static SerializedComment? FromOld(GameLevelComment? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -55,6 +55,6 @@ public class SerializedComment : IDataConvertableFrom<SerializedComment, Databas
         return comment;
     }
 
-    public static IEnumerable<SerializedComment> FromOldList(IEnumerable<Database.Models.Comments.GameProfileComment> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
-    public static IEnumerable<SerializedComment> FromOldList(IEnumerable<Database.Models.Comments.GameLevelComment> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
+    public static IEnumerable<SerializedComment> FromOldList(IEnumerable<GameProfileComment> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
+    public static IEnumerable<SerializedComment> FromOldList(IEnumerable<GameLevelComment> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.Interfaces.Game/Types/Lists/SerializedScoreLeaderboardList.cs
+++ b/Refresh.Interfaces.Game/Types/Lists/SerializedScoreLeaderboardList.cs
@@ -1,4 +1,5 @@
 using System.Xml.Serialization;
+using Refresh.Core.Types.Data;
 using Refresh.Database.Models.Levels.Scores;
 using Refresh.Interfaces.Game.Types.UserData.Leaderboard;
 
@@ -10,7 +11,7 @@ public class SerializedScoreLeaderboardList
     [XmlElement("playRecord")]
     public List<SerializedLeaderboardScore> Scores { get; set; } = new();
     
-    public static SerializedScoreLeaderboardList FromSubmittedEnumerable(IEnumerable<ScoreWithRank> list)
+    public static SerializedScoreLeaderboardList FromSubmittedEnumerable(IEnumerable<ScoreWithRank> list, DataContext dataContext)
     {
         SerializedScoreLeaderboardList value = new();
         
@@ -18,7 +19,7 @@ public class SerializedScoreLeaderboardList
         {
             value.Scores.Add(new SerializedLeaderboardScore
             {
-                Player = score.score.Players.FirstOrDefault()?.Username ?? "",
+                Player = dataContext.Database.GetSubmittingPlayerFromScore(score.score)?.Username ?? "",
                 Score = score.score.Score,
                 Rank = score.rank,
             });

--- a/Refresh.Interfaces.Game/Types/Lists/SerializedScoreList.cs
+++ b/Refresh.Interfaces.Game/Types/Lists/SerializedScoreList.cs
@@ -1,4 +1,5 @@
 using System.Xml.Serialization;
+using Refresh.Core.Types.Data;
 using Refresh.Database.Models.Levels.Scores;
 using Refresh.Interfaces.Game.Types.UserData.Leaderboard;
 
@@ -10,7 +11,7 @@ public class SerializedScoreList
     [XmlElement("playRecord")]
     public List<SerializedLeaderboardScore> Scores { get; set; } = new();
 
-    public static SerializedScoreList FromSubmittedEnumerable(IEnumerable<GameSubmittedScore> list, int skip)
+    public static SerializedScoreList FromSubmittedEnumerable(IEnumerable<GameSubmittedScore> list, DataContext dataContext, int skip)
     {
         SerializedScoreList value = new();
 
@@ -21,7 +22,7 @@ public class SerializedScoreList
             
             value.Scores.Add(new SerializedLeaderboardScore
             {
-                Player = score.Players.FirstOrDefault()?.Username ?? "",
+                Player = dataContext.Database.GetSubmittingPlayerFromScore(score)?.Username ?? "",
                 Score = score.Score,
                 Rank = i,
             });

--- a/Refresh.Interfaces.Game/Types/UserData/Leaderboard/SerializedLeaderboardScore.cs
+++ b/Refresh.Interfaces.Game/Types/UserData/Leaderboard/SerializedLeaderboardScore.cs
@@ -1,4 +1,6 @@
 using System.Xml.Serialization;
+using Refresh.Core.Types.Data;
+using Refresh.Database.Models.Levels.Scores;
 
 namespace Refresh.Interfaces.Game.Types.UserData.Leaderboard;
 
@@ -10,9 +12,9 @@ public class SerializedLeaderboardScore
     [XmlElement("score")] public int Score { get; set; }
     [XmlElement("rank")] public int Rank { get; set; }
 
-    public static SerializedLeaderboardScore FromOld(Database.Models.Levels.Scores.GameSubmittedScore score, int rank) => new()
+    public static SerializedLeaderboardScore FromOld(GameSubmittedScore score, DataContext dataContext, int rank) => new()
     {
-        Player = score.Players[0].Username,
+        Player = dataContext.Database.GetSubmittingPlayerFromScore(score)?.Username ?? "",
         Score = score.Score,
         Rank = rank,
     };

--- a/Refresh.Interfaces.Game/Types/UserData/Leaderboard/SerializedMultiLeaderboardResponse.cs
+++ b/Refresh.Interfaces.Game/Types/UserData/Leaderboard/SerializedMultiLeaderboardResponse.cs
@@ -1,4 +1,5 @@
 using System.Xml.Serialization;
+using Refresh.Core.Types.Data;
 using Refresh.Database;
 using Refresh.Database.Models.Levels.Scores;
 
@@ -20,12 +21,12 @@ public class SerializedMultiLeaderboardResponse
     [XmlElement("topScores")]
     public List<SerializedPlayerLeaderboardResponse> Scoreboards;
 
-    public static SerializedMultiLeaderboardResponse FromOld(MultiLeaderboard multiLeaderboard)
+    public static SerializedMultiLeaderboardResponse FromOld(MultiLeaderboard multiLeaderboard, DataContext dataContext)
     {
         List<SerializedPlayerLeaderboardResponse> leaderboards = new();
 
         //Iterate over all leaderboards in the list
-        foreach ((byte type, DatabaseList<Database.Models.Levels.Scores.GameSubmittedScore> scores) in multiLeaderboard.Leaderboards)
+        foreach ((byte type, DatabaseList<GameSubmittedScore> scores) in multiLeaderboard.Leaderboards)
         {
             SerializedPlayerLeaderboardResponse leaderboard = new()
             {
@@ -34,9 +35,9 @@ public class SerializedMultiLeaderboardResponse
             };
 
             int i = 1;
-            foreach (Database.Models.Levels.Scores.GameSubmittedScore score in scores.Items)
+            foreach (GameSubmittedScore score in scores.Items)
             {
-                leaderboard.Scores.Add(SerializedLeaderboardScore.FromOld(score, i));
+                leaderboard.Scores.Add(SerializedLeaderboardScore.FromOld(score, dataContext, i));
                 i += 1;
             }
             

--- a/Refresh.Interfaces.Workers/Workers/DiscordIntegrationWorker.cs
+++ b/Refresh.Interfaces.Workers/Workers/DiscordIntegrationWorker.cs
@@ -99,7 +99,7 @@ public class DiscordIntegrationWorker : IWorker
             embed.WithThumbnailUrl(this.GetAssetUrl(user.IconHash));
         
         embed.WithTimestamp(@event.Timestamp);
-        embed.WithAuthor(@event.User.Username, this.GetAssetUrl(@event.User.IconHash), $"{this._externalUrl}/u/{@event.UserId}");
+        embed.WithAuthor(@event.User.Username, this.GetAssetUrl(@event.User.IconHash), $"{this._externalUrl}/u/{@event.User.UserId}");
 
         return embed.Build();
     }

--- a/RefreshTests.GameServer/ExtraAssemblyInfo.cs
+++ b/RefreshTests.GameServer/ExtraAssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly:LevelOfParallelism(32)]

--- a/RefreshTests.GameServer/GameServer/ContainerPool.cs
+++ b/RefreshTests.GameServer/GameServer/ContainerPool.cs
@@ -1,4 +1,6 @@
-﻿using Testcontainers.PostgreSql;
+﻿#if POSTGRES
+
+using Testcontainers.PostgreSql;
 
 namespace RefreshTests.GameServer.GameServer;
 
@@ -47,3 +49,5 @@ public class ContainerPool : IDisposable
         GC.SuppressFinalize(this);
     }
 }
+
+#endif

--- a/RefreshTests.GameServer/GameServer/ContainerPool.cs
+++ b/RefreshTests.GameServer/GameServer/ContainerPool.cs
@@ -1,0 +1,49 @@
+﻿using Testcontainers.PostgreSql;
+
+namespace RefreshTests.GameServer.GameServer;
+
+public class ContainerPool : IDisposable
+{
+    public static readonly ContainerPool Instance = new();
+
+    private readonly Queue<PostgreSqlContainer> _containers = [];
+    private readonly List<PostgreSqlContainer> _allContainers = [];
+
+    public PostgreSqlContainer Take()
+    {
+        // PostgreSqlContainer? container = null;
+        if (this._containers.TryDequeue(out PostgreSqlContainer? container))
+        {
+            return container;
+        }
+        
+        container = new PostgreSqlBuilder()
+            .WithImage("postgres:latest")
+            .WithDatabase("refresh")
+            .Build();
+        
+        container.StartAsync().Wait();
+        
+        this._allContainers.Add(container);
+        return container;
+    }
+
+    public void Return(PostgreSqlContainer container)
+    {
+        this._containers.Enqueue(container);
+    }
+
+    public void Dispose()
+    {
+        this._containers.Clear();
+        
+        foreach (PostgreSqlContainer container in this._allContainers)
+        {
+            container.DisposeAsync().AsTask().Wait();
+        }
+        
+        this._allContainers.Clear();
+        
+        GC.SuppressFinalize(this);
+    }
+}

--- a/RefreshTests.GameServer/GameServer/GameServerTest.cs
+++ b/RefreshTests.GameServer/GameServer/GameServerTest.cs
@@ -35,6 +35,6 @@ public class GameServerTest
         if (startServer) _ = gameServer.Value;
         else provider.Initialize();
 
-        return new TestContext(gameServer, provider.GetContext(), client, listener, time);
+        return new TestContext(gameServer, provider, client, listener, time);
     }
 }

--- a/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
+++ b/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
@@ -26,7 +26,7 @@ public class TestGameDatabaseContext : GameDatabaseContext
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
         options.UseNpgsql(this._container.GetConnectionString() + ";Include Error Detail=true");
-        options.LogTo(Console.WriteLine, LogLevel.Information);
+        // options.LogTo(Console.WriteLine, LogLevel.Information);
     }
 }
 

--- a/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
+++ b/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
@@ -3,25 +3,28 @@
 using Microsoft.EntityFrameworkCore;
 using Refresh.Common.Time;
 using Refresh.Database;
+using Testcontainers.PostgreSql;
 
 namespace RefreshTests.GameServer.GameServer;
 
 public class TestGameDatabaseContext : GameDatabaseContext
 {
-    private readonly int _databaseId;
+    private readonly PostgreSqlContainer _container;
     
-    [Obsolete("Do not use.")]
+    [Obsolete("Do not use.", true)]
     public TestGameDatabaseContext()
-    {}
-
-    public TestGameDatabaseContext(IDateTimeProvider time, int databaseId) : base(time)
     {
-        this._databaseId = databaseId;
+        throw new InvalidOperationException("Do not use this constructor.");
+    }
+
+    public TestGameDatabaseContext(IDateTimeProvider time, PostgreSqlContainer container) : base(time)
+    {
+        this._container = container;
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
-        options.UseInMemoryDatabase(this._databaseId.ToString());
+        options.UseNpgsql(this._container.GetConnectionString() + ";Include Error Detail=true");
     }
 }
 

--- a/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
+++ b/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
@@ -1,6 +1,7 @@
 ﻿#if POSTGRES
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Refresh.Common.Time;
 using Refresh.Database;
 using Testcontainers.PostgreSql;
@@ -25,6 +26,7 @@ public class TestGameDatabaseContext : GameDatabaseContext
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
         options.UseNpgsql(this._container.GetConnectionString() + ";Include Error Detail=true");
+        options.LogTo(Console.WriteLine, LogLevel.Information);
     }
 }
 

--- a/RefreshTests.GameServer/GameServer/TestGameDatabaseProvider.cs
+++ b/RefreshTests.GameServer/GameServer/TestGameDatabaseProvider.cs
@@ -1,21 +1,28 @@
 using Refresh.Database;
 using RefreshTests.GameServer.Time;
+
+#if POSTGRES
 using Testcontainers.PostgreSql;
+#endif
 
 namespace RefreshTests.GameServer.GameServer;
 
 public class TestGameDatabaseProvider : GameDatabaseProvider
 {
     private readonly MockDateTimeProvider _time;
+#if POSTGRES
     private readonly PostgreSqlContainer _container;
+#endif
 
     public TestGameDatabaseProvider(MockDateTimeProvider time) : base(time)
     {
         this._time = time;
+#if POSTGRES
         this._container = ContainerPool.Instance.Take();
+#endif
     }
     
-    #if POSTGRES
+#if POSTGRES
     public override TestGameDatabaseContext GetContext()
     {
         return new TestGameDatabaseContext(this._time, this._container);
@@ -37,5 +44,5 @@ public class TestGameDatabaseProvider : GameDatabaseProvider
     private readonly int _databaseId = Random.Shared.Next();
     protected override string Filename => $"realm-inmemory-{this._databaseId}";
     protected override bool InMemory => true;
-    #endif
+#endif
 }

--- a/RefreshTests.GameServer/GameServer/TestGameDatabaseProvider.cs
+++ b/RefreshTests.GameServer/GameServer/TestGameDatabaseProvider.cs
@@ -1,30 +1,40 @@
 using Refresh.Database;
 using RefreshTests.GameServer.Time;
+using Testcontainers.PostgreSql;
 
 namespace RefreshTests.GameServer.GameServer;
 
 public class TestGameDatabaseProvider : GameDatabaseProvider
 {
     private readonly MockDateTimeProvider _time;
-    private readonly int _databaseId = Random.Shared.Next();
+    private readonly PostgreSqlContainer _container;
 
     public TestGameDatabaseProvider(MockDateTimeProvider time) : base(time)
     {
         this._time = time;
+        this._container = ContainerPool.Instance.Take();
     }
     
     #if POSTGRES
     public override TestGameDatabaseContext GetContext()
     {
-        return new TestGameDatabaseContext(this._time, this._databaseId);
+        return new TestGameDatabaseContext(this._time, this._container);
     }
 
     public override void Initialize()
     {
         using TestGameDatabaseContext context = this.GetContext();
+        context.Database.EnsureDeleted();
         context.Database.EnsureCreated();
     }
+
+    public override void Dispose()
+    {
+        ContainerPool.Instance.Return(this._container);
+        base.Dispose();
+    }
 #else
+    private readonly int _databaseId = Random.Shared.Next();
     protected override string Filename => $"realm-inmemory-{this._databaseId}";
     protected override bool InMemory => true;
     #endif

--- a/RefreshTests.GameServer/RefreshTests.GameServer.csproj
+++ b/RefreshTests.GameServer/RefreshTests.GameServer.csproj
@@ -59,7 +59,7 @@
     </ItemGroup>
     
     <ItemGroup Condition="'$(Configuration)'=='DebugPostgres'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -170,8 +170,8 @@ public class TestContext : IDisposable
 
     public void Dispose()
     {
-        this.DatabaseProvider.Dispose();
         this.Database.Dispose();
+        this.DatabaseProvider.Dispose();
         this.Http.Dispose();
         this.Listener.Dispose();
 

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -19,14 +19,16 @@ public class TestContext : IDisposable
 {
     public Lazy<TestRefreshGameServer> Server { get; }
     public GameDatabaseContext Database { get; }
+    public TestGameDatabaseProvider DatabaseProvider { get; }
     public HttpClient Http { get; }
     public MockDateTimeProvider Time { get; }
     private DirectHttpListener Listener { get; }
     
-    public TestContext(Lazy<TestRefreshGameServer> server, GameDatabaseContext database, HttpClient http, DirectHttpListener listener, MockDateTimeProvider time)
+    public TestContext(Lazy<TestRefreshGameServer> server, TestGameDatabaseProvider database, HttpClient http, DirectHttpListener listener, MockDateTimeProvider time)
     {
         this.Server = server;
-        this.Database = database;
+        this.DatabaseProvider = database;
+        this.Database = database.GetContext();
         this.Http = http;
         this.Listener = listener;
         this.Time = time;
@@ -168,6 +170,7 @@ public class TestContext : IDisposable
 
     public void Dispose()
     {
+        this.DatabaseProvider.Dispose();
         this.Database.Dispose();
         this.Http.Dispose();
         this.Listener.Dispose();

--- a/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
@@ -424,7 +424,7 @@ public class ScoreLeaderboardTests : GameServerTest
             // Check that notification was sent to the last #1 users
             if (lastBestScore == null) continue;
 
-            GameUser notificationRecipient = lastBestScore.Players.First();
+            GameUser notificationRecipient = context.Database.GetSubmittingPlayerFromScore(lastBestScore)!;
             GameNotification? notification = context.Database.GetNotificationsByUser(notificationRecipient, 1, 0).Items.FirstOrDefault();
 
             if (lastBestScore.Score <= 0)


### PR DESCRIPTION
This PR does a couple new things. Most importantly is that each test has its own 100% real Postgres database. This is achieved through Docker containers thanks to the Testcontainers library.

Unfortunately this will mean that tests will take longer to run, but it also gives us the 100% security that everything will just work, because Postgres has more restrictions than the in-memory database we were using previously. When I switched to this method of testing, I was actually very surprised because the error count jumped to 90. Most things were getting flagged because you can't run multiple SQL queries on the same context, but by sprinkling some `.ToArray` calls down everywhere I was able to get things back to where they were. We will have to revisit how mapping works though as this causes a lot of DB calls.

This also introduces a workflow for the Postgres configuration. It's there mainly to test that the new Postgres stuff would work in CI, so I've allowed it to just fail for now. I can't do this cleanly because GitHub Actions still hasn't gotten their shit together regarding an option like `allow-failure`: https://github.com/actions/runner/issues/2347

The current failing test count is now down to 15.
![image](https://github.com/user-attachments/assets/b18b81d2-f603-4a61-91c0-f7a05c399e98)