### PR TITLE
Remove old authentication failures

### DIFF
--- a/Refresh.Database/Migrations/20250702215204_RemoveOldAuthFailures.cs
+++ b/Refresh.Database/Migrations/20250702215204_RemoveOldAuthFailures.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250702215204_RemoveOldAuthFailures")]
+    public partial class RemoveOldAuthFailures : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DELETE FROM \"GameNotifications\" WHERE \"Title\" LIKE 'Authentication failure'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
Followup to #835.

Since I changed the title of authentication failures the changes I made don't address old existing login notifications.

To rectify this I made a simple migration that nukes everything with the old name.