### PR TITLE
Implement user categories and expose them to LBP3

### DIFF
--- a/Refresh.Core/Types/Categories/CategoryService.cs
+++ b/Refresh.Core/Types/Categories/CategoryService.cs
@@ -2,6 +2,7 @@ using System.Collections.Frozen;
 using Bunkum.Core.Services;
 using NotEnoughLogs;
 using Refresh.Core.Types.Categories.Levels;
+using Refresh.Core.Types.Categories.Users;
 
 namespace Refresh.Core.Types.Categories;
 
@@ -36,8 +37,20 @@ public class CategoryService : EndpointService
         new AdventureCategory(),
     ];
 
+    // User Categories
+    public readonly FrozenSet<GameUserCategory> UserCategories;
+
+    // ReSharper disable once InconsistentNaming
+    private readonly List<GameUserCategory> _userCategories =
+    [
+        new HeartedUsersByUserCategory(),
+        new MostHeartedUsersCategory(),
+        new NewestUsersCategory()
+    ];
+
     internal CategoryService(Logger logger) : base(logger)
     {
         this.LevelCategories = this._levelCategories.ToFrozenSet();
+        this.UserCategories = this._userCategories.ToFrozenSet();
     }
 }

--- a/Refresh.Core/Types/Categories/Users/GameUserCategory.cs
+++ b/Refresh.Core/Types/Categories/Users/GameUserCategory.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.Contracts;
+using Bunkum.Core;
+using Refresh.Core.Types.Data;
+using Refresh.Database;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Query;
+
+namespace Refresh.Core.Types.Categories.Users;
+
+[JsonObject(MemberSerialization.OptIn)]
+public abstract class GameUserCategory : GameCategory
+{
+    internal GameUserCategory(string apiRoute, string gameRoute, bool requiresUser) : base(apiRoute, [gameRoute], requiresUser) {}
+    
+    internal GameUserCategory(string apiRoute, string[] gameRoutes, bool requiresUser) : base(apiRoute, gameRoutes, requiresUser) {}
+
+    [Pure]
+    public abstract DatabaseList<GameUser>? Fetch(RequestContext context, int skip, int count, DataContext dataContext,
+        LevelFilterSettings levelFilterSettings, GameUser? user);
+}

--- a/Refresh.Core/Types/Categories/Users/HeartedUsersByUserCategory.cs
+++ b/Refresh.Core/Types/Categories/Users/HeartedUsersByUserCategory.cs
@@ -1,0 +1,29 @@
+using Bunkum.Core;
+using Refresh.Core.Types.Data;
+using Refresh.Database;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Query;
+
+namespace Refresh.Core.Types.Categories.Users;
+
+public class HeartedUsersByUserCategory : GameUserCategory
+{
+    public HeartedUsersByUserCategory() : base("hearted", [], false)
+    {
+        this.Name = "My hearted users";
+        this.Description = "Users you've hearted.";
+        this.FontAwesomeIcon = "heart";
+        this.IconHash = "g820612";
+    }
+
+    public override DatabaseList<GameUser>? Fetch(RequestContext context, int skip, int count, DataContext dataContext,
+        LevelFilterSettings levelFilterSettings, GameUser? user)
+    {
+        // Prefer username from query, but fallback to user passed into this category if it's missing
+        string? username = context.QueryString["u"] ?? context.QueryString["username"];
+        if (username != null) user = dataContext.Database.GetUserByUsername(username);
+
+        if (user == null) return null;
+        return dataContext.Database.GetUsersFavouritedByUser(user, skip, count);
+    }
+}

--- a/Refresh.Core/Types/Categories/Users/MostHeartedUsersCategory.cs
+++ b/Refresh.Core/Types/Categories/Users/MostHeartedUsersCategory.cs
@@ -1,0 +1,25 @@
+using Bunkum.Core;
+using Refresh.Core.Types.Data;
+using Refresh.Database;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Query;
+
+namespace Refresh.Core.Types.Categories.Users;
+
+public class MostHeartedUsersCategory : GameUserCategory
+{
+    public MostHeartedUsersCategory() : base("mostHearted", [], false)
+    {
+        this.Name = "Top Creators";
+        this.Description = "Our most hearted users.";
+        this.FontAwesomeIcon = "heart";
+        this.IconHash = "g820627";
+    }
+
+    public override DatabaseList<GameUser>? Fetch(RequestContext context, int skip, int count, DataContext dataContext,
+        LevelFilterSettings levelFilterSettings, GameUser? user)
+    {
+        if (user == null) return null;
+        return dataContext.Database.GetMostFavouritedUsers(skip, count);
+    }
+}

--- a/Refresh.Core/Types/Categories/Users/NewestUsersCategory.cs
+++ b/Refresh.Core/Types/Categories/Users/NewestUsersCategory.cs
@@ -1,0 +1,24 @@
+using Bunkum.Core;
+using Refresh.Core.Types.Data;
+using Refresh.Database;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Query;
+
+namespace Refresh.Core.Types.Categories.Users;
+
+public class NewestUsersCategory : GameUserCategory
+{
+    public NewestUsersCategory() : base("newest", [], false)
+    {
+        this.Name = "Newest users";
+        this.Description = "Our newest server users.";
+        this.FontAwesomeIcon = "user-plus";
+        this.IconHash = "g820625";
+    }
+
+    public override DatabaseList<GameUser>? Fetch(RequestContext context, int skip, int count, DataContext dataContext,
+        LevelFilterSettings levelFilterSettings, GameUser? _)
+    {
+        return dataContext.Database.GetUsers(count, skip);
+    }
+}

--- a/Refresh.Database/GameDatabaseContext.Activity.cs
+++ b/Refresh.Database/GameDatabaseContext.Activity.cs
@@ -45,7 +45,7 @@ public partial class GameDatabaseContext // Activity
 
         if (parameters is { ExcludeFavouriteUsers: true, User: not null })
         {
-            List<GameUser> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User, 1000, 0).ToList();
+            List<GameUser> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User, 0, 1000).Items.ToList();
             
             query = query.Where(e => favouriteUsers.All(r => r.UserId != e.User.UserId && (e.StoredDataType != EventDataType.User || r.UserId != e.StoredObjectId))); 
         }
@@ -107,7 +107,7 @@ public partial class GameDatabaseContext // Activity
 
         if (parameters.User != null)
         {
-            List<ObjectId?> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User, 1000, 0).Select(f => (ObjectId?)f.UserId).ToList();
+            List<ObjectId?> favouriteUsers = this.GetUsersFavouritedByUser(parameters.User, 0, 1000).Items.Select(f => (ObjectId?)f.UserId).ToList();
             List<ObjectId?> userFriends = this.GetUsersMutuals(parameters.User).Select(u => (ObjectId?)u.UserId).ToList();
 
             query = query.Where(e =>

--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -108,19 +108,18 @@ public partial class GameDatabaseContext // Relations
     [Pure]
     public IEnumerable<GameUser> GetUsersMutuals(GameUser user)
     {
-        return this.GetUsersFavouritedByUser(user, 1000, 0)
+        return this.GetUsersFavouritedByUser(user, 0, 1000)
+            .Items
             .ToArray()
             .Where(u => this.IsUserFavouritedByUser(user, u));
     }
     
     [Pure]
-    public IEnumerable<GameUser> GetUsersFavouritedByUser(GameUser user, int count, int skip) => this.FavouriteUserRelationsIncluded
+    public DatabaseList<GameUser> GetUsersFavouritedByUser(GameUser user, int skip, int count) => new(this.FavouriteUserRelationsIncluded
         .Where(r => r.UserFavouriting == user)
         .OrderByDescending(r => r.Timestamp)
         .AsEnumerableIfRealm()
-        .Select(r => r.UserToFavourite)
-        .Skip(skip)
-        .Take(count);
+        .Select(r => r.UserToFavourite), skip, count);
     
     public int GetTotalUsersFavouritedByUser(GameUser user)
         => this.FavouriteUserRelations

--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -87,6 +87,11 @@ public partial class GameDatabaseContext // Users
 
     public DatabaseList<GameUser> GetUsers(int count, int skip)
         => new(this.GameUsersIncluded.OrderByDescending(u => u.JoinDate), skip, count);
+    
+    public DatabaseList<GameUser> GetMostFavouritedUsers(int skip, int count)
+        => new(this.GameUsersIncluded
+            .Where(u => u.Statistics!.FavouriteCount > 0)
+            .OrderByDescending(u => u.Statistics!.FavouriteCount), skip, count);
 
     public void UpdateUserData(GameUser user, ISerializedEditUser data, TokenGame game)
     {

--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameUserResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameUserResponse.cs
@@ -172,7 +172,7 @@ public class GameUserResponse : IDataConvertableFrom<GameUserResponse, GameUser>
                 response.Handle.IconHash = old.PspIconHash;
 
                 //Fill out PSP favourite users
-                List<GameUser> users = dataContext.Database.GetUsersFavouritedByUser(old, 20, 0).ToList();
+                List<GameUser> users = dataContext.Database.GetUsersFavouritedByUser(old, 0, 20).Items.ToList();
                 response.FavouriteUsers = new SerializedMinimalFavouriteUserList(users.Select(u => SerializedUserHandle.FromUser(u, dataContext)).ToList(), users.Count);
 
                 //Fill out PSP favourite levels

--- a/Refresh.Interfaces.Game/Endpoints/RelationEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/RelationEndpoints.cs
@@ -106,10 +106,9 @@ public class RelationEndpoints : EndpointGroup
         if (user == null) return null;
 
         (int skip, int count) = context.GetPageData();
-        List<GameUser> users = database.GetUsersFavouritedByUser(user, count, skip)
-            .ToList();
 
-        return new SerializedFavouriteUserList(GameUserResponse.FromOldList(users, dataContext).ToList(), users.Count, skip + count);
+        DatabaseList<GameUser> users = database.GetUsersFavouritedByUser(user, skip, count);
+        return new SerializedFavouriteUserList(GameUserResponse.FromOldList(users.Items.ToArray(), dataContext).ToList(), users.TotalItems, users.NextPageIndex);
     }
 
     [GameEndpoint("lolcatftw/add/{slotType}/{id}", HttpMethods.Post)]

--- a/Refresh.Interfaces.Game/Types/Categories/SerializedUserCategory.cs
+++ b/Refresh.Interfaces.Game/Types/Categories/SerializedUserCategory.cs
@@ -1,0 +1,51 @@
+using System.Xml.Serialization;
+using Bunkum.Core;
+using Refresh.Core.Types.Categories.Users;
+using Refresh.Core.Types.Data;
+using Refresh.Database;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Query;
+using Refresh.Interfaces.Game.Endpoints.DataTypes.Response;
+using Refresh.Interfaces.Game.Types.Lists;
+
+namespace Refresh.Interfaces.Game.Types.Categories;
+
+#nullable disable
+
+public class SerializedUserCategory : SerializedCategory
+{
+    [XmlElement("results")] public SerializedUserList Users { get; set; }
+
+    public static SerializedUserCategory FromUserCategory(GameUserCategory category)
+    {
+        SerializedUserCategory serializedCategory = new()
+        {
+            Name = category.Name,
+            Description = category.Description,
+            Url = "/searches/users/" + category.ApiRoute,
+            Tag = category.ApiRoute,
+            IconHash = category.IconHash,
+        };
+
+        return serializedCategory;
+    }
+
+    public static SerializedUserCategory FromUserCategory(GameUserCategory userCategory,
+        RequestContext context,
+        DataContext dataContext,
+        int skip = 0,
+        int count = 20)
+    {
+        SerializedUserCategory serializedUserCategory = FromUserCategory(userCategory);
+
+        LevelFilterSettings filterSettings = new(context, dataContext.Token!.TokenGame);
+        DatabaseList<GameUser> categoryLevels = userCategory.Fetch(context, skip, count, dataContext, filterSettings, dataContext.User);
+        
+        IEnumerable<GameUserResponse> users = categoryLevels?.Items.ToArray()
+            .Select(l => GameUserResponse.FromOld(l, dataContext)) ?? [];
+
+        serializedUserCategory.Users = new SerializedUserList() { Users = users.ToList() };
+
+        return serializedUserCategory;
+    }
+}

--- a/Refresh.Interfaces.Game/Types/Lists/SerializedCategoryList.cs
+++ b/Refresh.Interfaces.Game/Types/Lists/SerializedCategoryList.cs
@@ -3,9 +3,11 @@ using Refresh.Core.Types.Categories.Levels;
 using Refresh.Interfaces.Game.Types.Categories;
 
 namespace Refresh.Interfaces.Game.Types.Lists;
+
 [XmlRoot("categories")]
 [XmlType("categories")]
 [XmlInclude(typeof(SerializedLevelCategory))]
+[XmlInclude(typeof(SerializedUserCategory))]
 public class SerializedCategoryList : SerializedList<SerializedCategory>
 {
     public SerializedCategoryList(IEnumerable<SerializedCategory> items, SearchLevelCategory searchCategory, int total)

--- a/Refresh.Interfaces.Game/Types/Lists/SerializedCategoryResultsList.cs
+++ b/Refresh.Interfaces.Game/Types/Lists/SerializedCategoryResultsList.cs
@@ -25,5 +25,5 @@ public class SerializedCategoryResultsList : SerializedPaginationData
     }
 
     [XmlElement("slot")] public List<GameMinimalLevelResponse> Levels { get; set; } = [];
-    [XmlElement("users")] public List<GameUserResponse> Users { get; set; } = [];
+    [XmlElement("user")] public List<GameUserResponse> Users { get; set; } = [];
 }

--- a/Refresh.Interfaces.Game/Types/Lists/SerializedCategoryResultsList.cs
+++ b/Refresh.Interfaces.Game/Types/Lists/SerializedCategoryResultsList.cs
@@ -1,4 +1,5 @@
 using System.Xml.Serialization;
+using Refresh.Interfaces.Game.Endpoints.DataTypes.Response;
 using Refresh.Interfaces.Game.Types.Levels;
 
 namespace Refresh.Interfaces.Game.Types.Lists;
@@ -16,5 +17,13 @@ public class SerializedCategoryResultsList : SerializedPaginationData
         this.Total = totalItems;
     }
 
+    public SerializedCategoryResultsList(IEnumerable<GameUserResponse> users, int nextPageIndex, int totalItems)
+    {
+        this.Users = users.ToList();
+        this.NextPageStart = nextPageIndex!;
+        this.Total = totalItems;
+    }
+
     [XmlElement("slot")] public List<GameMinimalLevelResponse> Levels { get; set; } = [];
+    [XmlElement("users")] public List<GameUserResponse> Users { get; set; } = [];
 }


### PR DESCRIPTION
This PR implements a few user categories and allows LBP3 to show them alongside level categories. They work the same as level categories, but their results show users instead. User categories and their results don't get shown to the game if `GameServerConfig.PermitShowingOnlineUsers` is set to false in the configs.

<img width="1248" height="687" alt="lel_20250715_175618" src="https://github.com/user-attachments/assets/85912dca-18e6-431e-a72a-b41a2ff43f16" />

This PR does not implement them for the API, but that can be done in the future.