### PR TITLE
DB Schema Cleanup

### DIFF
--- a/Refresh.Database/Extensions/LevelEnumerableExtensions.cs
+++ b/Refresh.Database/Extensions/LevelEnumerableExtensions.cs
@@ -10,12 +10,12 @@ public static class LevelEnumerableExtensions
     public static IEnumerable<GameLevel> FilterByGameVersion(this IEnumerable<GameLevel> levels, TokenGame gameVersion)
         => gameVersion switch
         {
-            TokenGame.LittleBigPlanet1 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet1),
-            TokenGame.LittleBigPlanet2 => levels.Where(l => l._GameVersion <= (int)TokenGame.LittleBigPlanet2),
-            TokenGame.LittleBigPlanet3 => levels.Where(l => l._GameVersion <= (int)TokenGame.LittleBigPlanet3),
-            TokenGame.LittleBigPlanetVita => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetVita),
-            TokenGame.LittleBigPlanetPSP => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetPSP),
-            TokenGame.BetaBuild => levels.Where(l => l._GameVersion == (int)TokenGame.BetaBuild),
+            TokenGame.LittleBigPlanet1 => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanet1),
+            TokenGame.LittleBigPlanet2 => levels.Where(l => l.GameVersion <= TokenGame.LittleBigPlanet2),
+            TokenGame.LittleBigPlanet3 => levels.Where(l => l.GameVersion <= TokenGame.LittleBigPlanet3),
+            TokenGame.LittleBigPlanetVita => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanetVita),
+            TokenGame.LittleBigPlanetPSP => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanetPSP),
+            TokenGame.BetaBuild => levels.Where(l => l.GameVersion == TokenGame.BetaBuild),
             TokenGame.Website => levels,
             _ => throw new ArgumentOutOfRangeException(nameof(gameVersion), gameVersion, null),
         };
@@ -23,12 +23,12 @@ public static class LevelEnumerableExtensions
     public static IQueryable<GameLevel> FilterByGameVersion(this IQueryable<GameLevel> levels, TokenGame gameVersion)
         => gameVersion switch
         {
-            TokenGame.LittleBigPlanet1 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet1),
-            TokenGame.LittleBigPlanet2 => levels.Where(l => l._GameVersion <= (int)TokenGame.LittleBigPlanet2),
-            TokenGame.LittleBigPlanet3 => levels.Where(l => l._GameVersion <= (int)TokenGame.LittleBigPlanet3),
-            TokenGame.LittleBigPlanetVita => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetVita),
-            TokenGame.LittleBigPlanetPSP => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanetPSP),
-            TokenGame.BetaBuild => levels.Where(l => l._GameVersion == (int)TokenGame.BetaBuild),
+            TokenGame.LittleBigPlanet1 => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanet1),
+            TokenGame.LittleBigPlanet2 => levels.Where(l => l.GameVersion <= TokenGame.LittleBigPlanet2),
+            TokenGame.LittleBigPlanet3 => levels.Where(l => l.GameVersion <= TokenGame.LittleBigPlanet3),
+            TokenGame.LittleBigPlanetVita => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanetVita),
+            TokenGame.LittleBigPlanetPSP => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanetPSP),
+            TokenGame.BetaBuild => levels.Where(l => l.GameVersion == TokenGame.BetaBuild),
             TokenGame.Website => levels,
             _ => throw new ArgumentOutOfRangeException(nameof(gameVersion), gameVersion, null),
         };
@@ -50,9 +50,9 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.GameVersion != TokenGame.BetaBuild)
         {
             levels = levelFilterSettings.GameFilterType switch {
-                GameFilterType.LittleBigPlanet1 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet1),
-                GameFilterType.LittleBigPlanet2 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet2),
-                //NOTE: ideally this should be .Where(l => l._GameVersion == (int)TokenGame.LittleBigPlane1 || l._GameVersion == (int)TokenGame.LittleBigPlane2)
+                GameFilterType.LittleBigPlanet1 => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanet1),
+                GameFilterType.LittleBigPlanet2 => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanet2),
+                //NOTE: ideally this should be .Where(l => l._GameVersion == TokenGame.LittleBigPlane1 || l._GameVersion == TokenGame.LittleBigPlane2)
                 //      however, there should be no differences in all real-world cases
                 GameFilterType.Both => levels,
                 _ => throw new ArgumentOutOfRangeException(),
@@ -62,12 +62,12 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.Players != 0) 
             levels = levels.Where(l => l.MaxPlayers >= levelFilterSettings.Players && l.MinPlayers <= levelFilterSettings.Players);
 
-        if (!levelFilterSettings.DisplayLbp1) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanet1);
-        if (!levelFilterSettings.DisplayLbp2) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanet2);
-        if (!levelFilterSettings.DisplayLbp3) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanet3);
-        if (!levelFilterSettings.DisplayVita) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanetVita);
-        if (!levelFilterSettings.DisplayPSP) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanetPSP);
-        if (!levelFilterSettings.DisplayBeta) levels = levels.Where(l => l._GameVersion != (int)TokenGame.BetaBuild);
+        if (!levelFilterSettings.DisplayLbp1) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanet1);
+        if (!levelFilterSettings.DisplayLbp2) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanet2);
+        if (!levelFilterSettings.DisplayLbp3) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanet3);
+        if (!levelFilterSettings.DisplayVita) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanetVita);
+        if (!levelFilterSettings.DisplayPSP) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanetPSP);
+        if (!levelFilterSettings.DisplayBeta) levels = levels.Where(l => l.GameVersion != TokenGame.BetaBuild);
         
         //TODO: store move compatibility for levels
         // levels = levelFilterSettings.MoveFilterType switch {
@@ -100,9 +100,9 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.GameVersion != TokenGame.BetaBuild)
         {
             levels = levelFilterSettings.GameFilterType switch {
-                GameFilterType.LittleBigPlanet1 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet1),
-                GameFilterType.LittleBigPlanet2 => levels.Where(l => l._GameVersion == (int)TokenGame.LittleBigPlanet2),
-                //NOTE: ideally this should be .Where(l => l._GameVersion == (int)TokenGame.LittleBigPlane1 || l._GameVersion == (int)TokenGame.LittleBigPlane2)
+                GameFilterType.LittleBigPlanet1 => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanet1),
+                GameFilterType.LittleBigPlanet2 => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanet2),
+                //NOTE: ideally this should be .Where(l => l._GameVersion == TokenGame.LittleBigPlane1 || l._GameVersion == TokenGame.LittleBigPlane2)
                 //      however, there should be no differences in all real-world cases
                 GameFilterType.Both => levels,
                 _ => throw new ArgumentOutOfRangeException(),
@@ -112,12 +112,12 @@ public static class LevelEnumerableExtensions
         if (levelFilterSettings.Players != 0) 
             levels = levels.Where(l => l.MaxPlayers >= levelFilterSettings.Players && l.MinPlayers <= levelFilterSettings.Players);
 
-        if (!levelFilterSettings.DisplayLbp1) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanet1);
-        if (!levelFilterSettings.DisplayLbp2) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanet2);
-        if (!levelFilterSettings.DisplayLbp3) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanet3);
-        if (!levelFilterSettings.DisplayVita) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanetVita);
-        if (!levelFilterSettings.DisplayPSP) levels = levels.Where(l => l._GameVersion != (int)TokenGame.LittleBigPlanetPSP);
-        if (!levelFilterSettings.DisplayBeta) levels = levels.Where(l => l._GameVersion != (int)TokenGame.BetaBuild);
+        if (!levelFilterSettings.DisplayLbp1) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanet1);
+        if (!levelFilterSettings.DisplayLbp2) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanet2);
+        if (!levelFilterSettings.DisplayLbp3) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanet3);
+        if (!levelFilterSettings.DisplayVita) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanetVita);
+        if (!levelFilterSettings.DisplayPSP) levels = levels.Where(l => l.GameVersion != TokenGame.LittleBigPlanetPSP);
+        if (!levelFilterSettings.DisplayBeta) levels = levels.Where(l => l.GameVersion != TokenGame.BetaBuild);
         
         //TODO: store move compatibility for levels
         // levels = levelFilterSettings.MoveFilterType switch {

--- a/Refresh.Database/GameDatabaseContext.Activity.cs
+++ b/Refresh.Database/GameDatabaseContext.Activity.cs
@@ -121,7 +121,7 @@ public partial class GameDatabaseContext // Activity
     )
     {
         IEnumerable<Event> events = this.GetEvents(parameters)
-            .Where(e => e._StoredDataType == (int)EventDataType.Level && e.StoredSequentialId == level.LevelId)
+            .Where(e => e.StoredDataType == EventDataType.Level && e.StoredSequentialId == level.LevelId)
             .OrderByDescending(e => e.Timestamp);
 
         return GetRecentActivity(events, parameters);

--- a/Refresh.Database/GameDatabaseContext.ActivityRead.cs
+++ b/Refresh.Database/GameDatabaseContext.ActivityRead.cs
@@ -29,7 +29,7 @@ public partial class GameDatabaseContext // ActivityRead
         return this.GetLevelById(e.StoredSequentialId.Value);
     }
 
-    public GameSubmittedScore? GetScoreFromEvent(Event e)
+    public GameScore? GetScoreFromEvent(Event e)
     {
         if (e.StoredDataType != EventDataType.Score)
             throw new InvalidOperationException($"Event does not store the correct data type (expected {nameof(EventDataType.Score)})");

--- a/Refresh.Database/GameDatabaseContext.ActivityWrite.cs
+++ b/Refresh.Database/GameDatabaseContext.ActivityWrite.cs
@@ -189,9 +189,9 @@ public partial class GameDatabaseContext // ActivityWrite
     }
 
     /// <summary>
-    /// Creates a new LevelScore event from a <see cref='GameSubmittedScore'/>, and adds it to the event list.
+    /// Creates a new LevelScore event from a <see cref='GameScore'/>, and adds it to the event list.
     /// </summary>
-    public Event CreateLevelScoreEvent(GameUser userFrom, GameSubmittedScore score)
+    public Event CreateLevelScoreEvent(GameUser userFrom, GameScore score)
     {
         Event e = new()
         {

--- a/Refresh.Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.Database/GameDatabaseContext.Assets.cs
@@ -20,7 +20,7 @@ public partial class GameDatabaseContext // Assets
         => new(this.GameAssetsIncluded.Where(a => a.OriginalUploader == user), skip, count);
     
     public DatabaseList<GameAsset> GetAssetsUploadedByUser(GameUser? user, int skip, int count, GameAssetType type)
-        => new(this.GameAssetsIncluded.Where(a => a.OriginalUploader == user && a._AssetType == (int)type), skip, count);
+        => new(this.GameAssetsIncluded.Where(a => a.OriginalUploader == user && a.AssetType == type), skip, count);
 
     public GameAssetType? GetConvertedType(string hash)
     {
@@ -70,7 +70,7 @@ public partial class GameDatabaseContext // Assets
     
     public IEnumerable<GameAsset> GetAssetsByType(GameAssetType type) =>
         this.GameAssetsIncluded
-            .Where(a => a._AssetType == (int)type);
+            .Where(a => a.AssetType == type);
 
     public void AddAssetToDatabase(GameAsset asset) =>
         this.Write(() =>

--- a/Refresh.Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.Database/GameDatabaseContext.Leaderboard.cs
@@ -11,16 +11,16 @@ namespace Refresh.Database;
 
 public partial class GameDatabaseContext // Leaderboard
 {
-    private IQueryable<GameSubmittedScore> GameSubmittedScoresIncluded => this.GameSubmittedScores
+    private IQueryable<GameScore> GameScoresIncluded => this.GameScores
         .Include(s => s.Level)
         .Include(s => s.Level.Publisher);
     
-    public GameSubmittedScore SubmitScore(ISerializedScore score, Token token, GameLevel level)
+    public GameScore SubmitScore(ISerializedScore score, Token token, GameLevel level)
         => this.SubmitScore(score, token.User, level, token.TokenGame, token.TokenPlatform);
 
-    public GameSubmittedScore SubmitScore(ISerializedScore score, GameUser user, GameLevel level, TokenGame game, TokenPlatform platform)
+    public GameScore SubmitScore(ISerializedScore score, GameUser user, GameLevel level, TokenGame game, TokenPlatform platform)
     {
-        GameSubmittedScore newScore = new()
+        GameScore newScore = new()
         {
             Score = score.Score,
             ScoreType = score.ScoreType,
@@ -33,7 +33,7 @@ public partial class GameDatabaseContext // Leaderboard
 
         this.Write(() =>
         {
-            this.GameSubmittedScores.Add(newScore);
+            this.GameScores.Add(newScore);
         });
 
         this.CreateLevelScoreEvent(user, newScore);
@@ -62,9 +62,9 @@ public partial class GameDatabaseContext // Leaderboard
         return newScore;
     }
     
-    public DatabaseList<GameSubmittedScore> GetTopScoresForLevel(GameLevel level, int count, int skip, byte type, bool showDuplicates = false)
+    public DatabaseList<GameScore> GetTopScoresForLevel(GameLevel level, int count, int skip, byte type, bool showDuplicates = false)
     {
-        IEnumerable<GameSubmittedScore> scores = this.GameSubmittedScoresIncluded
+        IEnumerable<GameScore> scores = this.GameScoresIncluded
             .Where(s => s.ScoreType == type && s.Level == level)
             .OrderByDescending(s => s.Score)
             .AsEnumerableIfRealm();
@@ -72,16 +72,16 @@ public partial class GameDatabaseContext // Leaderboard
         if (!showDuplicates)
             scores = scores.DistinctBy(s => s.PlayerIds[0]);
 
-        return new DatabaseList<GameSubmittedScore>(scores, skip, count);
+        return new DatabaseList<GameScore>(scores, skip, count);
     }
 
-    public IEnumerable<ScoreWithRank> GetRankedScoresAroundScore(GameSubmittedScore score, int count)
+    public IEnumerable<ScoreWithRank> GetRankedScoresAroundScore(GameScore score, int count)
     {
         if (count % 2 != 1) throw new ArgumentException("The number of scores must be odd.", nameof(count));
         
         // this is probably REALLY fucking slow, and i probably shouldn't be trusted with LINQ anymore
 
-        List<GameSubmittedScore> scores = this.GameSubmittedScoresIncluded
+        List<GameScore> scores = this.GameScoresIncluded
             .Where(s => s.ScoreType == score.ScoreType && s.Level == score.Level)
             .OrderByDescending(s => s.Score)
             .AsEnumerable()
@@ -101,7 +101,7 @@ public partial class GameDatabaseContext // Leaderboard
             .AsEnumerableIfRealm()
             .Select(u => u.UserId);
         
-        IEnumerable<GameSubmittedScore> scores = this.GameSubmittedScores
+        IEnumerable<GameScore> scores = this.GameScores
             .Where(s => s.ScoreType == type && s.Level == level)
             .OrderByDescending(s => s.Score)
             .AsEnumerableIfRealm()
@@ -116,7 +116,7 @@ public partial class GameDatabaseContext // Leaderboard
 
     [Pure]
     [ContractAnnotation("null => null; notnull => canbenull")]
-    public GameSubmittedScore? GetScoreByUuid(string? uuid)
+    public GameScore? GetScoreByUuid(string? uuid)
     {
         if (uuid == null) return null;
         if(!ObjectId.TryParse(uuid, out ObjectId objectId)) return null;
@@ -126,14 +126,14 @@ public partial class GameDatabaseContext // Leaderboard
     
     [Pure]
     [ContractAnnotation("null => null; notnull => canbenull")]
-    public GameSubmittedScore? GetScoreByObjectId(ObjectId? id)
+    public GameScore? GetScoreByObjectId(ObjectId? id)
     {
         if (id == null) return null;
-        return this.GameSubmittedScoresIncluded
+        return this.GameScoresIncluded
             .FirstOrDefault(u => u.ScoreId == id);
     }
     
-    public void DeleteScore(GameSubmittedScore score)
+    public void DeleteScore(GameScore score)
     {
         IQueryable<Event> scoreEvents = this.Events
             .Where(e => e.StoredDataType == EventDataType.Score && e.StoredObjectId == score.ScoreId);
@@ -141,13 +141,13 @@ public partial class GameDatabaseContext // Leaderboard
         this.Write(() =>
         {
             this.Events.RemoveRange(scoreEvents);
-            this.GameSubmittedScores.Remove(score);
+            this.GameScores.Remove(score);
         });
     }
     
     public void DeleteScoresSetByUser(GameUser user)
     {
-        IEnumerable<GameSubmittedScore> scores = this.GameSubmittedScores
+        IEnumerable<GameScore> scores = this.GameScores
             // FIXME: Realm (ahem, I mean the atlas device sdk *rolls eyes*) is a fucking joke.
             // Realm doesn't support .Contains on IList<T>. Yes, really.
             // This means we are forced to iterate over EVERY SCORE.
@@ -158,18 +158,18 @@ public partial class GameDatabaseContext // Leaderboard
         
         this.Write(() =>
         {
-            foreach (GameSubmittedScore score in scores)
+            foreach (GameScore score in scores)
             {
                 IQueryable<Event> scoreEvents = this.Events
                     .Where(e => e.StoredDataType == EventDataType.Score && e.StoredObjectId == score.ScoreId);
                 
                 this.Events.RemoveRange(scoreEvents);
-                this.GameSubmittedScores.Remove(score);
+                this.GameScores.Remove(score);
             }
         });
     }
 
-    public IEnumerable<GameUser> GetPlayersFromScore(GameSubmittedScore score)
+    public IEnumerable<GameUser> GetPlayersFromScore(GameScore score)
     {
         IEnumerable<ObjectId> playerIds = score.PlayerIds.Select(p => p);
         return this.GameUsers
@@ -177,7 +177,7 @@ public partial class GameDatabaseContext // Leaderboard
             .Where(u => playerIds.Contains(u.UserId));
     }
     
-    public GameUser? GetSubmittingPlayerFromScore(GameSubmittedScore score)
+    public GameUser? GetSubmittingPlayerFromScore(GameScore score)
     {
         return this.GetUserByUuid(score.PlayerIdsRaw.FirstOrDefault());
     }

--- a/Refresh.Database/GameDatabaseContext.Leaderboard.cs
+++ b/Refresh.Database/GameDatabaseContext.Leaderboard.cs
@@ -136,7 +136,7 @@ public partial class GameDatabaseContext // Leaderboard
     public void DeleteScore(GameSubmittedScore score)
     {
         IQueryable<Event> scoreEvents = this.Events
-            .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
+            .Where(e => e.StoredDataType == EventDataType.Score && e.StoredObjectId == score.ScoreId);
         
         this.Write(() =>
         {
@@ -161,7 +161,7 @@ public partial class GameDatabaseContext // Leaderboard
             foreach (GameSubmittedScore score in scores)
             {
                 IQueryable<Event> scoreEvents = this.Events
-                    .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
+                    .Where(e => e.StoredDataType == EventDataType.Score && e.StoredObjectId == score.ScoreId);
                 
                 this.Events.RemoveRange(scoreEvents);
                 this.GameSubmittedScores.Remove(score);

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -220,16 +220,16 @@ public partial class GameDatabaseContext // Levels
             }
             this.GameChallenges.RemoveRange(challenges);
             
-            IQueryable<GameSubmittedScore> scores = this.GameSubmittedScores.Where(r => r.Level == level);
+            IQueryable<GameScore> scores = this.GameScores.Where(r => r.Level == level);
             
-            foreach (GameSubmittedScore score in scores)
+            foreach (GameScore score in scores)
             {
                 IQueryable<Event> scoreEvents = this.Events
                     .Where(e => e.StoredDataType == EventDataType.Score && e.StoredObjectId == score.ScoreId);
                 this.Events.RemoveRange(scoreEvents);
             }
             
-            this.GameSubmittedScores.RemoveRange(scores);
+            this.GameScores.RemoveRange(scores);
         });
 
         //do in separate transaction in a vain attempt to fix Weirdness with favourite level relations having missing levels

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -199,7 +199,7 @@ public partial class GameDatabaseContext // Levels
         this.Write(() =>
         {
             IQueryable<Event> levelEvents = this.Events
-                .Where(e => e._StoredDataType == (int)EventDataType.Level && e.StoredSequentialId == level.LevelId);
+                .Where(e => e.StoredDataType == EventDataType.Level && e.StoredSequentialId == level.LevelId);
             
             this.Events.RemoveRange(levelEvents);
 
@@ -225,7 +225,7 @@ public partial class GameDatabaseContext // Levels
             foreach (GameSubmittedScore score in scores)
             {
                 IQueryable<Event> scoreEvents = this.Events
-                    .Where(e => e._StoredDataType == (int)EventDataType.Score && e.StoredObjectId == score.ScoreId);
+                    .Where(e => e.StoredDataType == EventDataType.Score && e.StoredObjectId == score.ScoreId);
                 this.Events.RemoveRange(scoreEvents);
             }
             
@@ -365,7 +365,7 @@ public partial class GameDatabaseContext // Levels
         
         IEnumerable<GameLevel> filteredTaggedLevels = tagRelations
             .Include(x => x.Level.Publisher)
-            .Where(x => x._Tag == (int)tag)
+            .Where(x => x.Tag == tag)
             .AsEnumerableIfRealm()
             .Select(x => x.Level)
             .Distinct()
@@ -427,7 +427,7 @@ public partial class GameDatabaseContext // Levels
             .Include(r => r.Level.Publisher)
             .AsEnumerableIfRealm()
             .GroupBy(r => r.Level)
-            .Select(g => new { Level = g.Key, Karma = g.Sum(r => r._RatingType) })
+            .Select(g => new { Level = g.Key, Karma = g.Sum(r => (int)r.RatingType) })
             .OrderByDescending(x => x.Karma) // reddit moment
             .Select(x => x.Level)
             .Where(l => l != null)
@@ -517,7 +517,7 @@ public partial class GameDatabaseContext // Levels
     
     public int GetTotalLevelsPublishedByUser(GameUser user, TokenGame game)
         => this.GameLevels
-            .Count(r => r.Publisher == user && r._GameVersion == (int)game);
+            .Count(r => r.Publisher == user && r.GameVersion == game);
     
     [Pure]
     public int GetTotalTeamPickCount(TokenGame game) => this.GameLevels.FilterByGameVersion(game).Count(l => l.DateTeamPicked != null);

--- a/Refresh.Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.Database/GameDatabaseContext.Photos.cs
@@ -68,7 +68,7 @@ public partial class GameDatabaseContext // Photos
         this.Write(() =>
         {
             IQueryable<Event> photoEvents = this.Events
-                .Where(e => e._StoredDataType == (int)EventDataType.Photo && e.StoredSequentialId == photo.PhotoId);
+                .Where(e => e.StoredDataType == EventDataType.Photo && e.StoredSequentialId == photo.PhotoId);
                 
             // Remove all events referencing the photo
             this.Events.RemoveRange(photoEvents);

--- a/Refresh.Database/GameDatabaseContext.Pins.cs
+++ b/Refresh.Database/GameDatabaseContext.Pins.cs
@@ -107,7 +107,7 @@ public partial class GameDatabaseContext // Pins
 
     private IEnumerable<ProfilePinRelation> GetProfilePinsByUser(GameUser user, TokenGame game)
         => this.ProfilePinRelations
-            .Where(p => p.Publisher == user && p._Game == (int)game)
+            .Where(p => p.Publisher == user && p.Game == game)
             .OrderBy(p => p.Index);
 
     public DatabaseList<ProfilePinRelation> GetProfilePinsByUser(GameUser user, TokenGame game, int skip, int count)

--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -309,7 +309,7 @@ public partial class GameDatabaseContext // Relations
         => this.RateReviewRelationsIncluded.FirstOrDefault(relation => relation.User == user && relation.Review == review);
     
     public bool ReviewRatingExists(GameUser user, GameReview review, RatingType rating)
-        => this.RateReviewRelations.Any(r => r.Review == review && r.User == user && r._ReviewRatingType == (int)rating);
+        => this.RateReviewRelations.Any(r => r.Review == review && r.User == user && r.RatingType == rating);
 
     private RateLevelRelation? GetRateRelationByUser(GameLevel level, GameUser user)
         => this.RateLevelRelationsIncluded.FirstOrDefault(r => r.User == user && r.Level == level);
@@ -358,7 +358,7 @@ public partial class GameDatabaseContext // Relations
     public int GetTotalRatingsForLevel(GameLevel level, RatingType type, bool includingAuthor = true) =>
         this.RateLevelRelations.Count(r =>
             r.Level == level &&
-            r._RatingType == (int)type && 
+            r.RatingType == type && 
             (includingAuthor || r.User != level.Publisher));
     
     /// <summary>
@@ -544,10 +544,10 @@ public partial class GameDatabaseContext // Relations
         => this.GetLevelCommentRelationByUser(comment, user)?.RatingType;
     
     public int GetTotalRatingsForProfileComment(GameProfileComment comment, RatingType type) =>
-        this.ProfileCommentRelations.Count(r => r.Comment == comment && r._RatingType == (int)type);
+        this.ProfileCommentRelations.Count(r => r.Comment == comment && r.RatingType == type);
     
     public int GetTotalRatingsForLevelComment(GameLevelComment comment, RatingType type) =>
-        this.LevelCommentRelations.Count(r => r.Comment == comment && r._RatingType == (int)type);
+        this.LevelCommentRelations.Count(r => r.Comment == comment && r.RatingType == type);
 
     private bool RateComment<TComment, TCommentRelation>(GameUser user, TComment comment, RatingType ratingType, DbSet<TCommentRelation> list)
         where TComment : class, IGameComment
@@ -623,10 +623,10 @@ public partial class GameDatabaseContext // Relations
  
         IEnumerable<TagLevelRelation> tags = levelTags
             .AsEnumerableIfRealm() // TODO: optimize for postgres when realm is deleted
-            .GroupBy(t => t._Tag).Select(g => g.First())
+            .GroupBy(t => t.Tag).Select(g => g.First())
             // ^ is equivalent to .DistinctBy(t => t._Tag)
             .AsEnumerable()
-            .OrderByDescending(t => levelTags.Count(levelTag => levelTag._Tag == t._Tag));
+            .OrderByDescending(t => levelTags.Count(levelTag => levelTag.Tag == t.Tag));
 
         return tags;
     }

--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -497,7 +497,7 @@ public partial class GameDatabaseContext // Relations
         this.UniquePlayLevelRelations.Count(r => r.Level == level && (includingAuthor || r.User != level.Publisher));
 
     public int GetTotalCompletionsForLevel(GameLevel level) =>
-        this.GameSubmittedScores.Count(s => s.Level == level);
+        this.GameScores.Count(s => s.Level == level);
 
     #endregion
 

--- a/Refresh.Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.Database/GameDatabaseContext.Tokens.cs
@@ -73,7 +73,7 @@ public partial class GameDatabaseContext // Tokens
     {
         Token? token = this.Tokens
             .Include(t => t.User)
-            .FirstOrDefault(t => t.TokenData == tokenData && t._TokenType == (int)type);
+            .FirstOrDefault(t => t.TokenData == tokenData && t.TokenType == type);
 
         if (token == null) return null;
 
@@ -105,7 +105,7 @@ public partial class GameDatabaseContext // Tokens
     {
         if (tokenData == null) return false;
 
-        Token? token = this.Tokens.FirstOrDefault(t => t.TokenData == tokenData && t._TokenType == (int)type);
+        Token? token = this.Tokens.FirstOrDefault(t => t.TokenData == tokenData && t.TokenType == type);
         if (token == null) return false;
 
         this.RevokeToken(token);
@@ -133,7 +133,7 @@ public partial class GameDatabaseContext // Tokens
     {
         this.Write(() =>
         {
-            this.Tokens.RemoveRange(t => t.User == user && t._TokenType == (int)type);
+            this.Tokens.RemoveRange(t => t.User == user && t.TokenType == type);
         });
     }
     

--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -322,10 +322,10 @@ public partial class GameDatabaseContext // Users
             this.GamePhotos.RemoveRange(p => p.Publisher == user);
             this.GameUserVerifiedIpRelations.RemoveRange(p => p.User == user);
             
-            foreach (GameSubmittedScore score in this.GameSubmittedScores.ToList())
+            foreach (GameScore score in this.GameScores.ToList())
             {
                 if (!score.PlayerIds.Contains(user.UserId)) continue;
-                this.GameSubmittedScores.Remove(score);
+                this.GameScores.Remove(score);
             }
             
             foreach (GameLevel level in this.GameLevels.Where(l => l.Publisher == user))

--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -266,12 +266,7 @@ public partial class GameDatabaseContext // Users
     public bool IsUserRestricted(GameUser user) => this.IsUserPunished(user, GameUserRole.Restricted);
 
     public DatabaseList<GameUser> GetAllUsersWithRole(GameUserRole role)
-    {
-        // for some stupid reason, we have to do the byte conversion here or realm won't work correctly.
-        byte roleByte = (byte)role;
-        
-        return new DatabaseList<GameUser>(this.GameUsers.Where(u => u._Role == roleByte));
-    }
+        => new(this.GameUsers.Where(u => u.Role == role));
 
     public void RenameUser(GameUser user, string newUsername)
     {

--- a/Refresh.Database/GameDatabaseContext.cs
+++ b/Refresh.Database/GameDatabaseContext.cs
@@ -43,7 +43,7 @@ public partial class GameDatabaseContext : DbContext, IDatabaseContext
     internal DbSet<UniquePlayLevelRelation> UniquePlayLevelRelations { get; set; }
     internal DbSet<RateLevelRelation> RateLevelRelations { get; set; }
     internal DbSet<Event> Events { get; set; }
-    internal DbSet<GameSubmittedScore> GameSubmittedScores { get; set; }
+    internal DbSet<GameScore> GameScores { get; set; }
     internal DbSet<GameAsset> GameAssets { get; set; }
     internal DbSet<GameNotification> GameNotifications { get; set; }
     internal DbSet<GamePhoto> GamePhotos { get; set; }

--- a/Refresh.Database/Migrations/20250625192822_CleanupRealmEnumWorkarounds.cs
+++ b/Refresh.Database/Migrations/20250625192822_CleanupRealmEnumWorkarounds.cs
@@ -1,0 +1,124 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250625192822_CleanupRealmEnumWorkarounds")]
+    /// <inheritdoc />
+    public partial class CleanupRealmEnumWorkarounds : Migration
+    {
+        private void MapFromEnum(MigrationBuilder migration, string name, string table, bool smallInt = true, [CanBeNull] string srcName = null)
+        {
+            if (srcName == null)
+                srcName = '_' + name;
+
+            migration.RenameColumn(srcName, table, name);
+
+            if (smallInt)
+                migration.AlterColumn<short>(name, table, type: "smallint");
+        }
+        
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migration)
+        {
+            migration.DropColumn(
+                name: "TokenGame",
+                table: "Tokens");
+
+            migration.DropColumn(
+                name: "TokenPlatform",
+                table: "Tokens");
+
+            migration.DropColumn(
+                name: "TokenType",
+                table: "Tokens");
+
+            this.MapFromEnum(migration, "TokenGame", "Tokens", false);
+            this.MapFromEnum(migration, "TokenPlatform", "Tokens", false);
+            this.MapFromEnum(migration, "TokenType", "Tokens", false);
+            
+            this.MapFromEnum(migration, "RatingType", "RateReviewRelations", srcName: "_ReviewRatingType");
+            this.MapFromEnum(migration, "RatingType", "RateLevelRelations");
+
+            migration.DropColumn(
+                name: "Game",
+                table: "ProfilePinRelations");
+            
+            this.MapFromEnum(migration, "Game", "ProfilePinRelations", false);
+
+            this.MapFromEnum(migration, "RatingType", "ProfileCommentRelations");
+            this.MapFromEnum(migration, "RatingType", "LevelCommentRelations");
+
+            migration.DropColumn(
+                name: "GameVersion",
+                table: "GameLevels");
+
+            migration.DropColumn(
+                name: "LevelType",
+                table: "GameLevels");
+            
+            this.MapFromEnum(migration, "GameVersion", "GameLevels", false);
+            this.MapFromEnum(migration, "LevelType", "GameLevels");
+
+            migration.DropColumn(
+                name: "Type",
+                table: "GameChallenges");
+
+            this.MapFromEnum(migration, "Type", "GameChallenges", false);
+            
+            this.MapFromEnum(migration, "AssetFormat", "GameAssets", srcName: "_AssetSerializationMethod");
+            
+            this.MapFromEnum(migration, "EventType", "Events");
+
+            migration.RenameColumn(
+                name: "_Tag",
+                table: "TagLevelRelations",
+                newName: "Tag");
+
+            migration.RenameColumn(
+                name: "_Role",
+                table: "GameUsers",
+                newName: "Role");
+
+            migration.RenameColumn(
+                name: "_Platform",
+                table: "GameSubmittedScores",
+                newName: "Platform");
+
+            migration.RenameColumn(
+                name: "_Game",
+                table: "GameSubmittedScores",
+                newName: "Game");
+
+            migration.RenameIndex(
+                name: "IX_GameSubmittedScores__Game_Score_ScoreType",
+                table: "GameSubmittedScores",
+                newName: "IX_GameSubmittedScores_Game_Score_ScoreType");
+
+            migration.RenameColumn(
+                name: "_ConditionType",
+                table: "GameSkillRewards",
+                newName: "ConditionType");
+
+            migration.RenameColumn(
+                name: "_AssetType",
+                table: "GameAssets",
+                newName: "AssetType");
+
+            migration.RenameColumn(
+                name: "_StoredDataType",
+                table: "Events",
+                newName: "StoredDataType");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            throw new Exception($"Downgrading is not supported with this {nameof(CleanupRealmEnumWorkarounds)}.");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/20250625194345_AddVisibilityToGameUsers.cs
+++ b/Refresh.Database/Migrations/20250625194345_AddVisibilityToGameUsers.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250625194345_AddVisibilityToGameUsers")]
+    /// <inheritdoc />
+    public partial class AddVisibilityToGameUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migration)
+        {
+            migration.AddColumn<int>("LevelVisibility", "GameUsers", type: "integer", nullable: false, defaultValue: 0);
+            migration.AddColumn<int>("ProfileVisibility", "GameUsers", type: "integer", nullable: false, defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migration)
+        {
+            migration.DropColumn("LevelVisibility", "GameUsers");
+            migration.DropColumn("ProfileVisibility", "GameUsers");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/20250625195135_RenameGameSubmittedScoreToGameScore.cs
+++ b/Refresh.Database/Migrations/20250625195135_RenameGameSubmittedScoreToGameScore.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250625195135_RenameGameSubmittedScoreToGameScore")]
+    /// <inheritdoc />
+    public partial class RenameGameSubmittedScoreToGameScore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameTable("GameSubmittedScores", newName: "GameScores");
+            migrationBuilder.RenameIndex("PK_GameSubmittedScores", "PK_GameScores");
+            migrationBuilder.RenameIndex("IX_GameSubmittedScores_Game_Score_ScoreType", "IX_GameScores_Game_Score_ScoreType");
+            migrationBuilder.RenameIndex("IX_GameSubmittedScores_LevelId", "IX_GameScores_LevelId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameTable("GameScores", newName: "GameSubmittedScores");
+            migrationBuilder.RenameIndex(newName: "PK_GameSubmittedScores", name: "PK_GameScores");
+            migrationBuilder.RenameIndex(newName: "IX_GameSubmittedScores_Game_Score_ScoreType", name: "IX_GameScores_Game_Score_ScoreType");
+            migrationBuilder.RenameIndex(newName: "IX_GameScores_LevelId", name: "IX_GameScores_LevelId");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -28,8 +28,14 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("EventId")
                         .HasColumnType("text");
 
+                    b.Property<byte>("EventType")
+                        .HasColumnType("smallint");
+
                     b.Property<bool>("IsPrivate")
                         .HasColumnType("boolean");
+
+                    b.Property<int>("StoredDataType")
+                        .HasColumnType("integer");
 
                     b.Property<string>("StoredObjectId")
                         .HasColumnType("text");
@@ -43,12 +49,6 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<int>("_EventType")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("_StoredDataType")
-                        .HasColumnType("integer");
 
                     b.HasKey("EventId");
 
@@ -71,6 +71,12 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("AsMipIconHash")
                         .HasColumnType("text");
 
+                    b.Property<byte>("AssetFormat")
+                        .HasColumnType("smallint");
+
+                    b.Property<int>("AssetType")
+                        .HasColumnType("integer");
+
                     b.Property<bool>("IsPSP")
                         .HasColumnType("boolean");
 
@@ -82,12 +88,6 @@ namespace Refresh.Database.Migrations
 
                     b.Property<DateTimeOffset>("UploadDate")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("_AssetSerializationMethod")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("_AssetType")
-                        .HasColumnType("integer");
 
                     b.HasKey("AssetHash");
 
@@ -132,15 +132,6 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<int>("_TokenGame")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("_TokenPlatform")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("_TokenType")
-                        .HasColumnType("integer");
 
                     b.HasKey("TokenId");
 
@@ -330,9 +321,6 @@ namespace Refresh.Database.Migrations
                     b.Property<byte>("Type")
                         .HasColumnType("smallint");
 
-                    b.Property<byte>("_Type")
-                        .HasColumnType("smallint");
-
                     b.HasKey("ChallengeId");
 
                     b.HasIndex("LevelId");
@@ -468,12 +456,6 @@ namespace Refresh.Database.Migrations
                     b.Property<DateTimeOffset>("UpdateDate")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int>("_GameVersion")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("_LevelType")
-                        .HasColumnType("integer");
-
                     b.HasKey("LevelId");
 
                     b.HasIndex("PublisherUserId");
@@ -491,6 +473,9 @@ namespace Refresh.Database.Migrations
                     b.Property<int>("Id")
                         .HasColumnType("integer");
 
+                    b.Property<int>("ConditionType")
+                        .HasColumnType("integer");
+
                     b.Property<bool>("Enabled")
                         .HasColumnType("boolean");
 
@@ -499,9 +484,6 @@ namespace Refresh.Database.Migrations
 
                     b.Property<string>("Title")
                         .HasColumnType("text");
-
-                    b.Property<int>("_ConditionType")
-                        .HasColumnType("integer");
 
                     b.HasKey("LevelId", "Id");
 
@@ -513,7 +495,13 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("ScoreId")
                         .HasColumnType("text");
 
+                    b.Property<int>("Game")
+                        .HasColumnType("integer");
+
                     b.Property<int>("LevelId")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("Platform")
                         .HasColumnType("integer");
 
                     b.PrimitiveCollection<List<string>>("PlayerIdsRaw")
@@ -528,17 +516,11 @@ namespace Refresh.Database.Migrations
                     b.Property<byte>("ScoreType")
                         .HasColumnType("smallint");
 
-                    b.Property<int>("_Game")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("_Platform")
-                        .HasColumnType("integer");
-
                     b.HasKey("ScoreId");
 
                     b.HasIndex("LevelId");
 
-                    b.HasIndex("_Game", "Score", "ScoreType");
+                    b.HasIndex("Game", "Score", "ScoreType");
 
                     b.ToTable("GameSubmittedScores");
                 });
@@ -833,15 +815,15 @@ namespace Refresh.Database.Migrations
                     b.Property<int>("CommentSequentialId")
                         .HasColumnType("integer");
 
+                    b.Property<short>("RatingType")
+                        .HasColumnType("smallint");
+
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<int>("_RatingType")
-                        .HasColumnType("integer");
 
                     b.HasKey("CommentRelationId");
 
@@ -935,15 +917,15 @@ namespace Refresh.Database.Migrations
                     b.Property<int>("CommentSequentialId")
                         .HasColumnType("integer");
 
+                    b.Property<short>("RatingType")
+                        .HasColumnType("smallint");
+
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<int>("_RatingType")
-                        .HasColumnType("integer");
 
                     b.HasKey("CommentRelationId");
 
@@ -970,9 +952,6 @@ namespace Refresh.Database.Migrations
 
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("_Game")
-                        .HasColumnType("integer");
 
                     b.HasKey("PinId", "PublisherId");
 
@@ -1007,15 +986,15 @@ namespace Refresh.Database.Migrations
                     b.Property<int>("LevelId")
                         .HasColumnType("integer");
 
+                    b.Property<short>("RatingType")
+                        .HasColumnType("smallint");
+
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UserId")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<int>("_RatingType")
-                        .HasColumnType("integer");
 
                     b.HasKey("RateLevelRelationId");
 
@@ -1034,11 +1013,11 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("UserId")
                         .HasColumnType("text");
 
+                    b.Property<short>("RatingType")
+                        .HasColumnType("smallint");
+
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("_ReviewRatingType")
-                        .HasColumnType("integer");
 
                     b.HasKey("ReviewId", "UserId");
 
@@ -1067,7 +1046,7 @@ namespace Refresh.Database.Migrations
 
             modelBuilder.Entity("Refresh.Database.Models.Relations.TagLevelRelation", b =>
                 {
-                    b.Property<byte>("_Tag")
+                    b.Property<byte>("Tag")
                         .HasColumnType("smallint");
 
                     b.Property<string>("UserId")
@@ -1079,7 +1058,7 @@ namespace Refresh.Database.Migrations
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
 
-                    b.HasKey("_Tag", "UserId", "LevelId");
+                    b.HasKey("Tag", "UserId", "LevelId");
 
                     b.HasIndex("LevelId");
 
@@ -1230,6 +1209,9 @@ namespace Refresh.Database.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
+                    b.Property<int>("LevelVisibility")
+                        .HasColumnType("integer");
+
                     b.Property<int>("LocationX")
                         .HasColumnType("integer");
 
@@ -1246,12 +1228,18 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("PresenceServerAuthToken")
                         .HasColumnType("text");
 
+                    b.Property<int>("ProfileVisibility")
+                        .HasColumnType("integer");
+
                     b.Property<bool>("PsnAuthenticationAllowed")
                         .HasColumnType("boolean");
 
                     b.Property<string>("PspIconHash")
                         .IsRequired()
                         .HasColumnType("text");
+
+                    b.Property<short>("Role")
+                        .HasColumnType("smallint");
 
                     b.Property<bool>("RpcnAuthenticationAllowed")
                         .HasColumnType("boolean");
@@ -1293,9 +1281,6 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("YayFaceHash")
                         .IsRequired()
                         .HasColumnType("text");
-
-                    b.Property<byte>("_Role")
-                        .HasColumnType("smallint");
 
                     b.HasKey("UserId");
 

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -490,7 +490,7 @@ namespace Refresh.Database.Migrations
                     b.ToTable("GameSkillRewards");
                 });
 
-            modelBuilder.Entity("Refresh.Database.Models.Levels.Scores.GameSubmittedScore", b =>
+            modelBuilder.Entity("Refresh.Database.Models.Levels.Scores.GameScore", b =>
                 {
                     b.Property<string>("ScoreId")
                         .HasColumnType("text");
@@ -522,7 +522,7 @@ namespace Refresh.Database.Migrations
 
                     b.HasIndex("Game", "Score", "ScoreType");
 
-                    b.ToTable("GameSubmittedScores");
+                    b.ToTable("GameScores");
                 });
 
             modelBuilder.Entity("Refresh.Database.Models.Notifications.GameAnnouncement", b =>
@@ -1474,7 +1474,7 @@ namespace Refresh.Database.Migrations
                     b.Navigation("Level");
                 });
 
-            modelBuilder.Entity("Refresh.Database.Models.Levels.Scores.GameSubmittedScore", b =>
+            modelBuilder.Entity("Refresh.Database.Models.Levels.Scores.GameScore", b =>
                 {
                     b.HasOne("Refresh.Database.Models.Levels.GameLevel", "Level")
                         .WithMany()

--- a/Refresh.Database/Models/Activity/DatabaseActivityPage.cs
+++ b/Refresh.Database/Models/Activity/DatabaseActivityPage.cs
@@ -44,7 +44,7 @@ public class DatabaseActivityPage
 
     public readonly List<GameUser> Users = [];
     public readonly List<GameLevel> Levels = [];
-    public readonly List<GameSubmittedScore> Scores = [];
+    public readonly List<GameScore> Scores = [];
     public readonly List<GamePhoto> Photos = [];
 
     #region Generation
@@ -159,7 +159,7 @@ public class DatabaseActivityPage
     {
         foreach (Event @event in events.Where(e => e.EventType == EventType.LevelScore))
         {
-            GameSubmittedScore score = this.Scores.First(u => u.ScoreId == @event.StoredObjectId);
+            GameScore score = this.Scores.First(u => u.ScoreId == @event.StoredObjectId);
             GameLevel level = score.Level;
 
             DatabaseActivityUserGroup group = GetOrCreateLevelUserGroup(@event, level);

--- a/Refresh.Database/Models/Activity/Event.cs
+++ b/Refresh.Database/Models/Activity/Event.cs
@@ -18,15 +18,8 @@ public partial class Event
     /// </summary>
     public ObjectId EventId { get; set; } = ObjectId.GenerateNewId();
     
-    [NotMapped]
-    public EventType EventType
-    {
-        get => (EventType)this._EventType;
-        set => this._EventType = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _EventType { get; set; }
+    public EventType EventType { get; set; }
+
 
     /// <summary>
     /// The user in question that created this event.
@@ -45,15 +38,7 @@ public partial class Event
     /// <summary>
     /// The type of data that this event is referencing.
     /// </summary>
-    [NotMapped]
-    public EventDataType StoredDataType
-    {
-        get => (EventDataType)this._StoredDataType;
-        set => this._StoredDataType = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _StoredDataType { get; set; }
+    public EventDataType StoredDataType { get; set; }
     
     /// <summary>
     /// The sequential ID of the object this event is referencing. If null, use <see cref="StoredObjectId"/>.

--- a/Refresh.Database/Models/Assets/GameAsset.cs
+++ b/Refresh.Database/Models/Assets/GameAsset.cs
@@ -10,23 +10,9 @@ public partial class GameAsset
     public DateTimeOffset UploadDate { get; set; }
     public bool IsPSP { get; set; }
     public int SizeInBytes { get; set; }
-    [NotMapped] public GameAssetType AssetType
-    {
-        get => (GameAssetType)this._AssetType;
-        set => this._AssetType = (int)value;
-    }
+    public GameAssetType AssetType { get; set; }
 
-    // ReSharper disable once InconsistentNaming
-    public int _AssetType { get; set; }
-
-    [NotMapped] public GameAssetFormat AssetFormat
-    {
-        get => (GameAssetFormat)this._AssetSerializationMethod;
-        set => this._AssetSerializationMethod = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _AssetSerializationMethod { get; set; }
+    public GameAssetFormat AssetFormat { get; set; }
 
     [NotMapped] 
     public AssetFlags AssetFlags

--- a/Refresh.Database/Models/Authentication/Token.cs
+++ b/Refresh.Database/Models/Authentication/Token.cs
@@ -16,30 +16,11 @@ public partial class Token : IToken<GameUser>
     
     // this shouldn't ever be serialized, but just in case let's ignore it
     [XmlIgnore, JsonIgnore] public string TokenData { get; set; }
-    
-    // Realm can't store enums, use recommended workaround
-    // ReSharper disable once InconsistentNaming (can't fix due to conflict with TokenType)
-    public int _TokenType { get; set; }
 
-    public TokenType TokenType
-    {
-        get => (TokenType)this._TokenType;
-        set => this._TokenType = (int)value;
-    }
+    public TokenType TokenType { get; set; }
     
-    public int _TokenPlatform { get; set; }
-    public int _TokenGame { get; set; }
-    
-    public TokenPlatform TokenPlatform 
-    {
-        get => (TokenPlatform)this._TokenPlatform;
-        set => this._TokenPlatform = (int)value;
-    }
-    public TokenGame TokenGame 
-    {
-        get => (TokenGame)this._TokenGame;
-        set => this._TokenGame = (int)value;
-    }
+    public TokenPlatform TokenPlatform  { get; set; }
+    public TokenGame TokenGame  { get; set; }
 
     public DateTimeOffset ExpiresAt { get; set; }
     public DateTimeOffset LoginDate { get; set; }

--- a/Refresh.Database/Models/Levels/Challenges/GameChallenge.cs
+++ b/Refresh.Database/Models/Levels/Challenges/GameChallenge.cs
@@ -26,12 +26,7 @@ public partial class GameChallenge : ISequentialId
     /// The challenge's criteria type (time/score/lives etc).
     /// </summary>
     /// <seealso cref="GameChallengeCriteriaType"/>
-    public GameChallengeCriteriaType Type
-    {
-        get => (GameChallengeCriteriaType)this._Type;
-        set => this._Type = (byte)value;
-    }
-    public byte _Type { get; set; }
+    public GameChallengeCriteriaType Type { get; set; }
 
     public DateTimeOffset PublishDate { get; set; }
     public DateTimeOffset LastUpdateDate { get; set; }

--- a/Refresh.Database/Models/Levels/GameLevel.cs
+++ b/Refresh.Database/Models/Levels/GameLevel.cs
@@ -50,23 +50,8 @@ public partial class GameLevel : ISequentialId
     /// </summary>
     public string? BackgroundGuid { get; set; }
     
-    public TokenGame GameVersion 
-    {
-        get => (TokenGame)this._GameVersion;
-        set => this._GameVersion = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _GameVersion { get; set; }
-    
-    public GameLevelType LevelType
-    {
-        get => (GameLevelType)this._LevelType;
-        set => this._LevelType = (int)value;
-    }
-
-    // ReSharper disable once InconsistentNaming
-    public int _LevelType { get; set; }
+    public TokenGame GameVersion  { get; set; }
+    public GameLevelType LevelType { get; set; }
 
     /// <summary>
     /// The associated ID for the developer level.

--- a/Refresh.Database/Models/Levels/GameSkillReward.cs
+++ b/Refresh.Database/Models/Levels/GameSkillReward.cs
@@ -17,14 +17,6 @@ public partial class GameSkillReward
     [XmlIgnore] public GameLevel Level { get; set; } = null!;
     [XmlIgnore] public int LevelId { get; set; }
 
-    // Realm can't store enums, use recommended workaround
-    // ReSharper disable once InconsistentNaming (can't fix due to conflict with ConditionType)
-    // ReSharper disable once MemberCanBePrivate.Global
-    public int _ConditionType { get; set; }
-    [NotMapped] [XmlElement("condition")]
-    public GameSkillRewardCondition ConditionType
-    {
-        get => (GameSkillRewardCondition)this._ConditionType;
-        set => this._ConditionType = (int)value;
-    }
+    [XmlElement("condition")]
+    public GameSkillRewardCondition ConditionType { get; set; }
 }

--- a/Refresh.Database/Models/Levels/Scores/GameScore.cs
+++ b/Refresh.Database/Models/Levels/Scores/GameScore.cs
@@ -7,7 +7,7 @@ namespace Refresh.Database.Models.Levels.Scores;
 #nullable disable
 
 [Index(nameof(Game), nameof(Score), nameof(ScoreType))]
-public partial class GameSubmittedScore // TODO: Rename to GameScore
+public partial class GameScore
 {
     [Key] public ObjectId ScoreId { get; set; } = ObjectId.GenerateNewId();
 

--- a/Refresh.Database/Models/Levels/Scores/GameSubmittedScore.cs
+++ b/Refresh.Database/Models/Levels/Scores/GameSubmittedScore.cs
@@ -6,26 +6,13 @@ namespace Refresh.Database.Models.Levels.Scores;
 
 #nullable disable
 
-[Index(nameof(_Game), nameof(Score), nameof(ScoreType))]
+[Index(nameof(Game), nameof(Score), nameof(ScoreType))]
 public partial class GameSubmittedScore // TODO: Rename to GameScore
 {
     [Key] public ObjectId ScoreId { get; set; } = ObjectId.GenerateNewId();
-    
-    // ReSharper disable once InconsistentNaming
-    public int _Game { get; set; }
-    [NotMapped] public TokenGame Game
-    {
-        get => (TokenGame)this._Game;
-        set => this._Game = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _Platform { get; set; }
-    [NotMapped] public TokenPlatform Platform
-    {
-        get => (TokenPlatform)this._Platform;
-        set => this._Platform = (int)value;
-    }
+
+     public TokenGame Game { get; set; }
+    public TokenPlatform Platform { get; set; }
 
     [Required] public GameLevel Level { get; set; }
     public DateTimeOffset ScoreSubmitted { get; set; }

--- a/Refresh.Database/Models/Levels/Scores/MultiLeaderboard.cs
+++ b/Refresh.Database/Models/Levels/Scores/MultiLeaderboard.cs
@@ -4,11 +4,11 @@ namespace Refresh.Database.Models.Levels.Scores;
 
 public class MultiLeaderboard
 {
-    public readonly Dictionary<byte, DatabaseList<GameSubmittedScore>> Leaderboards;
+    public readonly Dictionary<byte, DatabaseList<GameScore>> Leaderboards;
 
     public MultiLeaderboard(GameDatabaseContext database, GameLevel level, TokenGame game)
     {
-        this.Leaderboards = new Dictionary<byte, DatabaseList<GameSubmittedScore>>
+        this.Leaderboards = new Dictionary<byte, DatabaseList<GameScore>>
         {
             //On all games set the 1 player leaderboards
             [1] = database.GetTopScoresForLevel(level, 10, 0, 1),

--- a/Refresh.Database/Models/Levels/Scores/ScoreWithRank.cs
+++ b/Refresh.Database/Models/Levels/Scores/ScoreWithRank.cs
@@ -1,3 +1,3 @@
 namespace Refresh.Database.Models.Levels.Scores;
 
-public record ScoreWithRank(GameSubmittedScore score, int rank);
+public record ScoreWithRank(GameScore score, int rank);

--- a/Refresh.Database/Models/Relations/LevelCommentRelation.cs
+++ b/Refresh.Database/Models/Relations/LevelCommentRelation.cs
@@ -11,14 +11,6 @@ public partial class LevelCommentRelation : ICommentRelation<GameLevelComment>
     [Key] public ObjectId CommentRelationId { get; set; } = ObjectId.GenerateNewId();
     [Required] public GameUser User { get; set; }
     [Required] public GameLevelComment Comment { get; set; }
-    [NotMapped]
-    public RatingType RatingType
-    {
-        get => (RatingType)this._RatingType;
-        set => this._RatingType = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _RatingType { get; set; }
+    public RatingType RatingType { get; set; }
     public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.Database/Models/Relations/ProfileCommentRelation.cs
+++ b/Refresh.Database/Models/Relations/ProfileCommentRelation.cs
@@ -11,14 +11,6 @@ public partial class ProfileCommentRelation : ICommentRelation<GameProfileCommen
     [Key] public ObjectId CommentRelationId { get; set; } = ObjectId.GenerateNewId();
     [Required] public GameUser User { get; set; }
     [Required] public GameProfileComment Comment { get; set; }
-    [NotMapped]
-    public RatingType RatingType
-    {
-        get => (RatingType)this._RatingType;
-        set => this._RatingType = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _RatingType { get; set; }
+    public RatingType RatingType { get; set; }
     public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.Database/Models/Relations/ProfilePinRelation.cs
+++ b/Refresh.Database/Models/Relations/ProfilePinRelation.cs
@@ -23,12 +23,7 @@ public partial class ProfilePinRelation
     /// <summary>
     /// The game to show this profile pin on, to allow different sets of profile pins per game
     /// </summary>
-    public TokenGame Game
-    {
-        get => (TokenGame)this._Game;
-        set => this._Game = (int)value;
-    }
-    public int _Game { get; set; }
+    public TokenGame Game { get; set; }
 
     public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.Database/Models/Relations/RateLevelRelation.cs
+++ b/Refresh.Database/Models/Relations/RateLevelRelation.cs
@@ -11,15 +11,7 @@ public partial class RateLevelRelation
 {
     public ObjectId RateLevelRelationId { get; set; } = ObjectId.GenerateNewId();
     
-    [NotMapped]
-    public RatingType RatingType
-    {
-        get => (RatingType)this._RatingType;
-        set => this._RatingType = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _RatingType { get; set; }
+    public RatingType RatingType { get; set; }
     
     [Required] public GameLevel Level { get; set; }
     [Required] public GameUser User { get; set; }

--- a/Refresh.Database/Models/Relations/RateReviewRelation.cs
+++ b/Refresh.Database/Models/Relations/RateReviewRelation.cs
@@ -18,14 +18,6 @@ public partial class RateReviewRelation
     [Required] public ObjectId UserId { get; set; }
     
     // we could just reuse RatingType from GameLevel rating logic
-    [NotMapped]
-    public RatingType RatingType
-    {
-        get => (RatingType)this._ReviewRatingType;
-        set => this._ReviewRatingType = (int)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public int _ReviewRatingType { get; set; }
+    public RatingType RatingType { get; set; }
     public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.Database/Models/Relations/TagLevelRelation.cs
+++ b/Refresh.Database/Models/Relations/TagLevelRelation.cs
@@ -6,7 +6,7 @@ namespace Refresh.Database.Models.Relations;
 
 #nullable disable
 
-[PrimaryKey(nameof(_Tag), nameof(UserId), nameof(LevelId))]
+[PrimaryKey(nameof(Tag), nameof(UserId), nameof(LevelId))]
 public partial class TagLevelRelation
 {
     [ForeignKey(nameof(LevelId))]
@@ -19,15 +19,7 @@ public partial class TagLevelRelation
     [Required] public int LevelId { get; set; }
     [Required] public ObjectId UserId { get; set; }
     
-    [NotMapped]
-    public Tag Tag
-    {
-        get => (Tag)this._Tag;
-        set => this._Tag = (byte)value;
-    }
-    
-    // ReSharper disable once InconsistentNaming
-    public byte _Tag { get; set; }
+    public Tag Tag { get; set; }
 
     public DateTimeOffset Timestamp { get; set; }
 }

--- a/Refresh.Database/Models/Users/GameUser.cs
+++ b/Refresh.Database/Models/Users/GameUser.cs
@@ -91,9 +91,6 @@ public partial class GameUser : IRateLimitUser
     public bool RpcnAuthenticationAllowed { get; set; }
     public bool PsnAuthenticationAllowed { get; set; }
     
-    private int _ProfileVisibility { get; set; } = (int)Visibility.All;
-    private int _LevelVisibility { get; set; } = (int)Visibility.All;
-    
     /// <summary>
     /// The auth token the presence server knows this user by, null if not connected to the presence server
     /// </summary>
@@ -104,37 +101,23 @@ public partial class GameUser : IRateLimitUser
     /// although the game does not expose the ability to do this normally.
     /// </summary>
     public GamePlaylist? RootPlaylist { get; set; }
-    
+
     /// <summary>
     /// Whether the user's profile information is exposed in the public API.
     /// </summary>
-    [NotMapped]
-    public Visibility ProfileVisibility
-    {
-        get => (Visibility)this._ProfileVisibility;
-        set => this._ProfileVisibility = (int)value;
-    }
-    
+    public Visibility ProfileVisibility { get; set; } = Visibility.All;
+
     /// <summary>
     /// Whether the user's levels are exposed in the public API.
     /// </summary>
-    [NotMapped]
-    public Visibility LevelVisibility
-    {
-        get => (Visibility)this._LevelVisibility;
-        set => this._LevelVisibility = (int)value;
-    }
+    public Visibility LevelVisibility { get; set; } = Visibility.All;
 
     /// <summary>
     /// If `true`, unescape XML tags sent to /filter
     /// </summary>
     public bool UnescapeXmlSequences { get; set; }
     
-    [NotMapped] public GameUserRole Role
-    {
-        get => (GameUserRole)this._Role;
-        set => this._Role = (byte)value;
-    }
+    public GameUserRole Role { get; set; }
 
     /// <summary>
     /// Whether modded content should be shown in level listings
@@ -145,9 +128,6 @@ public partial class GameUser : IRateLimitUser
     /// Whether reuploaded content should be shown in level listings
     /// </summary>
     public bool ShowReuploadedContent { get; set; } = true;
-
-    // ReSharper disable once InconsistentNaming
-    public byte _Role { get; set; }
 
     public string UsernameLower
     {

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminLeaderboardApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminLeaderboardApiEndpoints.cs
@@ -19,7 +19,7 @@ public class AdminLeaderboardApiEndpoints : EndpointGroup
     public ApiOkResponse DeleteScore(RequestContext context, GameDatabaseContext database,
         [DocSummary("The UUID of the score")] string uuid)
     {
-        GameSubmittedScore? score = database.GetScoreByUuid(uuid);
+        GameScore? score = database.GetScoreByUuid(uuid);
         if (score == null) return ApiNotFoundError.Instance;
         
         database.DeleteScore(score);

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameScoreResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameScoreResponse.cs
@@ -6,7 +6,7 @@ using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Users;
 namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Levels;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameScoreResponse, GameSubmittedScore>
+public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameScoreResponse, GameScore>
 {
     public required string ScoreId { get; set; }
     public required ApiGameLevelResponse Level { get; set; }
@@ -18,7 +18,7 @@ public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameSc
     public required TokenGame Game { get; set; }
     public required TokenPlatform Platform { get; set; }
     
-    public static ApiGameScoreResponse? FromOld(GameSubmittedScore? old, DataContext dataContext)
+    public static ApiGameScoreResponse? FromOld(GameScore? old, DataContext dataContext)
     {
         if (old == null) return null;
 
@@ -35,6 +35,6 @@ public class ApiGameScoreResponse : IApiResponse, IDataConvertableFrom<ApiGameSc
         };
     }
     
-    public static IEnumerable<ApiGameScoreResponse> FromOldList(IEnumerable<GameSubmittedScore> oldList,
+    public static IEnumerable<ApiGameScoreResponse> FromOldList(IEnumerable<GameScore> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/LeaderboardApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/LeaderboardApiEndpoints.cs
@@ -36,8 +36,8 @@ public class LeaderboardApiEndpoints : EndpointGroup
         bool result = bool.TryParse(context.QueryString.Get("showAll") ?? "false", out bool showAll);
         if (!result) return ApiValidationError.BooleanParseError;
 
-        DatabaseList<GameSubmittedScore> scores = database.GetTopScoresForLevel(level, count, skip, (byte)mode, showAll);
-        DatabaseList<ApiGameScoreResponse> ret = DatabaseListExtensions.FromOldList<ApiGameScoreResponse, GameSubmittedScore>(scores, dataContext);
+        DatabaseList<GameScore> scores = database.GetTopScoresForLevel(level, count, skip, (byte)mode, showAll);
+        DatabaseList<ApiGameScoreResponse> ret = DatabaseListExtensions.FromOldList<ApiGameScoreResponse, GameScore>(scores, dataContext);
         return ret;
     }
 
@@ -48,7 +48,7 @@ public class LeaderboardApiEndpoints : EndpointGroup
         DataContext dataContext,
         [DocSummary("The UUID of the score")] string uuid)
     {
-        GameSubmittedScore? score = database.GetScoreByUuid(uuid);
+        GameScore? score = database.GetScoreByUuid(uuid);
         if (score == null) return ApiNotFoundError.Instance;
         
         return ApiGameScoreResponse.FromOld(score, dataContext);

--- a/Refresh.Interfaces.Game/Endpoints/Levels/LeaderboardEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/LeaderboardEndpoints.cs
@@ -114,7 +114,7 @@ public class LeaderboardEndpoints : EndpointGroup
             return BadRequest;
         }
 
-        GameSubmittedScore score = database.SubmitScore(body, token, level);
+        GameScore score = database.SubmitScore(body, token, level);
 
         IEnumerable<ScoreWithRank>? scores = database.GetRankedScoresAroundScore(score, 5);
         Debug.Assert(scores != null);

--- a/Refresh.Interfaces.Game/Types/Activity/SerializedEvents/SerializedEvent.cs
+++ b/Refresh.Interfaces.Game/Types/Activity/SerializedEvents/SerializedEvent.cs
@@ -33,7 +33,7 @@ public abstract class SerializedEvent : IDataConvertableFrom<SerializedEvent, Ev
 
         GameUser? user = null;
         GameLevel? level = null;
-        GameSubmittedScore? score = null;
+        GameScore? score = null;
         GamePhoto? photo = null;
 
         if (old.StoredDataType == EventDataType.User)

--- a/Refresh.Interfaces.Game/Types/Activity/SerializedEvents/SerializedScoreSubmitEvent.cs
+++ b/Refresh.Interfaces.Game/Types/Activity/SerializedEvents/SerializedScoreSubmitEvent.cs
@@ -11,7 +11,7 @@ public class SerializedScoreSubmitEvent : SerializedLevelEvent
     [XmlElement("count")]
     public int ScoreType { get; set; }
     
-    public static SerializedScoreSubmitEvent? FromSerializedLevelEvent(SerializedLevelEvent? e, GameSubmittedScore? score)
+    public static SerializedScoreSubmitEvent? FromSerializedLevelEvent(SerializedLevelEvent? e, GameScore? score)
     {
         if (e == null || score == null)
             return null;

--- a/Refresh.Interfaces.Game/Types/Lists/SerializedScoreList.cs
+++ b/Refresh.Interfaces.Game/Types/Lists/SerializedScoreList.cs
@@ -11,12 +11,12 @@ public class SerializedScoreList
     [XmlElement("playRecord")]
     public List<SerializedLeaderboardScore> Scores { get; set; } = new();
 
-    public static SerializedScoreList FromSubmittedEnumerable(IEnumerable<GameSubmittedScore> list, DataContext dataContext, int skip)
+    public static SerializedScoreList FromSubmittedEnumerable(IEnumerable<GameScore> list, DataContext dataContext, int skip)
     {
         SerializedScoreList value = new();
 
         int i = skip;
-        foreach (GameSubmittedScore score in list)
+        foreach (GameScore score in list)
         {
             i++;
             

--- a/Refresh.Interfaces.Game/Types/UserData/Leaderboard/SerializedLeaderboardScore.cs
+++ b/Refresh.Interfaces.Game/Types/UserData/Leaderboard/SerializedLeaderboardScore.cs
@@ -12,7 +12,7 @@ public class SerializedLeaderboardScore
     [XmlElement("score")] public int Score { get; set; }
     [XmlElement("rank")] public int Rank { get; set; }
 
-    public static SerializedLeaderboardScore FromOld(GameSubmittedScore score, DataContext dataContext, int rank) => new()
+    public static SerializedLeaderboardScore FromOld(GameScore score, DataContext dataContext, int rank) => new()
     {
         Player = dataContext.Database.GetSubmittingPlayerFromScore(score)?.Username ?? "",
         Score = score.Score,

--- a/Refresh.Interfaces.Game/Types/UserData/Leaderboard/SerializedMultiLeaderboardResponse.cs
+++ b/Refresh.Interfaces.Game/Types/UserData/Leaderboard/SerializedMultiLeaderboardResponse.cs
@@ -26,7 +26,7 @@ public class SerializedMultiLeaderboardResponse
         List<SerializedPlayerLeaderboardResponse> leaderboards = new();
 
         //Iterate over all leaderboards in the list
-        foreach ((byte type, DatabaseList<GameSubmittedScore> scores) in multiLeaderboard.Leaderboards)
+        foreach ((byte type, DatabaseList<GameScore> scores) in multiLeaderboard.Leaderboards)
         {
             SerializedPlayerLeaderboardResponse leaderboard = new()
             {
@@ -35,7 +35,7 @@ public class SerializedMultiLeaderboardResponse
             };
 
             int i = 1;
-            foreach (GameSubmittedScore score in scores.Items.ToArrayIfPostgres())
+            foreach (GameScore score in scores.Items.ToArrayIfPostgres())
             {
                 leaderboard.Scores.Add(SerializedLeaderboardScore.FromOld(score, dataContext, i));
                 i += 1;

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -136,7 +136,7 @@ public class TestContext : IDisposable
         }
     }
 
-    public GameSubmittedScore SubmitScore(int score, byte type, GameLevel level, GameUser user, TokenGame game, TokenPlatform platform)
+    public GameScore SubmitScore(int score, byte type, GameLevel level, GameUser user, TokenGame game, TokenPlatform platform)
     {
         SerializedScore scoreObject = new()
         {
@@ -145,7 +145,7 @@ public class TestContext : IDisposable
             ScoreType = type,
         };
         
-        GameSubmittedScore submittedScore = this.Database.SubmitScore(scoreObject, user, level, game, platform);
+        GameScore submittedScore = this.Database.SubmitScore(scoreObject, user, level, game, platform);
         Assert.That(submittedScore, Is.Not.Null);
 
         return submittedScore;

--- a/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ScoreLeaderboardTests.cs
@@ -132,7 +132,7 @@ public class ScoreLeaderboardTests : GameServerTest
 
         context.Database.Refresh();
 
-        List<GameSubmittedScore> scores = context.Database.GetTopScoresForLevel(level, 1, 0, 1).Items.ToList();
+        List<GameScore> scores = context.Database.GetTopScoresForLevel(level, 1, 0, 1).Items.ToList();
         Assert.That(scores, Has.Count.EqualTo(0));
     }
 
@@ -183,7 +183,7 @@ public class ScoreLeaderboardTests : GameServerTest
 
         context.Database.Refresh();
 
-        List<GameSubmittedScore> scores = context.Database.GetTopScoresForLevel(context.Database.GetStoryLevelById(1), 1, 0, 1).Items.ToList();
+        List<GameScore> scores = context.Database.GetTopScoresForLevel(context.Database.GetStoryLevelById(1), 1, 0, 1).Items.ToList();
         Assert.That(scores, Has.Count.EqualTo(0));
     }
     
@@ -260,7 +260,7 @@ public class ScoreLeaderboardTests : GameServerTest
         GameLevel level = context.CreateLevel(user);
 
         context.FillLeaderboard(level, leaderboardCount, 1);
-        GameSubmittedScore score = context.SubmitScore(submittedScore, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score = context.SubmitScore(submittedScore, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
 
         List<ObjectId> scores = context.Database.GetRankedScoresAroundScore(score, count)!
             .Select(s => s.score.ScoreId)
@@ -300,8 +300,8 @@ public class ScoreLeaderboardTests : GameServerTest
         
         GameLevel level = context.CreateLevel(user1);
         
-        GameSubmittedScore score1 = context.SubmitScore(0, 1, level, user1, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
-        GameSubmittedScore score2 = context.SubmitScore(0, 2, level, user2, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score1 = context.SubmitScore(0, 1, level, user1, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score2 = context.SubmitScore(0, 2, level, user2, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         
         Assert.Multiple(() =>
         {
@@ -315,7 +315,7 @@ public class ScoreLeaderboardTests : GameServerTest
     {
         using TestContext context = this.GetServer(false);
         GameUser user = context.CreateUser();
-        GameSubmittedScore score = context.SubmitScore(0, 1, context.CreateLevel(user), user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score = context.SubmitScore(0, 1, context.CreateLevel(user), user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         
         Assert.That(() => context.Database.GetRankedScoresAroundScore(score, 2), Throws.ArgumentException);
     }
@@ -436,7 +436,7 @@ public class ScoreLeaderboardTests : GameServerTest
 
         for (int i = 0; i < users.Count; i++)
         {
-            GameSubmittedScore? lastBestScore = context.Database.GetTopScoresForLevel(level, 1, 0, 1, true).Items.FirstOrDefault();
+            GameScore? lastBestScore = context.Database.GetTopScoresForLevel(level, 1, 0, 1, true).Items.FirstOrDefault();
             
             GameUser user = users[i];
             context.SubmitScore(i, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);

--- a/RefreshTests.GameServer/Tests/Levels/ScoreModerationTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ScoreModerationTests.cs
@@ -16,7 +16,7 @@ public class ScoreModerationTests : GameServerTest
         GameUser user = context.CreateUser();
         GameLevel level = context.CreateLevel(user);
         
-        GameSubmittedScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         string uuid = score.ScoreId.ToString();
         
         // Act
@@ -35,7 +35,7 @@ public class ScoreModerationTests : GameServerTest
         GameUser user = context.CreateUser();
         GameLevel level = context.CreateLevel(user);
         
-        GameSubmittedScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         string uuid = score.ScoreId.ToString();
         
         // Act
@@ -56,7 +56,7 @@ public class ScoreModerationTests : GameServerTest
         GameLevel level = context.CreateLevel(user);
         context.Database.SetUserRole(user, GameUserRole.Admin);
         
-        GameSubmittedScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score = context.SubmitScore(1, 1, level, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         string uuid = score.ScoreId.ToString();
 
         using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
@@ -79,8 +79,8 @@ public class ScoreModerationTests : GameServerTest
         GameLevel level1 = context.CreateLevel(user);
         GameLevel level2 = context.CreateLevel(user);
         
-        GameSubmittedScore score1 = context.SubmitScore(1, 1, level1, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
-        GameSubmittedScore score2 = context.SubmitScore(1, 1, level2, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score1 = context.SubmitScore(1, 1, level1, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
+        GameScore score2 = context.SubmitScore(1, 1, level2, user, TokenGame.LittleBigPlanet2, TokenPlatform.PS3);
         string uuid1 = score1.ScoreId.ToString();
         string uuid2 = score2.ScoreId.ToString();
         


### PR DESCRIPTION
This cleans up a couple of the workarounds we were having to use with Realm.

Primarily, this removes the 'underscore' workaround we were using for enums. I also finally renamed `GameSubmittedScore` to `GameScore`.