### PR TITLE
Fix rate-limiting logic applying globally for every user

### DIFF
--- a/Refresh.Database/Models/Users/GameUser.cs
+++ b/Refresh.Database/Models/Users/GameUser.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Xml.Serialization;
 using MongoDB.Bson;
 using Bunkum.Core.RateLimit;
@@ -164,8 +165,7 @@ public partial class GameUser : IRateLimitUser
         return this.UserId.Equals(id);
     }
 
-    // Defined in authentication provider. Avoids Realm threading nonsense.
-    [NotMapped] [XmlIgnore] public object RateLimitUserId { get; set; } = null!;
+    [NotMapped] public object RateLimitUserId => this.UserId; 
 
     #endregion
 

--- a/Refresh.GameServer/Authentication/GameAuthenticationProvider.cs
+++ b/Refresh.GameServer/Authentication/GameAuthenticationProvider.cs
@@ -65,7 +65,6 @@ public class GameAuthenticationProvider : IAuthenticationProvider<Token>
             return null;
 
         GameUser user = token.User;
-        user.RateLimitUserId = user.UserId;
         
         // Don't allow non-admins to authenticate during maintenance mode.
         // technically, this check isn't here for token but this is okay since


### PR DESCRIPTION
Previously, Realm would share returned users or presumably operate with magic.

The assumption that `RateLimitUserId` would be held for every GameUser no longer holds true with Postgres/EF, so make it work with Bunkum as intended.

I highly suspect rate-limiting was never working properly.