### PR TITLE
Cool Levels June 2025 Rebalance

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -469,8 +469,8 @@ public partial class GameDatabaseContext // Levels
     public DatabaseList<GameLevel> GetCoolLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings) =>
         new(this.GetLevelsByGameVersion(levelFilterSettings.GameVersion)
             .FilterByLevelFilterSettings(user, levelFilterSettings)
-            .Where(l => l.Score > 0)
-            .OrderByDescending(l => l.Score), skip, count);
+            .Where(l => l.CoolRating > 0)
+            .OrderByDescending(l => l.CoolRating), skip, count);
 
     [Pure]
     public DatabaseList<GameLevel> GetAdventureLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings) =>
@@ -511,7 +511,7 @@ public partial class GameDatabaseContext // Levels
             levels.AddRange(validLevels.Where(l => l.Publisher == publisher));
         }
 
-        return new DatabaseList<GameLevel>(levels.OrderByDescending(l => l.Score), skip, count);
+        return new DatabaseList<GameLevel>(levels.OrderByDescending(l => l.CoolRating), skip, count);
     }
 
     [Pure]
@@ -574,11 +574,11 @@ public partial class GameDatabaseContext // Levels
         });
     }
 
-    public void SetLevelScores(Dictionary<GameLevel, float> scoresToSet)
+    public void SetLevelCoolRatings(Dictionary<GameLevel, float> coolRatingsToSet)
     {
-        foreach ((GameLevel level, float score) in scoresToSet)
+        foreach ((GameLevel level, float coolRating) in coolRatingsToSet)
         {
-            level.Score = score;
+            level.CoolRating = coolRating;
         }
 
         this.SaveChanges();

--- a/Refresh.Database/Migrations/20250628183816_RenameScoreToCoolRating.cs
+++ b/Refresh.Database/Migrations/20250628183816_RenameScoreToCoolRating.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250628183816_RenameScoreToCoolRating")]
+    public partial class RenameScoreToCoolRating : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Score",
+                table: "GameLevels",
+                newName: "CoolRating");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "CoolRating",
+                table: "GameLevels",
+                newName: "Score");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -376,6 +376,9 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("BackgroundGuid")
                         .HasColumnType("text");
 
+                    b.Property<float>("CoolRating")
+                        .HasColumnType("real");
+
                     b.Property<DateTimeOffset?>("DateTeamPicked")
                         .HasColumnType("timestamp with time zone");
 
@@ -444,9 +447,6 @@ namespace Refresh.Database.Migrations
 
                     b.Property<bool>("SameScreenGame")
                         .HasColumnType("boolean");
-
-                    b.Property<float>("Score")
-                        .HasColumnType("real");
 
                     b.Property<int?>("StatisticsLevelId")
                         .HasColumnType("integer");

--- a/Refresh.Database/Models/Levels/GameLevel.cs
+++ b/Refresh.Database/Models/Levels/GameLevel.cs
@@ -73,7 +73,7 @@ public partial class GameLevel : ISequentialId
     /// The score, used for Cool Levels.
     /// </summary>
     /// <seealso cref="CoolLevelsWorker"/>
-    public float Score { get; set; }
+    public float CoolRating { get; set; }
     
     [NotMapped] public int SequentialId
     {

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelResponse.cs
@@ -95,7 +95,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
             IsCopyable = level.IsCopyable,
             IsLocked = level.IsLocked,
             IsSubLevel = level.IsSubLevel,
-            Score = level.Score,
+            Score = level.CoolRating,
             PhotosTaken = level.Statistics.PhotoInLevelCount,
             LevelComments = level.Statistics.CommentCount,
             Reviews = level.Statistics.ReviewCount,

--- a/Refresh.Interfaces.Workers/Workers/CoolLevelsWorker.cs
+++ b/Refresh.Interfaces.Workers/Workers/CoolLevelsWorker.cs
@@ -131,7 +131,7 @@ public class CoolLevelsWorker : IWorker
         };
 
         if (level.TeamPicked)
-            score += 50;
+            score += 100;
         
         int positiveRatings = level.Statistics.YayCountExcludingPublisher;
         int negativeRatings = level.Statistics.BooCountExcludingPublisher;

--- a/Refresh.Interfaces.Workers/Workers/CoolLevelsWorker.cs
+++ b/Refresh.Interfaces.Workers/Workers/CoolLevelsWorker.cs
@@ -70,7 +70,7 @@ public class CoolLevelsWorker : IWorker
             }
             
             // Commit scores to database. This method lets us use a dictionary so we can batch everything in one write
-            context.Database.SetLevelScores(scoresToSet);
+            context.Database.SetLevelCoolRatings(scoresToSet);
             
             // Load the next page
             levels = context.Database.GetUserLevelsChunk(levels.NextPageIndex - 1, pageSize);

--- a/Refresh.Interfaces.Workers/Workers/CoolLevelsWorker.cs
+++ b/Refresh.Interfaces.Workers/Workers/CoolLevelsWorker.cs
@@ -152,6 +152,9 @@ public class CoolLevelsWorker : IWorker
         if (level.Publisher?.Role == GameUserRole.Trusted)
             score += trustedAuthorPoints;
 
+        if (level.IsReUpload)
+            score *= 0.95f;
+
         Log(context.Logger, LogLevel.Trace, "positiveScore is {0}", score);
         return score;
     }

--- a/Refresh.Interfaces.Workers/Workers/ObjectStatisticsWorker.cs
+++ b/Refresh.Interfaces.Workers/Workers/ObjectStatisticsWorker.cs
@@ -13,14 +13,18 @@ public class ObjectStatisticsWorker : IWorker
     [SuppressMessage("ReSharper.DPA", "DPA0005: Database issues")]
     public void DoWork(DataContext context)
     {
-        GameLevel[] levels = context.Database.GetLevelsWithStatisticsNeedingUpdates().ToArray();
+        GameLevel[] levels = context.Database.GetLevelsWithStatisticsNeedingUpdates()
+            .Take(500)
+            .ToArray();
 
         foreach (GameLevel level in levels)
         {
             context.Database.RecalculateLevelStatistics(level);
         }
         
-        GameUser[] users = context.Database.GetUsersWithStatisticsNeedingUpdates().ToArray();
+        GameUser[] users = context.Database.GetUsersWithStatisticsNeedingUpdates()
+            .Take(500)
+            .ToArray();
 
         foreach (GameUser user in users)
         {


### PR DESCRIPTION
- Renames `Score` to `CoolRating` internally
- Implement per-game rating & heart multipliers (closes #837)
Relevant multipliers:
```csharp
        float positiveRatingPoints = level.GameVersion switch
        {
            TokenGame.LittleBigPlanet1 => 2.5f,
            TokenGame.LittleBigPlanet2 => 7.5f,
            TokenGame.LittleBigPlanet3 => 15,
            TokenGame.LittleBigPlanetVita => 7.5f,
            TokenGame.LittleBigPlanetPSP => 15f,
            _ => 5, // default for games unlisted above
        };

        float heartPoints = level.GameVersion switch {
            TokenGame.LittleBigPlanet3 => 15,
            TokenGame.LittleBigPlanetVita => 15,
            TokenGame.LittleBigPlanetPSP => 15,
            _ => 10, // default for games unlisted above
        };
```
- Remove good play-yay ratio bonus for LBP1 levels
This was causing most of the LBP1 level inflation.
- Only allow 95% max positive score if level is a reupload (closes #790)
This wasn't needed as stated by cranky in the issue so it's a low penalty.
- Bump team pick from 50 to 100

| Production | cool-levels-jun-2025 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f0602184-b1fb-43bf-84d0-412adcb4fb90) | ![image](https://github.com/user-attachments/assets/265cbe05-4a96-4b8d-9fa0-bf66438e28a1) |
