### PR TITLE
Fix profile pin updating bugs

### DIFF
--- a/Refresh.Database/Migrations/20250705101737_ProfilePinRelationUpdatingFix.cs
+++ b/Refresh.Database/Migrations/20250705101737_ProfilePinRelationUpdatingFix.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProfilePinRelationUpdatingFix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ProfilePinRelations",
+                table: "ProfilePinRelations");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ProfilePinRelations",
+                table: "ProfilePinRelations",
+                columns: new[] { "Index", "PublisherId", "Game" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ProfilePinRelations",
+                table: "ProfilePinRelations");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ProfilePinRelations",
+                table: "ProfilePinRelations",
+                columns: new[] { "PinId", "PublisherId" });
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -945,8 +945,8 @@ namespace Refresh.Database.Migrations
 
             modelBuilder.Entity("Refresh.Database.Models.Relations.ProfilePinRelation", b =>
                 {
-                    b.Property<long>("PinId")
-                        .HasColumnType("bigint");
+                    b.Property<int>("Index")
+                        .HasColumnType("integer");
 
                     b.Property<string>("PublisherId")
                         .HasColumnType("text");
@@ -954,13 +954,13 @@ namespace Refresh.Database.Migrations
                     b.Property<int>("Game")
                         .HasColumnType("integer");
 
-                    b.Property<int>("Index")
-                        .HasColumnType("integer");
+                    b.Property<long>("PinId")
+                        .HasColumnType("bigint");
 
                     b.Property<DateTimeOffset>("Timestamp")
                         .HasColumnType("timestamp with time zone");
 
-                    b.HasKey("PinId", "PublisherId");
+                    b.HasKey("Index", "PublisherId", "Game");
 
                     b.HasIndex("PublisherId");
 

--- a/Refresh.Database/Models/Relations/ProfilePinRelation.cs
+++ b/Refresh.Database/Models/Relations/ProfilePinRelation.cs
@@ -6,10 +6,11 @@ namespace Refresh.Database.Models.Relations;
 
 #nullable disable
 
-[PrimaryKey(nameof(PinId), nameof(PublisherId))]
+[PrimaryKey(nameof(Index), nameof(PublisherId), nameof(Game))]
 public partial class ProfilePinRelation
 {
     public long PinId { get; set; }
+    
     [ForeignKey(nameof(PublisherId))]
     [Required] public GameUser Publisher { get; set; }
     


### PR DESCRIPTION
This fixes profile pin update failures if you either move a profile pin, or if you try setting the same pin as a profile pin in multiple games, by reworking the profile pin updating method and editing the primary key of `ProfilePinRelation`.

I have replaced `PinId` with `Index` in the primary key as a part of fixing the former bug, because I think updating profile pins per index instead of per pin ID helps keep the updating method easier and more reliable, the primary key already has to be updated to fix the latter bug, and the order of profile pins is probably more important than checking if a user has duplicate profile pins set for one game, which even if anyone somehow manages to do that, I don't think it will negatively impact anything anyway.