### PR TITLE
Add `DownloadingDataStore` to help with common archived assets

### DIFF
--- a/Refresh.Core/Storage/DownloadingDataStore.cs
+++ b/Refresh.Core/Storage/DownloadingDataStore.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Concurrent;
+using Bunkum.Core.Storage;
+
+namespace Refresh.Core.Storage;
+
+public class DownloadingDataStore : IDataStore
+{
+    private readonly IDataStore _localDataStore;
+    private readonly IDataStore _remoteDataStore;
+    private readonly ConcurrentDictionary<string, int> _hits = [];
+
+    private const int HitsBeforeDownload = 3;
+    
+    private const string WriteError = $"{nameof(DownloadingDataStore)} is a read-only source, and cannot be written to.";
+
+    public DownloadingDataStore(IDataStore localDataStore, IDataStore remoteDataStore)
+    {
+        this._localDataStore = localDataStore;
+        this._remoteDataStore = remoteDataStore;
+    }
+
+    private bool Hit(string key)
+    {
+        if (!this._hits.TryGetValue(key, out int value) && this._remoteDataStore.ExistsInStore(key))
+        {
+            _hits[key] = 1;
+            return false;
+        }
+
+        value++;
+        _hits[key] = value;
+
+        return value >= HitsBeforeDownload;
+    }
+
+    
+    public bool ExistsInStore(string key)
+    {
+        if (this._hits.ContainsKey(key))
+            return true;
+
+        return this._remoteDataStore.ExistsInStore(key);
+    }
+
+    public bool WriteToStore(string key, byte[] data)
+    {
+        throw new InvalidOperationException(WriteError);
+    }
+
+    public byte[] GetDataFromStore(string key)
+    {
+        byte[] data = this._remoteDataStore.GetDataFromStore(key);
+        if (this.Hit(key))
+        {
+            this._hits.Remove(key, out _);
+            this._localDataStore.WriteToStore(key, data);
+        }
+
+        return data;
+    }
+
+    public bool RemoveFromStore(string key)
+    {
+        throw new InvalidOperationException(WriteError);
+    }
+
+    public string[] GetKeysFromStore()
+    {
+        return this._remoteDataStore.GetKeysFromStore();
+    }
+
+    public bool WriteToStoreFromStream(string key, Stream data)
+    {
+        throw new InvalidOperationException(WriteError);
+    }
+
+    public Stream GetStreamFromStore(string key)
+    {
+        Stream data = this._remoteDataStore.GetStreamFromStore(key);
+        if (this.Hit(key))
+        {
+            this._hits.Remove(key, out _);
+            this._localDataStore.WriteToStoreFromStream(key, data);
+            data.Seek(0, SeekOrigin.Begin);
+        }
+
+        return data;
+    }
+
+    public Stream OpenWriteStream(string key)
+    {
+        throw new InvalidOperationException(WriteError);
+    }
+}


### PR DESCRIPTION
On production the DataStore for the dry archive is mounted on an NFS. This can sometimes mean requests that depend on the dry archive can take a few seconds to complete due to some IO bottlenecks when requesting many assets at once.

I believe this is mostly due to the sheer size of the directories we're pulling from, but I'm not entirely certain.

Either way, this introduces a new datastore that looks at what assets have been requested and copies them to the primary data store (in our case, `FileSystemDataStore`) if there are 3 or more 'hits' to that asset. The idea is that if a asset is only requested once, then we don't need to download it, else we end up just storing the entire dry archive. However, if it's requested more than a few times it's probably worth downloading.

The number of hits is stored in-memory. We probably want to store this information in the database or in Valkey in the future, but I think this is okay for now.