### PR TITLE
Allow specifying the connection string for Postgres

### DIFF
--- a/Refresh.Core/Configuration/DatabaseConfig.cs
+++ b/Refresh.Core/Configuration/DatabaseConfig.cs
@@ -1,0 +1,19 @@
+﻿using Bunkum.Core.Configuration;
+using Refresh.Database;
+using Refresh.Database.Configuration;
+
+namespace Refresh.Core.Configuration;
+
+public class DatabaseConfig : Config, IDatabaseConfig
+{
+    public override int CurrentConfigVersion => 1;
+    public override int Version { get; set; }
+    
+    protected override void Migrate(int oldVer, dynamic oldConfig)
+    {
+        
+    }
+
+    public string ConnectionString { get; set; } = "Database=refresh;Username=refresh;Password=refresh;Host=localhost;Port=5432";
+    public bool PreferConnectionStringEnvironmentVariable { get; set; } = false;
+}

--- a/Refresh.Core/Configuration/DatabaseConfig.cs
+++ b/Refresh.Core/Configuration/DatabaseConfig.cs
@@ -15,5 +15,5 @@ public class DatabaseConfig : Config, IDatabaseConfig
     }
 
     public string ConnectionString { get; set; } = "Database=refresh;Username=refresh;Password=refresh;Host=localhost;Port=5432";
-    public bool PreferConnectionStringEnvironmentVariable { get; set; } = false;
+    public bool PreferConnectionStringEnvironmentVariable { get; set; } = true;
 }

--- a/Refresh.Core/RefreshContext.cs
+++ b/Refresh.Core/RefreshContext.cs
@@ -11,4 +11,5 @@ public enum RefreshContext
     Publishing,
     Aipi,
     Presence,
+    Database,
 }

--- a/Refresh.Database/Configuration/EmptyDatabaseConfig.cs
+++ b/Refresh.Database/Configuration/EmptyDatabaseConfig.cs
@@ -1,10 +1,9 @@
-﻿using Npgsql;
-
-namespace Refresh.Database.Configuration;
+﻿namespace Refresh.Database.Configuration;
 
 public class EmptyDatabaseConfig : IDatabaseConfig
 {
-    public string ConnectionString => new NpgsqlConnectionStringBuilder
+    #if POSTGRES
+    public string ConnectionString => new Npgsql.NpgsqlConnectionStringBuilder
     {
         Database = "refresh",
         Username = "refresh",
@@ -12,6 +11,9 @@ public class EmptyDatabaseConfig : IDatabaseConfig
         Host = "localhost",
         Port = 5432,
     }.ToString();
+    #else
+    public string ConnectionString => string.Empty;
+    #endif
 
     public bool PreferConnectionStringEnvironmentVariable => false;
 }

--- a/Refresh.Database/Configuration/EmptyDatabaseConfig.cs
+++ b/Refresh.Database/Configuration/EmptyDatabaseConfig.cs
@@ -1,0 +1,17 @@
+﻿using Npgsql;
+
+namespace Refresh.Database.Configuration;
+
+public class EmptyDatabaseConfig : IDatabaseConfig
+{
+    public string ConnectionString => new NpgsqlConnectionStringBuilder
+    {
+        Database = "refresh",
+        Username = "refresh",
+        Password = "refresh",
+        Host = "localhost",
+        Port = 5432,
+    }.ToString();
+
+    public bool PreferConnectionStringEnvironmentVariable => false;
+}

--- a/Refresh.Database/Configuration/IDatabaseConfig.cs
+++ b/Refresh.Database/Configuration/IDatabaseConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace Refresh.Database.Configuration;
+
+public interface IDatabaseConfig
+{
+    public string ConnectionString { get; }
+    public bool PreferConnectionStringEnvironmentVariable { get; }
+}

--- a/Refresh.Database/GameDatabaseContext.cs
+++ b/Refresh.Database/GameDatabaseContext.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Refresh.Common.Time;
+using Refresh.Database.Configuration;
 using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Activity;
 using Refresh.Database.Models.Assets;
@@ -35,6 +36,7 @@ public partial class GameDatabaseContext :
     private static readonly object IdLock = new();
 
     private readonly IDateTimeProvider _time;
+    private readonly IDatabaseConfig _config;
     
     #if !POSTGRES
     private RealmDbSet<GameUser> GameUsers => new(this._realm);
@@ -119,14 +121,15 @@ public partial class GameDatabaseContext :
     internal DbSet<GameSkillReward> GameSkillRewards { get; set; }
     #endif
     
-    internal GameDatabaseContext(IDateTimeProvider time)
+    internal GameDatabaseContext(IDateTimeProvider time, IDatabaseConfig config)
     {
         this._time = time;
+        this._config = config;
     }
 
 #if POSTGRES
     [Obsolete("For use by the `dotnet ef` tool only.", true)]
-    public GameDatabaseContext() : this(new SystemDateTimeProvider())
+    public GameDatabaseContext() : this(new SystemDateTimeProvider(), new EmptyDatabaseConfig())
     {}
 
     protected override void OnConfiguring(DbContextOptionsBuilder options)

--- a/Refresh.Database/GameDatabaseProvider.cs
+++ b/Refresh.Database/GameDatabaseProvider.cs
@@ -1,4 +1,5 @@
 using Refresh.Common.Time;
+using Refresh.Database.Configuration;
 #if !POSTGRES
 using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Comments;
@@ -27,15 +28,18 @@ public class GameDatabaseProvider :
 #endif
 {
     private readonly IDateTimeProvider _time;
+    private readonly IDatabaseConfig _config;
     
     public GameDatabaseProvider()
     {
         this._time = new SystemDateTimeProvider();
+        this._config = new EmptyDatabaseConfig();
     }
 
     protected GameDatabaseProvider(IDateTimeProvider time)
     {
         this._time = time;
+        this._config = new EmptyDatabaseConfig();
     }
     
     #if POSTGRES
@@ -137,7 +141,7 @@ public class GameDatabaseProvider :
     protected override GameDatabaseContext CreateContext()
     #endif
     {
-        return new GameDatabaseContext(this._time);
+        return new GameDatabaseContext(this._time, this._config);
     }
 
     #if !POSTGRES

--- a/Refresh.Database/GameDatabaseProvider.cs
+++ b/Refresh.Database/GameDatabaseProvider.cs
@@ -28,18 +28,18 @@ public class GameDatabaseProvider :
 #endif
 {
     private readonly IDateTimeProvider _time;
-    private readonly IDatabaseConfig _config;
-    
-    public GameDatabaseProvider()
+    private readonly IDatabaseConfig _dbConfig;
+
+    public GameDatabaseProvider(IDatabaseConfig dbConfig)
     {
         this._time = new SystemDateTimeProvider();
-        this._config = new EmptyDatabaseConfig();
+        this._dbConfig = dbConfig;
     }
 
     protected GameDatabaseProvider(IDateTimeProvider time)
     {
         this._time = time;
-        this._config = new EmptyDatabaseConfig();
+        this._dbConfig = new EmptyDatabaseConfig();
     }
     
     #if POSTGRES
@@ -141,7 +141,7 @@ public class GameDatabaseProvider :
     protected override GameDatabaseContext CreateContext()
     #endif
     {
-        return new GameDatabaseContext(this._time, this._config);
+        return new GameDatabaseContext(this._time, this._dbConfig);
     }
 
     #if !POSTGRES

--- a/RefreshTests.GameServer/GameServer/TestDatabaseConfig.cs
+++ b/RefreshTests.GameServer/GameServer/TestDatabaseConfig.cs
@@ -1,15 +1,23 @@
 ﻿using Refresh.Database.Configuration;
-using Testcontainers.PostgreSql;
 
 namespace RefreshTests.GameServer.GameServer;
 
 public class TestDatabaseConfig : IDatabaseConfig
 {
-    public TestDatabaseConfig(PostgreSqlContainer container)
+    #if POSTGRES
+    public TestDatabaseConfig(Testcontainers.PostgreSql.PostgreSqlContainer container)
     {
         this.ConnectionString = container.GetConnectionString() + ";Include Error Detail=true";
         this.PreferConnectionStringEnvironmentVariable = false;
     }
+    #else
+    // ReSharper disable once ConvertConstructorToMemberInitializers
+    public TestDatabaseConfig()
+    {
+        this.ConnectionString = "";
+        this.PreferConnectionStringEnvironmentVariable = false;
+    }
+    #endif
     
     public string ConnectionString { get; }
     public bool PreferConnectionStringEnvironmentVariable { get; }

--- a/RefreshTests.GameServer/GameServer/TestDatabaseConfig.cs
+++ b/RefreshTests.GameServer/GameServer/TestDatabaseConfig.cs
@@ -1,0 +1,16 @@
+﻿using Refresh.Database.Configuration;
+using Testcontainers.PostgreSql;
+
+namespace RefreshTests.GameServer.GameServer;
+
+public class TestDatabaseConfig : IDatabaseConfig
+{
+    public TestDatabaseConfig(PostgreSqlContainer container)
+    {
+        this.ConnectionString = container.GetConnectionString() + ";Include Error Detail=true";
+        this.PreferConnectionStringEnvironmentVariable = false;
+    }
+    
+    public string ConnectionString { get; }
+    public bool PreferConnectionStringEnvironmentVariable { get; }
+}

--- a/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
+++ b/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
@@ -18,7 +18,7 @@ public class TestGameDatabaseContext : GameDatabaseContext
         throw new InvalidOperationException("Do not use this constructor.");
     }
 
-    public TestGameDatabaseContext(IDateTimeProvider time, PostgreSqlContainer container) : base(time)
+    public TestGameDatabaseContext(IDateTimeProvider time, PostgreSqlContainer container) : base(time, new TestDatabaseConfig(container))
     {
         this._container = container;
     }

--- a/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
+++ b/RefreshTests.GameServer/GameServer/TestGameDatabaseContext.cs
@@ -1,7 +1,5 @@
 ﻿#if POSTGRES
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using Refresh.Common.Time;
 using Refresh.Database;
 using Testcontainers.PostgreSql;
@@ -10,24 +8,9 @@ namespace RefreshTests.GameServer.GameServer;
 
 public class TestGameDatabaseContext : GameDatabaseContext
 {
-    private readonly PostgreSqlContainer _container;
-    
-    [Obsolete("Do not use.", true)]
-    public TestGameDatabaseContext()
-    {
-        throw new InvalidOperationException("Do not use this constructor.");
-    }
-
-    public TestGameDatabaseContext(IDateTimeProvider time, PostgreSqlContainer container) : base(time, new TestDatabaseConfig(container))
-    {
-        this._container = container;
-    }
-
-    protected override void OnConfiguring(DbContextOptionsBuilder options)
-    {
-        options.UseNpgsql(this._container.GetConnectionString() + ";Include Error Detail=true");
-        // options.LogTo(Console.WriteLine, LogLevel.Information);
-    }
+    public TestGameDatabaseContext(IDateTimeProvider time, PostgreSqlContainer container) :
+        base(time, new TestDatabaseConfig(container))
+    {}
 }
 
 #endif


### PR DESCRIPTION
This can be done with either of the following methods:

- Using the `POSTGRES_CONNECTION_STRING` environment variable
- Writing it to `db.json`

This refactors a bit of the database initialization code to make this possible.

On Realm builds, this creates the new config file but has no effect