### PR TITLE
mark level as reupload by prefix + specify original publisher

### DIFF
--- a/Refresh.Common/Constants/LevelPrefixes.cs
+++ b/Refresh.Common/Constants/LevelPrefixes.cs
@@ -4,7 +4,7 @@ namespace Refresh.Common.Constants;
 
 public static partial class LevelPrefixes
 {
-    [GeneratedRegex(@"\?(\w+)\.([\w-]+)")]
+    [GeneratedRegex(@"\?(\w+)[\.:]([\w-]+)")]
     public static partial Regex AttributeRegex();
     
     /// <summary>

--- a/Refresh.Common/Constants/LevelPrefixes.cs
+++ b/Refresh.Common/Constants/LevelPrefixes.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Refresh.Common.Constants;
+
+public static partial class LevelPrefixes
+{
+    [GeneratedRegex(@"\?(\w+)\.([\w-]+)")]
+    public static partial Regex AttributeRegex();
+    
+    /// <summary>
+    /// Keywords that indicate a level is a reupload
+    /// </summary>
+    public static readonly string[] ReuploadKeywords = { 
+        "(reupload)", "[reupload]",
+        "(archive)", "[archive]"
+    };
+}

--- a/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.Tracing;
-using System.Text.RegularExpressions;
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
 using Bunkum.Core.RateLimit;
@@ -212,23 +210,6 @@ public class PublishEndpoints : EndpointGroup
                 dataContext.Database.AddPublishFailNotification("The uploaded level data was corrupted.", level, dataContext.User!);
                 return BadRequest;
             }
-        }
-        
-        // Automatically mark level as reupload by keyword matching the title
-        // + get original publisher from the description??
-        string[] reuploadWords = { 
-            "(reupload)", "[reupload]",
-            "(archive)", "[archive]"
-        };
-       
-        bool isReUpload = reuploadWords.Any(keyword => level.Title.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) >= 0);
-        if (isReUpload)
-        {
-            level.IsReUpload = true;
-
-            // get publisher -- [OriginalPublisher:{username}]
-            Match attributeMatch = Regex.Match(level.Description, @"\[OriginalPublisher:([^\]]+)\]", RegexOptions.IgnoreCase); // could we turn this in the future into something that allows custom level attributes?
-            level.OriginalPublisher = attributeMatch.Groups[1].Value;
         }
 
         if (level.LevelId != default) // Republish requests contain the id of the old level

--- a/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.Tracing;
+using System.Text.RegularExpressions;
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
 using Bunkum.Core.RateLimit;
@@ -210,6 +212,23 @@ public class PublishEndpoints : EndpointGroup
                 dataContext.Database.AddPublishFailNotification("The uploaded level data was corrupted.", level, dataContext.User!);
                 return BadRequest;
             }
+        }
+        
+        // Automatically mark level as reupload by keyword matching the title
+        // maybe get original publisher from the description??
+        string[] reuploadWords = { 
+            "(reupload)", "[reupload]",
+            "(archive)", "[archive]"
+        };
+       
+        bool isReUpload = reuploadWords.Any(keyword => level.Title.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) >= 0);
+        if (isReUpload)
+        {
+            level.IsReUpload = true;
+
+            // get publisher -- [OriginalPublisher:{username}]
+            Match attributeMatch = Regex.Match(level.Title, @"\[OriginalPublisher:([^\]]+)\]", RegexOptions.IgnoreCase); // could we turn this in the future into something that allows custom level attributes?
+            level.OriginalPublisher = attributeMatch.Groups[1].Value;
         }
 
         if (level.LevelId != default) // Republish requests contain the id of the old level

--- a/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
@@ -227,7 +227,7 @@ public class PublishEndpoints : EndpointGroup
             level.IsReUpload = true;
 
             // get publisher -- [OriginalPublisher:{username}]
-            Match attributeMatch = Regex.Match(level.Title, @"\[OriginalPublisher:([^\]]+)\]", RegexOptions.IgnoreCase); // could we turn this in the future into something that allows custom level attributes?
+            Match attributeMatch = Regex.Match(level.Description, @"\[OriginalPublisher:([^\]]+)\]", RegexOptions.IgnoreCase); // could we turn this in the future into something that allows custom level attributes?
             level.OriginalPublisher = attributeMatch.Groups[1].Value;
         }
 
@@ -246,7 +246,7 @@ public class PublishEndpoints : EndpointGroup
             return new Response(GameLevelResponse.FromOld(newBody, dataContext)!, ContentType.Xml);
         }
 
-        //Mark the user as no longer publishing
+        // Mark the user as no longer publishing
         commandService.StopPublishing(dataContext.User!.UserId);
 
         level.Publisher = dataContext.User;

--- a/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
@@ -215,7 +215,7 @@ public class PublishEndpoints : EndpointGroup
         }
         
         // Automatically mark level as reupload by keyword matching the title
-        // maybe get original publisher from the description??
+        // + get original publisher from the description??
         string[] reuploadWords = { 
             "(reupload)", "[reupload]",
             "(archive)", "[archive]"

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -126,6 +126,20 @@ public class TestContext : IDisposable
         this.Database.AddLevel(level);
         return level;
     }
+    
+    public GameLevel CreateLevel(GameUser author, string title, string description, TokenGame gameVersion = TokenGame.LittleBigPlanet1)
+    {
+        GameLevel level = new()
+        {
+            Title = title,
+            Description = description,
+            Publisher = author,
+            GameVersion = gameVersion,
+        };
+
+        this.Database.AddLevel(level);
+        return level;
+    }
 
     public void FillLeaderboard(GameLevel level, int count, byte type)
     {

--- a/RefreshTests.GameServer/Tests/Levels/ReuploadDetectionTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ReuploadDetectionTests.cs
@@ -1,0 +1,58 @@
+﻿using Refresh.Database.Models.Levels;
+using Refresh.Database.Models.Users;
+
+namespace RefreshTests.GameServer.Tests.Levels;
+
+public class ReuploadDetectionTests : GameServerTest
+{
+    [Test]
+    public void LevelPublishesNormally()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user, "All The Boxes", "One big level. Full of boxes.");
+        
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(level.IsReUpload, Is.False);
+            Assert.That(level.OriginalPublisher, Is.Null);
+        }
+    }
+    
+    [Test]
+    [TestCase("[reupload]")]
+    [TestCase("[REUPLOAD]")]
+    [TestCase("(REUPLOAD)")]
+    [TestCase("(ReUpload)")]
+    [TestCase("(reupload)")]
+    public void ReuploadDetectedInTitle(string suffix)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user, "All The Boxes " + suffix, "One big level. Full of boxes.");
+        
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(level.IsReUpload, Is.True);
+            Assert.That(level.OriginalPublisher, Is.Null);
+        }
+    }
+    
+    [Test]
+    [TestCase("?op.gamer1\n")]
+    [TestCase("?op:gamer1\n")]
+    [TestCase("?op.gamer1 ")]
+    [TestCase("?op.gamer1\r\n")]
+    public void OriginalPublisherDetectedInDescription(string prefix)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user, "All The Boxes (reupload)", $"{prefix}One big level. Full of boxes.");
+        
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(level.IsReUpload, Is.True);
+            Assert.That(level.OriginalPublisher, Is.EqualTo("gamer1"));
+        }
+    }
+}


### PR DESCRIPTION
Closes #715 

adding one of the 4  case insensitive prefixes `(reupload)` `[reupload]` `(archive)` `[archive)` to the level title will automatically mark it as`isReUpload`

additionally adding ?op.{username} to the description anywhere will populate `OriginalPublisher` automatically using a simplistic attributes thingy