### PR TITLE
Don't allow Cloudflare to mutate game requests

### DIFF
--- a/Refresh.GameServer/Middlewares/DeflateMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/DeflateMiddleware.cs
@@ -42,6 +42,10 @@ public class DeflateMiddleware(GameServerConfig config) : IMiddleware
         context.ResponseHeaders["Vary"] = "Accept-Encoding";
         context.ResponseHeaders["Content-Encoding"] = "deflate";
         
+        // If the request is coming through Cloudflare, tell cloudflare not to touch the data
+        if (context.RequestHeaders["Cf-Ray"] != null)
+            context.ResponseHeaders["Cache-Control"] = "no-transform";
+        
         // Create a copy of our uncompressed data
         byte[] uncompressed = context.ResponseStream.ToArray();
         

--- a/Refresh.sln.DotSettings
+++ b/Refresh.sln.DotSettings
@@ -41,6 +41,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ingame/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inmemory/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=jvyden/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lbpbonsai/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lbpcool/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lbppsp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lbpv/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Thanks to @uhwot for discovering this incorrect configuration.

Instead of patching production I decided to implement the logic in Refresh itself so it works for everyone, everywhere.