### PR TITLE
Temporarily add option to enable `RemoteRefreshDataStore` in `DebugPostgres` builds

### DIFF
--- a/Refresh.Core/Storage/DryArchiveConfig.cs
+++ b/Refresh.Core/Storage/DryArchiveConfig.cs
@@ -15,4 +15,9 @@ public class DryArchiveConfig : Config
     public bool Enabled { get; set; }
     public string Location { get; set; } = "/var/dry/";
     public bool UseFolderNames { get; set; } = true;
+    
+#if DEBUG && POSTGRES
+    // ReSharper disable once InconsistentNaming
+    public bool TemporaryWillBeRemoved_UseProductionRefreshData { get; set; } = false;
+#endif
 }

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -63,9 +63,10 @@ public class RefreshGameServer : RefreshServer
 
         this._dataStore = dataStore;
 
+        DryArchiveConfig? dryConfig = null;
         try
         {
-            DryArchiveConfig dryConfig = Config.LoadFromJsonFile<DryArchiveConfig>("dry.json", this.Logger);
+            dryConfig = Config.LoadFromJsonFile<DryArchiveConfig>("dry.json", this.Logger);
             if (dryConfig.Enabled)
                 this._dataStore = new AggregateDataStore(dataStore, new DryDataStore(dryConfig));
         }
@@ -95,9 +96,11 @@ public class RefreshGameServer : RefreshServer
         this._databaseProvider.Initialize();
 
         // Uncomment if you want to use production refresh as a source for assets
-        #if DEBUG
-        // this._dataStore = new AggregateDataStore(dataStore, new RemoteRefreshDataStore());
-        #endif
+        // TODO: remove config option when test.lbpbonsai.com instance no longer needs prod assets
+#if DEBUG && POSTGRES
+        if (dryConfig?.TemporaryWillBeRemoved_UseProductionRefreshData ?? false)
+            this._dataStore = new AggregateDataStore(dataStore, new RemoteRefreshDataStore());
+#endif
         
         this.SetupInitializer(() =>
         {


### PR DESCRIPTION
For testing on https://test.lbpbonsai.com