### PR TITLE
Playlist fixes post-database migration

### DIFF
--- a/Refresh.Core/Extensions/GamePlaylistExtensions.cs
+++ b/Refresh.Core/Extensions/GamePlaylistExtensions.cs
@@ -14,10 +14,10 @@ public static class GamePlaylistExtensions
     public static void TraverseParentsRecursively(this GamePlaylist playlist, GameDatabaseContext database,
         Func<GamePlaylist, bool> callback)
     {
-#pragma warning disable CS0618 // obsolete warning
-        // Iterate over all parents
-        foreach (GamePlaylist parent in database.GetPlaylistsContainingPlaylist(playlist).ToArray())
-#pragma warning restore CS0618
+        // Iterate over all parents.
+        // While this will not return all parents in very specific cases, I doubt anyone will go this far
+        // just to create a loop in their playlist tree.
+        foreach (GamePlaylist parent in database.GetPlaylistsContainingPlaylist(playlist, 0, 1000).Items.ToArray())
         {
             // Call the callback for this parent. If the callback requests to stop the traversal by returning false 
             // (for example because it has detected a loop in the tree), stop the traversal by returning

--- a/Refresh.Core/Extensions/GamePlaylistExtensions.cs
+++ b/Refresh.Core/Extensions/GamePlaylistExtensions.cs
@@ -3,7 +3,6 @@ using Refresh.Database.Models.Playlists;
 
 namespace Refresh.Core.Extensions;
 
-#pragma warning disable CS0618
 public static class GamePlaylistExtensions
 {
     /// <summary>
@@ -15,8 +14,10 @@ public static class GamePlaylistExtensions
     public static void TraverseParentsRecursively(this GamePlaylist playlist, GameDatabaseContext database,
         Func<GamePlaylist, bool> callback)
     {
+#pragma warning disable CS0618 // obsolete warning
         // Iterate over all parents
         foreach (GamePlaylist parent in database.GetPlaylistsContainingPlaylist(playlist).ToArray())
+#pragma warning restore CS0618
         {
             // Call the callback for this parent. If the callback requests to stop the traversal by returning false 
             // (for example because it has detected a loop in the tree), stop the traversal by returning

--- a/Refresh.Core/Extensions/GamePlaylistExtensions.cs
+++ b/Refresh.Core/Extensions/GamePlaylistExtensions.cs
@@ -3,6 +3,7 @@ using Refresh.Database.Models.Playlists;
 
 namespace Refresh.Core.Extensions;
 
+#pragma warning disable CS0618
 public static class GamePlaylistExtensions
 {
     /// <summary>
@@ -15,7 +16,7 @@ public static class GamePlaylistExtensions
         Func<GamePlaylist, bool> callback)
     {
         // Iterate over all parents
-        foreach (GamePlaylist parent in database.GetPlaylistsContainingPlaylist(playlist))
+        foreach (GamePlaylist parent in database.GetPlaylistsContainingPlaylist(playlist).ToArray())
         {
             // Call the callback for this parent. If the callback requests to stop the traversal by returning false 
             // (for example because it has detected a loop in the tree), stop the traversal by returning

--- a/Refresh.Database/Extensions/GamePlaylistExtensions.cs
+++ b/Refresh.Database/Extensions/GamePlaylistExtensions.cs
@@ -1,7 +1,6 @@
-using Refresh.Database;
 using Refresh.Database.Models.Playlists;
 
-namespace Refresh.Core.Extensions;
+namespace Refresh.Database.Extensions;
 
 public static class GamePlaylistExtensions
 {
@@ -14,10 +13,8 @@ public static class GamePlaylistExtensions
     public static void TraverseParentsRecursively(this GamePlaylist playlist, GameDatabaseContext database,
         Func<GamePlaylist, bool> callback)
     {
-        // Iterate over all parents.
-        // While this will not return all parents in very specific cases, I doubt anyone will go this far
-        // just to create a loop in their playlist tree.
-        foreach (GamePlaylist parent in database.GetPlaylistsContainingPlaylist(playlist, 0, 1000).Items.ToArray())
+        // Iterate over all parents
+        foreach (GamePlaylist parent in database.GetPlaylistsContainingPlaylistInternal(playlist).ToArray())
         {
             // Call the callback for this parent. If the callback requests to stop the traversal by returning false 
             // (for example because it has detected a loop in the tree), stop the traversal by returning

--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -216,7 +216,7 @@ public partial class GameDatabaseContext // Playlists
         => this.SubPlaylistRelations
             .Where(p => p.SubPlaylist == playlist)
             .OrderByDescending(r => r.Timestamp)
-            .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.Playlist.PlaylistId))
+            .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.PlaylistId))
             .Where(p => !p.IsRoot);
 
 #pragma warning disable CS0618 // obsolete warning
@@ -230,7 +230,7 @@ public partial class GameDatabaseContext // Playlists
 
     public DatabaseList<GamePlaylist> GetPlaylistsInPlaylist(GamePlaylist playlist, int skip, int count)
         => new(this.SubPlaylistRelations
-            .Where(p => p.Playlist == playlist)
+            .Where(p => p.PlaylistId == playlist.PlaylistId)
             .OrderByDescending(r => r.Timestamp)
             .Select(l => l.SubPlaylist), skip, count);
     
@@ -244,7 +244,7 @@ public partial class GameDatabaseContext // Playlists
         => this.LevelPlaylistRelations
             .Where(p => p.Level == level)
             .OrderByDescending(r => r.Timestamp)
-            .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.Playlist.PlaylistId));
+            .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.PlaylistId));
 
     public DatabaseList<GamePlaylist> GetPlaylistsByAuthorContainingLevel(GameUser author, GameLevel level, int skip, int count)
         => new(GetPlaylistsContainingLevelInternal(level)
@@ -269,15 +269,15 @@ public partial class GameDatabaseContext // Playlists
 
     public DatabaseList<GamePlaylist> GetPlaylistsFavouritedByUser(GameUser user, int skip, int count) 
         => new(this.FavouritePlaylistRelations
-            .Where(r => r.User == user)
+            .Where(r => r.UserId == user.UserId)
             .OrderByDescending(r => r.Timestamp)
             .Select(r => r.Playlist), skip, count);
 
     public int GetFavouriteCountForPlaylist(GamePlaylist playlist)
-        => this.FavouritePlaylistRelations.Count(r => r.Playlist == playlist);
+        => this.FavouritePlaylistRelations.Count(r => r.PlaylistId == playlist.PlaylistId);
 
     public bool IsPlaylistFavouritedByUser(GamePlaylist playlist, GameUser user)
-        => this.FavouritePlaylistRelations.FirstOrDefault(r => r.Playlist == playlist && r.User == user) != null;
+        => this.FavouritePlaylistRelations.Any(r => r.PlaylistId == playlist.PlaylistId && r.UserId == user.UserId);
 
     public bool FavouritePlaylist(GamePlaylist playlist, GameUser user)
     {
@@ -297,7 +297,7 @@ public partial class GameDatabaseContext // Playlists
     public bool UnfavouritePlaylist(GamePlaylist playlist, GameUser user)
     {
         FavouritePlaylistRelation? relation = this.FavouritePlaylistRelations
-            .FirstOrDefault(r => r.Playlist == playlist && r.User == user);
+            .FirstOrDefault(r => r.PlaylistId == playlist.PlaylistId && r.UserId == user.UserId);
 
         if (relation == null) return false;
 

--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -220,7 +220,7 @@ public partial class GameDatabaseContext // Playlists
     public int GetTotalLevelsInPlaylistCount(GamePlaylist playlist) 
         => this.LevelPlaylistRelations.Count(l => l.Playlist == playlist);
 
-    private IEnumerable<GamePlaylist> GetPlaylistsContainingPlaylistInternal(GamePlaylist playlist)
+    internal IEnumerable<GamePlaylist> GetPlaylistsContainingPlaylistInternal(GamePlaylist playlist)
         => this.SubPlaylistRelations
             .Where(p => p.SubPlaylistId == playlist.PlaylistId)
             .OrderByDescending(r => r.Timestamp)

--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -18,6 +18,10 @@ public partial class GameDatabaseContext // Playlists
     private IQueryable<LevelPlaylistRelation> LevelPlaylistRelationsIncluded => this.LevelPlaylistRelations
         .Include(r => r.Level);
 
+    private IQueryable<FavouritePlaylistRelation> FavouritePlaylistRelationsIncluded => this.FavouritePlaylistRelations
+        .Include(r => r.Playlist)
+        .Include(r => r.Playlist.Publisher);
+    
     private void CreatePlaylistInternal(GamePlaylist createInfo)
     {
         DateTimeOffset now = this._time.Now;
@@ -47,11 +51,10 @@ public partial class GameDatabaseContext // Playlists
         };
 
         this.CreatePlaylistInternal(playlist);
-
         return playlist;
     }
 
-    public void CreateRootPlaylist(GameUser user)
+    public GamePlaylist CreateRootPlaylist(GameUser user)
     {
         GameLocation randomLocation = GameLocation.Random;
 
@@ -67,6 +70,7 @@ public partial class GameDatabaseContext // Playlists
         };
 
         this.CreatePlaylistInternal(rootPlaylist);
+        return rootPlaylist;
     }
 
     public GamePlaylist? GetPlaylistById(int playlistId) 
@@ -268,7 +272,7 @@ public partial class GameDatabaseContext // Playlists
             .Where(p => p != null), skip, count);
 
     public DatabaseList<GamePlaylist> GetPlaylistsFavouritedByUser(GameUser user, int skip, int count) 
-        => new(this.FavouritePlaylistRelations
+        => new(this.FavouritePlaylistRelationsIncluded
             .Where(r => r.UserId == user.UserId)
             .OrderByDescending(r => r.Timestamp)
             .Select(r => r.Playlist), skip, count);

--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -64,7 +64,6 @@ public partial class GameDatabaseContext // Playlists
         };
 
         this.CreatePlaylistInternal(rootPlaylist);
-        this.SetUserRootPlaylist(user, rootPlaylist);
     }
 
     public GamePlaylist? GetPlaylistById(int playlistId) 

--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -8,7 +8,7 @@ using Refresh.Database.Models.Relations;
 
 namespace Refresh.Database;
 
-#pragma warning disable CS0618
+
 public partial class GameDatabaseContext // Playlists
 {
     /// <summary>
@@ -221,12 +221,14 @@ public partial class GameDatabaseContext // Playlists
             .Where(p => !p.IsRoot);
     }
 
+#pragma warning disable CS0618 // obsolete warning
     public DatabaseList<GamePlaylist> GetPlaylistsContainingPlaylist(GamePlaylist playlist, int skip, int count)
         => new(GetPlaylistsContainingPlaylist(playlist), skip, count);
 
     public DatabaseList<GamePlaylist> GetPlaylistsByAuthorContainingPlaylist(GameUser user, GamePlaylist playlist, int skip, int count)
         => new(GetPlaylistsContainingPlaylist(playlist)
             .Where(p => p.PublisherId == user.UserId), skip, count);
+#pragma warning restore CS0618
 
     public DatabaseList<GamePlaylist> GetPlaylistsInPlaylist(GamePlaylist playlist, int skip, int count)
         => new(this.SubPlaylistRelations

--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -210,9 +210,7 @@ public partial class GameDatabaseContext // Playlists
     }
 
     public IEnumerable<GamePlaylist> GetPlaylistsContainingPlaylist(GamePlaylist playlist)
-        // TODO: with postgres this can be IQueryable
         => this.SubPlaylistRelations.Where(p => p.SubPlaylist == playlist).OrderByDescending(r => r.Timestamp)
-            .AsEnumerable()
             .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.Playlist.PlaylistId))
             .Where(p => !p.IsRoot);
 
@@ -220,34 +218,27 @@ public partial class GameDatabaseContext // Playlists
         => new(this.GetPlaylistsContainingPlaylist(playlist), skip, count);
     
     public DatabaseList<GamePlaylist> GetPlaylistsByAuthorContainingPlaylist(GameUser user, GamePlaylist playlist, int skip, int count)
-        // TODO: with postgres this can be IQueryable
         => new(this.SubPlaylistRelations
             .Where(p => p.SubPlaylist == playlist)
             .OrderByDescending(r => r.Timestamp)
-            .AsEnumerable()
             .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.Playlist.PlaylistId))
             .Where(p => p.Publisher.UserId == user.UserId)
             .Where(p => !p.IsRoot), skip, count);
 
     public IEnumerable<GameLevel> GetLevelsInPlaylist(GamePlaylist playlist, TokenGame game)
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance. 
         => this.LevelPlaylistRelations
             .Where(l => l.Playlist == playlist)
             .OrderBy(r => r.Index)
-            .AsEnumerable()
             .Select(l => l.Level)
             .FilterByGameVersion(game);
         
     public DatabaseList<GameLevel> GetLevelsInPlaylist(GamePlaylist playlist, TokenGame game, int skip, int count)
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance. 
         => new(this.GetLevelsInPlaylist(playlist, game), skip, count);
 
     public DatabaseList<GameLevel> GetLevelsInPlaylist(GamePlaylist playlist, int skip, int count)
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance. 
         => new(this.LevelPlaylistRelations
             .Where(l => l.Playlist == playlist)
             .OrderBy(r => r.Index)
-            .AsEnumerable()
             .Select(l => l.Level), skip, count);
 
     public int GetTotalLevelsInPlaylistCount(GamePlaylist playlist, TokenGame game) => 
@@ -261,15 +252,12 @@ public partial class GameDatabaseContext // Playlists
         this.LevelPlaylistRelations.Count(l => l.Playlist == playlist);
 
     public IEnumerable<GamePlaylist> GetPlaylistsInPlaylist(GamePlaylist playlist)
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance. 
         => this.SubPlaylistRelations
             .Where(p => p.Playlist == playlist)
             .OrderByDescending(r => r.Timestamp)
-            .AsEnumerable()
             .Select(l => l.SubPlaylist);
 
     public DatabaseList<GamePlaylist> GetPlaylistsInPlaylist(GamePlaylist playlist, int skip, int count)
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance. 
         => new(this.GetPlaylistsInPlaylist(playlist), skip, count);
 
     public IEnumerable<GamePlaylist> GetPlaylistsByAuthor(GameUser author)
@@ -282,20 +270,16 @@ public partial class GameDatabaseContext // Playlists
         => new(this.GetPlaylistsByAuthor(author), skip, count);
 
     public DatabaseList<GamePlaylist> GetPlaylistsByAuthorContainingLevel(GameUser author, GameLevel level, int skip, int count)
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance. 
         => new(this.LevelPlaylistRelations
             .Where(p => p.Level == level)
             .OrderByDescending(r => r.Timestamp)
-            .AsEnumerable()
             .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.Playlist.PlaylistId))
             .Where(p => p.Publisher.UserId == author.UserId), skip, count);
     
     public DatabaseList<GamePlaylist> GetPlaylistsContainingLevel(GameLevel level, int skip, int count)
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance. 
         => new(this.LevelPlaylistRelations
             .Where(p => p.Level == level)
             .OrderByDescending(r => r.Timestamp)
-            .AsEnumerable()
             .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.Playlist.PlaylistId)), skip, count);
 
     public DatabaseList<GamePlaylist> GetNewestPlaylists(int skip, int count)
@@ -304,22 +288,18 @@ public partial class GameDatabaseContext // Playlists
             .OrderByDescending(p => p.CreationDate), skip, count);
 
     public DatabaseList<GamePlaylist> GetMostHeartedPlaylists(int skip, int count) 
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance.
         // TODO: reduce code duplication for getting most of x
         => new(this.FavouritePlaylistRelations
             .GroupBy(r => r.Playlist)
             .Select(g => new { Playlist = g.Key, Count = g.Count() })
             .OrderByDescending(x => x.Count)
-            .AsEnumerable()
             .Select(x => x.Playlist)
             .Where(p => p != null), skip, count);
 
     public DatabaseList<GamePlaylist> GetPlaylistsFavouritedByUser(GameUser user, int skip, int count) 
-        // TODO: When we have postgres, remove the `AsEnumerable` call for performance.
         => new(this.FavouritePlaylistRelations
             .Where(r => r.User == user)
             .OrderByDescending(r => r.Timestamp)
-            .AsEnumerable()
             .Select(r => r.Playlist), skip, count);
 
     public int GetFavouriteCountForPlaylist(GamePlaylist playlist)

--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -220,22 +220,19 @@ public partial class GameDatabaseContext // Playlists
     public int GetTotalLevelsInPlaylistCount(GamePlaylist playlist) 
         => this.LevelPlaylistRelations.Count(l => l.Playlist == playlist);
 
-    [Obsolete("Only to be used by GameDatabaseContext and GamePlaylistExtensions.")]
-    public IEnumerable<GamePlaylist> GetPlaylistsContainingPlaylist(GamePlaylist playlist)
+    private IEnumerable<GamePlaylist> GetPlaylistsContainingPlaylistInternal(GamePlaylist playlist)
         => this.SubPlaylistRelations
-            .Where(p => p.SubPlaylist == playlist)
+            .Where(p => p.SubPlaylistId == playlist.PlaylistId)
             .OrderByDescending(r => r.Timestamp)
             .Select(r => this.GamePlaylists.First(p => p.PlaylistId == r.PlaylistId))
             .Where(p => !p.IsRoot);
 
-#pragma warning disable CS0618 // obsolete warning
     public DatabaseList<GamePlaylist> GetPlaylistsContainingPlaylist(GamePlaylist playlist, int skip, int count)
-        => new(GetPlaylistsContainingPlaylist(playlist), skip, count);
+        => new(GetPlaylistsContainingPlaylistInternal(playlist), skip, count);
 
     public DatabaseList<GamePlaylist> GetPlaylistsByAuthorContainingPlaylist(GameUser user, GamePlaylist playlist, int skip, int count)
-        => new(GetPlaylistsContainingPlaylist(playlist)
+        => new(GetPlaylistsContainingPlaylistInternal(playlist)
             .Where(p => p.PublisherId == user.UserId), skip, count);
-#pragma warning restore CS0618
 
     public DatabaseList<GamePlaylist> GetPlaylistsInPlaylist(GamePlaylist playlist, int skip, int count)
         => new(this.SubPlaylistRelationsIncluded
@@ -249,7 +246,7 @@ public partial class GameDatabaseContext // Playlists
             .Where(p => !p.IsRoot)
             .OrderByDescending(p => p.LastUpdateDate), skip, count);
     
-    public IEnumerable<GamePlaylist> GetPlaylistsContainingLevelInternal(GameLevel level)
+    private IEnumerable<GamePlaylist> GetPlaylistsContainingLevelInternal(GameLevel level)
         => this.LevelPlaylistRelationsIncluded
             .Where(p => p.LevelId == level.LevelId)
             .OrderByDescending(r => r.Timestamp)

--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -8,6 +8,7 @@ using Refresh.Database.Models.Relations;
 
 namespace Refresh.Database;
 
+#pragma warning disable CS0618
 public partial class GameDatabaseContext // Playlists
 {
     /// <summary>
@@ -218,7 +219,8 @@ public partial class GameDatabaseContext // Playlists
     public int GetTotalLevelsInPlaylistCount(GamePlaylist playlist) 
         => this.LevelPlaylistRelations.Count(l => l.Playlist == playlist);
 
-    private IEnumerable<GamePlaylist> GetPlaylistsContainingPlaylistInternal(GamePlaylist playlist)
+    [Obsolete("Only to be used by GameDatabaseContext and GamePlaylistExtensions.")]
+    public IEnumerable<GamePlaylist> GetPlaylistsContainingPlaylist(GamePlaylist playlist)
     {
         IQueryable<SubPlaylistRelation> allParents = this.SubPlaylistRelations
             .Where(p => p.SubPlaylist == playlist)
@@ -230,10 +232,10 @@ public partial class GameDatabaseContext // Playlists
     }
 
     public DatabaseList<GamePlaylist> GetPlaylistsContainingPlaylist(GamePlaylist playlist, int skip, int count)
-        => new(GetPlaylistsContainingPlaylistInternal(playlist), skip, count);
+        => new(GetPlaylistsContainingPlaylist(playlist), skip, count);
 
     public DatabaseList<GamePlaylist> GetPlaylistsByAuthorContainingPlaylist(GameUser user, GamePlaylist playlist, int skip, int count)
-        => new(GetPlaylistsContainingPlaylistInternal(playlist)
+        => new(GetPlaylistsContainingPlaylist(playlist)
             .Where(p => p.PublisherId == user.UserId), skip, count);
 
     public DatabaseList<GamePlaylist> GetPlaylistsInPlaylist(GamePlaylist playlist, int skip, int count)

--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -458,12 +458,17 @@ public partial class GameDatabaseContext // Users
         });
     }
 
+    public GamePlaylist? GetUserRootPlaylist(GameUser user)
+        => this.GamePlaylists.FirstOrDefault(p => p.IsRoot && p.Publisher == user);
+
     public void SetUserRootPlaylist(GameUser user, GamePlaylist playlist)
     {
+        /*
         this.Write(() =>
         {
             user.RootPlaylist = playlist;
         });
+        */
     }
 
     public void SetUserPresenceAuthToken(GameUser user, string? token)

--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -459,17 +459,7 @@ public partial class GameDatabaseContext // Users
     }
 
     public GamePlaylist? GetUserRootPlaylist(GameUser user)
-        => this.GamePlaylists.FirstOrDefault(p => p.IsRoot && p.Publisher == user);
-
-    public void SetUserRootPlaylist(GameUser user, GamePlaylist playlist)
-    {
-        /*
-        this.Write(() =>
-        {
-            user.RootPlaylist = playlist;
-        });
-        */
-    }
+        => this.GamePlaylists.FirstOrDefault(p => p.IsRoot && p.PublisherId == user.UserId);
 
     public void SetUserPresenceAuthToken(GameUser user, string? token)
     {

--- a/Refresh.Database/Migrations/20250705152755_FixPlaylistCreation.cs
+++ b/Refresh.Database/Migrations/20250705152755_FixPlaylistCreation.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixPlaylistCreation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_GamePlaylists_PublisherId",
+                table: "GamePlaylists");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GamePlaylists_PublisherId",
+                table: "GamePlaylists",
+                column: "PublisherId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_GamePlaylists_PublisherId",
+                table: "GamePlaylists");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GamePlaylists_PublisherId",
+                table: "GamePlaylists",
+                column: "PublisherId",
+                unique: true);
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -725,8 +725,7 @@ namespace Refresh.Database.Migrations
 
                     b.HasKey("PlaylistId");
 
-                    b.HasIndex("PublisherId")
-                        .IsUnique();
+                    b.HasIndex("PublisherId");
 
                     b.ToTable("GamePlaylists");
                 });
@@ -1695,8 +1694,8 @@ namespace Refresh.Database.Migrations
             modelBuilder.Entity("Refresh.Database.Models.Playlists.GamePlaylist", b =>
                 {
                     b.HasOne("Refresh.Database.Models.Users.GameUser", "Publisher")
-                        .WithOne("RootPlaylist")
-                        .HasForeignKey("Refresh.Database.Models.Playlists.GamePlaylist", "PublisherId")
+                        .WithMany()
+                        .HasForeignKey("PublisherId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
@@ -2012,11 +2011,6 @@ namespace Refresh.Database.Migrations
                         .HasForeignKey("StatisticsUserId");
 
                     b.Navigation("Statistics");
-                });
-
-            modelBuilder.Entity("Refresh.Database.Models.Users.GameUser", b =>
-                {
-                    b.Navigation("RootPlaylist");
                 });
 #pragma warning restore 612, 618
         }

--- a/Refresh.Database/Models/Playlists/GamePlaylist.cs
+++ b/Refresh.Database/Models/Playlists/GamePlaylist.cs
@@ -18,14 +18,12 @@ public partial class GamePlaylist : ISequentialId
     /// <summary>
     /// The ID of the user who published the playlist
     /// </summary>
-    public ObjectId PublisherId { get; set; } 
+    [Required] public ObjectId PublisherId { get; set; } 
     
     /// <summary>
     /// The user who published the playlist
     /// </summary>
-    [Required]
-    [ForeignKey(nameof(PublisherId))]
-    public GameUser Publisher { get; set; }
+    [Required] public GameUser Publisher { get; set; }
     
     /// <summary>
     /// The name of the playlist
@@ -56,7 +54,7 @@ public partial class GamePlaylist : ISequentialId
     /// <summary>
     /// Whether or not this playlist is a root playlist. This is to let us hide the root playlists when we 
     /// </summary>
-    public bool IsRoot { get; set; }
+    [Required]public bool IsRoot { get; set; }
     
     [NotMapped] public int SequentialId
     {

--- a/Refresh.Database/Models/Users/GameUser.cs
+++ b/Refresh.Database/Models/Users/GameUser.cs
@@ -98,12 +98,6 @@ public partial class GameUser : IRateLimitUser
     public string? PresenceServerAuthToken { get; set; }
     
     /// <summary>
-    /// The user's root playlist. This playlist contains all the user's playlists, and optionally other slots as well,
-    /// although the game does not expose the ability to do this normally.
-    /// </summary>
-    //public GamePlaylist? RootPlaylist { get; set; }
-
-    /// <summary>
     /// Whether the user's profile information is exposed in the public API.
     /// </summary>
     public Visibility ProfileVisibility { get; set; } = Visibility.All;

--- a/Refresh.Database/Models/Users/GameUser.cs
+++ b/Refresh.Database/Models/Users/GameUser.cs
@@ -101,7 +101,7 @@ public partial class GameUser : IRateLimitUser
     /// The user's root playlist. This playlist contains all the user's playlists, and optionally other slots as well,
     /// although the game does not expose the ability to do this normally.
     /// </summary>
-    public GamePlaylist? RootPlaylist { get; set; }
+    //public GamePlaylist? RootPlaylist { get; set; }
 
     /// <summary>
     /// Whether the user's profile information is exposed in the public API.

--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameUserResponse.cs
@@ -67,6 +67,8 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
         
         Debug.Assert(old.Statistics != null);
 
+        TokenGame game = dataContext.Game;
+
         GameUserResponse response = new()
         {
             Description = old.Description,
@@ -106,8 +108,16 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             return response;
         }
 
-        response.RootPlaylistId = dataContext.Database.GetUserRootPlaylist(old)?.PlaylistId.ToString();
-        response.ProfilePins = dataContext.Database.GetProfilePinsByUser(old, dataContext.Game, 0, 3).Items.Select(p => p.PinId).ToList();
+        // Fill out information only relevant in certain games
+        if (game is TokenGame.LittleBigPlanet1 or TokenGame.BetaBuild)
+        {
+            response.RootPlaylistId = dataContext.Database.GetUserRootPlaylist(old)?.PlaylistId.ToString();
+        }
+        if (game is not TokenGame.LittleBigPlanet1 or TokenGame.LittleBigPlanetPSP)
+        {
+            response.ProfilePins = dataContext.Database.GetProfilePinsByUser(old, dataContext.Game, 0, 3)
+                .Items.Select(p => p.PinId).ToList();
+        }
 
         response.PlanetsHash = dataContext.Game switch
         {

--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameUserResponse.cs
@@ -46,7 +46,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
     [XmlElement("lbp3UsedSlots")] public int UsedSlotsLBP3 { get; set; }
     [XmlElement("lbp2PurchasedSlots")] public int PurchasedSlotsLBP2 { get; set; }
     [XmlElement("lbp3PurchasedSlots")] public int PurchasedSlotsLBP3 { get; set; }
-    [XmlElement("rootPlaylist")] public string? RootPlaylist { get; set; }
+    [XmlElement("rootPlaylist")] public int? RootPlaylistId { get; set; }
     [XmlElement("pins")] public List<long> ProfilePins { get; set; } = [];
     
     /// <summary>
@@ -87,8 +87,6 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             PhotosByMeCount = old.Statistics.PhotosByUserCount,
             PhotosWithMeCount = old.Statistics.PhotosWithUserCount,
             ReviewCount = old.Statistics.ReviewCount,
-            RootPlaylist = old.RootPlaylist?.PlaylistId.ToString(),
-            ProfilePins = !old.FakeUser ? dataContext.Database.GetProfilePinsByUser(old, dataContext.Game, 0, 3).Items.Select(p => p.PinId).ToList() : [],
             
             EntitledSlots = UgcLimits.MaximumLevels,
             EntitledSlotsLBP2 = UgcLimits.MaximumLevels,
@@ -107,7 +105,10 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             
             return response;
         }
-        
+
+        response.RootPlaylistId = dataContext.Database.GetUserRootPlaylist(old)?.PlaylistId;
+        response.ProfilePins = dataContext.Database.GetProfilePinsByUser(old, dataContext.Game, 0, 3).Items.Select(p => p.PinId).ToList();
+
         response.PlanetsHash = dataContext.Game switch
         {
             TokenGame.LittleBigPlanet1 => "0",

--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameUserResponse.cs
@@ -46,7 +46,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
     [XmlElement("lbp3UsedSlots")] public int UsedSlotsLBP3 { get; set; }
     [XmlElement("lbp2PurchasedSlots")] public int PurchasedSlotsLBP2 { get; set; }
     [XmlElement("lbp3PurchasedSlots")] public int PurchasedSlotsLBP3 { get; set; }
-    [XmlElement("rootPlaylist")] public int? RootPlaylistId { get; set; }
+    [XmlElement("rootPlaylist")] public string? RootPlaylistId { get; set; }
     [XmlElement("pins")] public List<long> ProfilePins { get; set; } = [];
     
     /// <summary>
@@ -106,7 +106,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
             return response;
         }
 
-        response.RootPlaylistId = dataContext.Database.GetUserRootPlaylist(old)?.PlaylistId;
+        response.RootPlaylistId = dataContext.Database.GetUserRootPlaylist(old)?.PlaylistId.ToString();
         response.ProfilePins = dataContext.Database.GetProfilePinsByUser(old, dataContext.Game, 0, 3).Items.Select(p => p.PinId).ToList();
 
         response.PlanetsHash = dataContext.Game switch

--- a/Refresh.Interfaces.Game/Endpoints/Levels/LevelEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/LevelEndpoints.cs
@@ -75,12 +75,13 @@ public class LevelEndpoints : EndpointGroup
         if (route == "by" && dataContext.Game == TokenGame.LittleBigPlanet1)
         {
             // Get the requested user's root playlist
-            GamePlaylist? playlist = database.GetUserByUsername(context.QueryString.Get("u"))?.RootPlaylist;
+            GameUser? requestedUser = database.GetUserByUsername(context.QueryString.Get("u"));
+            GamePlaylist? rootPlaylist = requestedUser == null ? null : database.GetUserRootPlaylist(user);
 
             // If it was found, inject it into the response info
-            if (playlist != null)
+            if (rootPlaylist != null)
             {
-                DatabaseList<GamePlaylist> playlists = database.GetPlaylistsInPlaylist(playlist, skip, count);
+                DatabaseList<GamePlaylist> playlists = database.GetPlaylistsInPlaylist(rootPlaylist, skip, count);
                 slots = GameMinimalLevelResponse.FromOldList(playlists.Items, dataContext).Concat(slots);
 
                 // While this does technically return more slot results than the game is expecting,

--- a/Refresh.Interfaces.Game/Endpoints/Levels/LevelEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/LevelEndpoints.cs
@@ -76,7 +76,7 @@ public class LevelEndpoints : EndpointGroup
         {
             // Get the requested user's root playlist
             GameUser? requestedUser = database.GetUserByUsername(context.QueryString.Get("u"));
-            GamePlaylist? rootPlaylist = requestedUser == null ? null : database.GetUserRootPlaylist(user);
+            GamePlaylist? rootPlaylist = requestedUser == null ? null : database.GetUserRootPlaylist(requestedUser);
 
             // If it was found, inject it into the response info
             if (rootPlaylist != null)

--- a/Refresh.Interfaces.Game/Endpoints/Levels/LevelEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/LevelEndpoints.cs
@@ -82,7 +82,7 @@ public class LevelEndpoints : EndpointGroup
             if (rootPlaylist != null)
             {
                 DatabaseList<GamePlaylist> playlists = database.GetPlaylistsInPlaylist(rootPlaylist, skip, count);
-                slots = GameMinimalLevelResponse.FromOldList(playlists.Items, dataContext).Concat(slots);
+                slots = GameMinimalLevelResponse.FromOldList(playlists.Items.ToArray(), dataContext).Concat(slots);
 
                 // While this does technically return more slot results than the game is expecting,
                 // because we tell the game exactly what the "next page index" is (its not based on count sent),

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
@@ -55,10 +55,6 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
         // If there is a parent, add the new playlist to the parent
         if (parent != null) 
             dataContext.Database.AddPlaylistToPlaylist(playlist, parent);
-
-        // If this new playlist is the root playlist, mark the user's root playlist as it
-        if (playlist.IsRoot)
-            dataContext.Database.SetUserRootPlaylist(user, playlist);
         
         // Create the new playlist, returning the data
         return new Response(SerializedLbp1Playlist.FromOld(playlist, dataContext), ContentType.Xml);

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
@@ -29,6 +29,8 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
             return Unauthorized;
         
         GamePlaylist? parent = null;
+        GamePlaylist? rootPlaylist = dataContext.Database.GetUserRootPlaylist(user);
+
         // If the parent ID is specified, try to parse that out
         if (int.TryParse(context.QueryString["parent_id"], out int parentId))
         {
@@ -43,12 +45,12 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
                 return Unauthorized;
 
             // If the user has no root playlist, but they are trying to create a sub-playlist, something has gone wrong.
-            if (user.RootPlaylist == null)
+            if (rootPlaylist == null)
                 return BadRequest;
         }
 
         // Create the playlist, marking it as the root playlist if the user does not have one set already
-        GamePlaylist playlist = dataContext.Database.CreatePlaylist(user, body, user.RootPlaylist == null);
+        GamePlaylist playlist = dataContext.Database.CreatePlaylist(user, body, rootPlaylist == null);
 
         // If there is a parent, add the new playlist to the parent
         if (parent != null) 

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
@@ -77,8 +77,8 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
 
         // Concat together the playlist's sub-playlists and levels 
         IEnumerable<GameMinimalLevelResponse> slots =
-            GameMinimalLevelResponse.FromOldList(subPlaylists.Items, dataContext) // the sub-playlists
-                .Concat(GameMinimalLevelResponse.FromOldList(levels.Items, dataContext)); // the sub-levels
+            GameMinimalLevelResponse.FromOldList(subPlaylists.Items.ToArray(), dataContext) // the sub-playlists
+                .Concat(GameMinimalLevelResponse.FromOldList(levels.Items.ToArray(), dataContext)); // the sub-levels
         
         // Convert the GameLevelResponse list down to a GameMinimalLevelResponse
         return new SerializedMinimalLevelList(
@@ -134,7 +134,7 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
 
         // Return the serialized playlists 
         return new SerializedMinimalLevelList(
-            GameMinimalLevelResponse.FromOldList(playlists.Items, dataContext), 
+            GameMinimalLevelResponse.FromOldList(playlists.Items.ToArray(), dataContext), 
             playlists.TotalItems, 
             skip
         );

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
@@ -41,7 +41,7 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
                 return BadRequest;
             
             // Dont let you create a sub-playlist of someone else's playlist
-            if (user.UserId != parent.Publisher.UserId)
+            if (user.UserId != parent.PublisherId)
                 return Unauthorized;
 
             // If the user has no root playlist, but they are trying to create a sub-playlist, something has gone wrong.
@@ -152,7 +152,7 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // Dont allow the wrong user to update playlists
-        if (playlist.Publisher.UserId != user.UserId)
+        if (playlist.PublisherId != user.UserId)
             return Unauthorized;
         
         database.UpdatePlaylist(playlist, body);
@@ -171,7 +171,7 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // Dont allow the wrong user to delete playlists
-        if (playlist.Publisher.UserId != user.UserId)
+        if (playlist.PublisherId != user.UserId)
             return Unauthorized;
 
         database.DeletePlaylist(playlist);
@@ -197,7 +197,7 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // Dont let people add slots to other's playlists
-        if (parentPlaylist.Publisher.UserId != user.UserId)
+        if (parentPlaylist.PublisherId != user.UserId)
             return Unauthorized;
 
         // Adding a playlist to a playlist requires a special case, since we use `SubPlaylistRelation` internally to record child playlists.
@@ -278,7 +278,7 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // Dont let people remove slots from other's playlists
-        if (parentPlaylist.Publisher.UserId != user.UserId)
+        if (parentPlaylist.PublisherId != user.UserId)
             return Unauthorized;
 
         // Removing a playlist from a playlist requires a special case, since we use `SubPlaylistRelation` internally to record child playlists.

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
@@ -28,10 +28,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
         GamePlaylist? rootPlaylist = dataContext.Database.GetUserRootPlaylist(user);
 
         // if the player has no root playlist yet, create a new one first
-        if (rootPlaylist == null)
-        {
-            dataContext.Database.CreateRootPlaylist(user);
-        }
+        rootPlaylist ??= dataContext.Database.CreateRootPlaylist(user);
 
         // create the actual playlist and add it to the root playlist
         GamePlaylist playlist = dataContext.Database.CreatePlaylist(user, body);
@@ -196,7 +193,6 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
         if (user == null) 
             return null;
 
-        // The only LBP3 playlist endpoint so far which uses pagination
         (int skip, int count) = context.GetPageData();
         DatabaseList<GamePlaylist> playlists = dataContext.Database.GetPlaylistsFavouritedByUser(user, skip, count);
 

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
@@ -92,20 +92,20 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
         if (playlist == null)
             return null;
 
-        IEnumerable<GameLevel> levels = dataContext.Database.GetLevelsInPlaylist(playlist, dataContext.Game);
+        DatabaseList<GameLevel> levels = dataContext.Database.GetLevelsInPlaylist(playlist, dataContext.Game, 0, 100);
 
-        foreach(GameLevel level in levels)
+        foreach(GameLevel level in levels.Items)
         {
             context.Logger.LogDebug(BunkumCategory.UserContent, $"Level {level}, ID {level.LevelId}, title {level.Title}");
         }
 
-        IEnumerable<GameLevelResponse> serializedLevels = GameLevelResponse.FromOldList(levels, dataContext);
+        IEnumerable<GameLevelResponse> serializedLevels = GameLevelResponse.FromOldList(levels.Items, dataContext);
 
         return new SerializedLevelList
         {
             Items = serializedLevels.ToList(),
-            Total = 0,
-            NextPageStart = 0
+            Total = levels.TotalItems,
+            NextPageStart = levels.NextPageIndex
         };
     }
 
@@ -186,11 +186,11 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
         if (user == null) 
             return null;
 
-        IEnumerable<GamePlaylist> playlists = dataContext.Database.GetPlaylistsByAuthor(user);
+        DatabaseList<GamePlaylist> playlists = dataContext.Database.GetPlaylistsByAuthor(user, 0, 100);
 
         return new SerializedLbp3PlaylistList 
         {
-            Items = SerializedLbp3Playlist.FromOldList(playlists, dataContext).ToList()
+            Items = SerializedLbp3Playlist.FromOldList(playlists.Items, dataContext).ToList()
         };
     }
 

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
@@ -99,7 +99,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
             context.Logger.LogDebug(BunkumCategory.UserContent, $"Level {level}, ID {level.LevelId}, title {level.Title}");
         }
 
-        IEnumerable<GameLevelResponse> serializedLevels = GameLevelResponse.FromOldList(levels.Items, dataContext);
+        IEnumerable<GameLevelResponse> serializedLevels = GameLevelResponse.FromOldList(levels.Items.ToArray(), dataContext);
 
         return new SerializedLevelList
         {
@@ -150,7 +150,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
         if (playlist.Publisher.UserId != user.UserId)
             return Unauthorized;
 
-        dataContext.Database.UpdatePlaylistLevelOrder(playlist, body.LevelIds);
+        dataContext.Database.ReorderLevelsInPlaylist(body.LevelIds, playlist);
         return OK;
     }
 

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
@@ -94,16 +94,9 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
 
         DatabaseList<GameLevel> levels = dataContext.Database.GetLevelsInPlaylist(playlist, dataContext.Game, 0, 100);
 
-        foreach(GameLevel level in levels.Items)
-        {
-            context.Logger.LogDebug(BunkumCategory.UserContent, $"Level {level}, ID {level.LevelId}, title {level.Title}");
-        }
-
-        IEnumerable<GameLevelResponse> serializedLevels = GameLevelResponse.FromOldList(levels.Items.ToArray(), dataContext);
-
         return new SerializedLevelList
         {
-            Items = serializedLevels.ToList(),
+            Items = GameLevelResponse.FromOldList(levels.Items.ToArray(), dataContext).ToList(),
             Total = levels.TotalItems,
             NextPageStart = levels.NextPageIndex
         };

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
@@ -50,7 +50,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // don't allow the wrong user to update playlists
-        if (playlist.Publisher.UserId != user.UserId)
+        if (playlist.PublisherId != user.UserId)
             return Unauthorized;
         
         dataContext.Database.UpdatePlaylist(playlist, body);
@@ -73,7 +73,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // don't allow the wrong user to delete playlists
-        if (playlist.Publisher.UserId != user.UserId)
+        if (playlist.PublisherId != user.UserId)
             return Unauthorized;
 
         dataContext.Database.DeletePlaylist(playlist);
@@ -111,7 +111,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // Dont let people add levels to other's playlists
-        if (playlist.Publisher.UserId != user.UserId) 
+        if (playlist.PublisherId != user.UserId) 
             return Unauthorized;
 
         foreach (int levelId in body.LevelIds)
@@ -137,7 +137,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // Dont let people reorder levels in other's playlists
-        if (playlist.Publisher.UserId != user.UserId)
+        if (playlist.PublisherId != user.UserId)
             return Unauthorized;
 
         dataContext.Database.ReorderLevelsInPlaylist(body.LevelIds, playlist);
@@ -160,7 +160,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
             return NotFound;
 
         // Dont let people remove levels from other's playlists
-        if (playlist.Publisher.UserId != user.UserId)
+        if (playlist.PublisherId != user.UserId)
             return Unauthorized;
 
         dataContext.Database.RemoveLevelFromPlaylist(level, playlist);

--- a/Refresh.Interfaces.Game/Types/Playlists/SerializedLbp3Playlist.cs
+++ b/Refresh.Interfaces.Game/Types/Playlists/SerializedLbp3Playlist.cs
@@ -23,7 +23,7 @@ public class SerializedLbp3Playlist : IDataConvertableFrom<SerializedLbp3Playlis
     /// </summary>
     [XmlElement("author")] public SerializedLbp3PlaylistAuthor? Author { get; set; }
     /// <summary>
-    /// Amount of times this playlist has been hearted
+    /// Amount of times this playlist has been hearted, not actually used for anything in LBP3
     /// </summary>
     [XmlElement("hearts")] public int HeartCount { get; set; }
     /// <summary>
@@ -48,7 +48,7 @@ public class SerializedLbp3Playlist : IDataConvertableFrom<SerializedLbp3Playlis
             {
                 Username = old.Publisher.Username
             },
-            HeartCount = dataContext.Database.GetFavouriteCountForPlaylist(old),
+            HeartCount = 0,
             PlaylistQuota = UgcLimits.MaximumLevels,
         };
     }


### PR DESCRIPTION
This fixes everything playlist-related that broke after the Postgres migration, while also cleaning up `GameDatabaseContext.Playlist` in order to achieve that. Also, `GameUser.RootPlaylist` had to be removed, since both it and `GamePlaylist.Publisher` led to EF having a one-to-one relationship between users and playlists, preventing users from creating more than one playlist, and on top of that it was redundant information.