### PR TITLE
SerializedPins cleanup and efficiency

### DIFF
--- a/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
@@ -198,7 +198,6 @@ public class UserEndpoints : EndpointGroup
     public SerializedPins GetPins(RequestContext context, DataContext dataContext, GameUser user)
         => SerializedPins.FromOld
         (
-            dataContext.Database.GetPinProgressesByUser(user, dataContext.Game, 0, 999).Items,
-            dataContext.Database.GetProfilePinsByUser(user, dataContext.Game, 0, 3).Items
+            dataContext.Database.GetPinProgressesByUser(user, dataContext.Game, 0, 999).Items
         );
 }

--- a/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
@@ -10,10 +10,10 @@ using Refresh.Core.Services;
 using Refresh.Core.Types.Data;
 using Refresh.Database;
 using Refresh.Database.Models.Authentication;
-using Refresh.Database.Models.Pins;
 using Refresh.Database.Models.Users;
 using Refresh.Interfaces.Game.Endpoints.DataTypes.Response;
 using Refresh.Interfaces.Game.Types.Lists;
+using Refresh.Interfaces.Game.Types.Pins;
 using Refresh.Interfaces.Game.Types.UserData;
 
 namespace Refresh.Interfaces.Game.Endpoints;

--- a/Refresh.Interfaces.Game/Types/Pins/SerializedPins.cs
+++ b/Refresh.Interfaces.Game/Types/Pins/SerializedPins.cs
@@ -1,8 +1,7 @@
 using Refresh.Database.Models.Relations;
 
-namespace Refresh.Database.Models.Pins;
+namespace Refresh.Interfaces.Game.Types.Pins;
 
-#nullable disable
 public partial class SerializedPins
 {
     /// <summary>
@@ -11,7 +10,7 @@ public partial class SerializedPins
     /// Can contain the same pins as AwardPins (equal progressTypes), if it does, the times awarded and progress value
     /// is usually equal per pin (progressType).
     /// </summary>
-	[JsonProperty("progress")] public List<long> ProgressPins { get; set; }
+	[JsonProperty("progress")] public List<long> ProgressPins { get; set; } = [];
 
     /// <summary>
     /// Pins which can be awarded once or multiple times.
@@ -19,14 +18,12 @@ public partial class SerializedPins
     /// Can contain the same pins as ProgressPins (equal progressTypes), if it does, the times awarded and progress value
     /// is usually equal per pin (progressType).
     /// </summary>
-	[JsonProperty("awards")] public List<long> AwardPins { get; set; }
+	[JsonProperty("awards")] public List<long> AwardPins { get; set; } = [];
 
     /// <summary>
     /// The progressTypes of pins set to be shown on a user's profile for a certain game, in an order set by the user.
     /// </summary>
-	[JsonProperty("profile_pins")] public List<long> ProfilePins { get; set; }
-
-    #nullable enable
+	[JsonProperty("profile_pins")] public List<long> ProfilePins { get; set; } = [];
 
     /// <remarks>
     /// Can throw if either the rawPins list has an odd length or if a progress value from that list can't be casted to long.
@@ -35,7 +32,6 @@ public partial class SerializedPins
     public static Dictionary<long, int> ToDictionary(IList<long> rawPins)
     {
         Dictionary<long, int> dictionary = [];
-
         for (int i = 0; i < rawPins.Count; i += 2)
         {
             long progressType = rawPins[i];
@@ -50,7 +46,6 @@ public partial class SerializedPins
     public static Dictionary<long, int> ToMergedDictionary(IEnumerable<Dictionary<long, int>> dictionaries)
     {
         IEnumerable<KeyValuePair<long, int>> mergedDictionary = [];
-
         foreach (Dictionary<long, int> dictionary in dictionaries)
         {
             mergedDictionary = mergedDictionary.Concat(dictionary);

--- a/Refresh.Interfaces.Game/Types/Pins/SerializedPins.cs
+++ b/Refresh.Interfaces.Game/Types/Pins/SerializedPins.cs
@@ -57,7 +57,7 @@ public partial class SerializedPins
             .ToDictionary();
     }
         
-    public static SerializedPins FromOld(IEnumerable<PinProgressRelation> pinProgresses, IEnumerable<ProfilePinRelation> profilePins)
+    public static SerializedPins FromOld(IEnumerable<PinProgressRelation> pinProgresses)
     {
         // Convert pin progress relations (both progressTypes and progress values) back to a list
         List<long> rawPinList = [];
@@ -69,10 +69,10 @@ public partial class SerializedPins
 
         return new()
         {
-            // Setting both to the same list is easier and has no negative impacts in-game
+            // Setting both ProgressPins and AwardPins to the same list is easier and has no negative impacts in-game
             ProgressPins = rawPinList,
             AwardPins = rawPinList,
-            ProfilePins = profilePins.Select(p => p.PinId).ToList(),
+            ProfilePins = [], // LBP never seems to care about profile pins returned here
         };
     }
 }


### PR DESCRIPTION
This PR moves `SerializedPins` from `Refresh.Database` into `Refresh.Interfaces.Game` because it only gets used for a few game endpoints and nowhere in the database. Also, `SerializedPins.ProfilePins` does not get set for responses anymore, since LBP doesn't seem to care about the profile pins returned there, reducing a database query. 