### PR TITLE
Simplify and centralize configuration loading mechanisms

### DIFF
--- a/Refresh.Core/Configuration/ConfigStore.cs
+++ b/Refresh.Core/Configuration/ConfigStore.cs
@@ -1,0 +1,55 @@
+﻿using Bunkum.Core;
+using Bunkum.Core.Configuration;
+using NotEnoughLogs;
+
+namespace Refresh.Core.Configuration;
+
+public class ConfigStore
+{
+    public GameServerConfig GameServer { get; }
+    public DatabaseConfig DatabaseConfig { get; }
+    
+    public ContactInfoConfig ContactInfo { get; }
+    public IntegrationConfig Integration { get; }
+    public RichPresenceConfig RichPresence { get; }
+
+    public DryArchiveConfig DryArchive { get; }
+
+    private static readonly Lock ConfigLock = new();
+    public ConfigStore(Logger logger)
+    {
+        lock (ConfigLock)
+        {
+            this.GameServer = Config.LoadFromJsonFile<GameServerConfig>("refreshGameServer.json", logger);
+            this.DatabaseConfig = Config.LoadFromJsonFile<DatabaseConfig>("db.json", logger);
+        
+            this.ContactInfo = Config.LoadFromJsonFile<ContactInfoConfig>("contactInfo.json", logger);
+            this.Integration = Config.LoadFromJsonFile<IntegrationConfig>("integrations.json", logger);
+            this.RichPresence = Config.LoadFromJsonFile<RichPresenceConfig>("rpc.json", logger);
+        
+            this.DryArchive = Config.LoadFromJsonFile<DryArchiveConfig>("dry.json", logger);
+        }
+    }
+
+    public ConfigStore()
+    {
+        this.GameServer = new GameServerConfig();
+        this.DatabaseConfig = new DatabaseConfig();
+
+        this.ContactInfo = new ContactInfoConfig();
+        this.Integration = new IntegrationConfig();
+        this.RichPresence = new RichPresenceConfig();
+
+        this.DryArchive = new DryArchiveConfig();
+    }
+
+    public void AddToBunkum(BunkumServer server)
+    {
+        server.AddConfig(this.GameServer);
+        server.AddConfig(this.DatabaseConfig);
+        server.AddConfig(this.ContactInfo);
+        server.AddConfig(this.Integration);
+        server.AddConfig(this.RichPresence);
+        server.AddConfig(this.DryArchive);
+    }
+}

--- a/Refresh.Core/Configuration/ConfigStore.cs
+++ b/Refresh.Core/Configuration/ConfigStore.cs
@@ -7,7 +7,7 @@ namespace Refresh.Core.Configuration;
 public class ConfigStore
 {
     public GameServerConfig GameServer { get; }
-    public DatabaseConfig DatabaseConfig { get; }
+    public DatabaseConfig Database { get; }
     
     public ContactInfoConfig ContactInfo { get; }
     public IntegrationConfig Integration { get; }
@@ -21,7 +21,7 @@ public class ConfigStore
         lock (ConfigLock)
         {
             this.GameServer = Config.LoadFromJsonFile<GameServerConfig>("refreshGameServer.json", logger);
-            this.DatabaseConfig = Config.LoadFromJsonFile<DatabaseConfig>("db.json", logger);
+            this.Database = Config.LoadFromJsonFile<DatabaseConfig>("db.json", logger);
         
             this.ContactInfo = Config.LoadFromJsonFile<ContactInfoConfig>("contactInfo.json", logger);
             this.Integration = Config.LoadFromJsonFile<IntegrationConfig>("integrations.json", logger);
@@ -34,7 +34,7 @@ public class ConfigStore
     public ConfigStore()
     {
         this.GameServer = new GameServerConfig();
-        this.DatabaseConfig = new DatabaseConfig();
+        this.Database = new DatabaseConfig();
 
         this.ContactInfo = new ContactInfoConfig();
         this.Integration = new IntegrationConfig();
@@ -46,7 +46,7 @@ public class ConfigStore
     public void AddToBunkum(BunkumServer server)
     {
         server.AddConfig(this.GameServer);
-        server.AddConfig(this.DatabaseConfig);
+        server.AddConfig(this.Database);
         server.AddConfig(this.ContactInfo);
         server.AddConfig(this.Integration);
         server.AddConfig(this.RichPresence);

--- a/Refresh.Core/Configuration/DryArchiveConfig.cs
+++ b/Refresh.Core/Configuration/DryArchiveConfig.cs
@@ -1,6 +1,6 @@
 using Bunkum.Core.Configuration;
 
-namespace Refresh.Core.Storage;
+namespace Refresh.Core.Configuration;
 
 public class DryArchiveConfig : Config
 {

--- a/Refresh.Core/Storage/DryDataStore.cs
+++ b/Refresh.Core/Storage/DryDataStore.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Bunkum.Core.Storage;
 using JetBrains.Annotations;
 using Refresh.Common.Verification;
+using Refresh.Core.Configuration;
 using Refresh.Core.Metrics;
 
 namespace Refresh.Core.Storage;

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -57,7 +57,8 @@ public class RefreshGameServer : RefreshServer
 
         try
         {
-            this._configStore = new ConfigStore(this.Logger);
+            // ReSharper disable once VirtualMemberCallInConstructor (you can't stop me)
+            this._configStore = this.CreateConfigStore();
         }
         catch (Exception ex)
         {
@@ -97,6 +98,11 @@ public class RefreshGameServer : RefreshServer
 
             this.InjectBaseServices(provider, authProvider, this._dataStore);
         });
+    }
+
+    protected virtual ConfigStore CreateConfigStore()
+    {
+        return new ConfigStore(this.Logger);
     }
 
     private void InjectBaseServices(GameDatabaseProvider databaseProvider, IAuthenticationProvider<Token> authProvider, IDataStore dataStore)

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -69,7 +69,7 @@ public class RefreshGameServer : RefreshServer
         if (this._configStore.DryArchive.Enabled)
             dataStores.Add(new DownloadingDataStore(dataStore, new DryDataStore(this._configStore.DryArchive)));
 
-        databaseProvider ??= () => new GameDatabaseProvider(this.Logger, this._configStore.DatabaseConfig);
+        databaseProvider ??= () => new GameDatabaseProvider(this.Logger, this._configStore.Database);
         
         this._databaseProvider = databaseProvider.Invoke();
         this._databaseProvider.Initialize();

--- a/Refresh.WorkerManager/Program.cs
+++ b/Refresh.WorkerManager/Program.cs
@@ -2,6 +2,7 @@
 using Bunkum.Core.Storage;
 using NotEnoughLogs;
 using NotEnoughLogs.Behaviour;
+using Refresh.Core.Configuration;
 using Refresh.Database;
 using Refresh.Database.Configuration;
 using Refresh.Interfaces.Workers;
@@ -22,8 +23,11 @@ using Logger logger = new(loggerConfiguration);
 logger.LogInfo(BunkumCategory.Startup, "Starting up worker manager...");
 logger.LogCritical(BunkumCategory.Startup, "The dedicated worker manager isn't complete yet! It will work in a debug setting, but do not use this in production yet.");
 
-using GameDatabaseProvider database = new(logger, new EmptyDatabaseConfig());
+logger.LogInfo(BunkumCategory.Startup, "Initializing configs...");
+ConfigStore configStore = new(logger);
+
 logger.LogInfo(BunkumCategory.Startup, "Initializing database...");
+using GameDatabaseProvider database = new(logger, configStore.Database);
 database.Initialize();
 logger.LogInfo(BunkumCategory.Startup, "Warming up database...");
 database.Warmup();

--- a/Refresh.Workers/WorkerManager.cs
+++ b/Refresh.Workers/WorkerManager.cs
@@ -54,7 +54,7 @@ public class WorkerManager
             if (!job.CanExecute())
                 continue;
             
-            this._logger.LogDebug(RefreshContext.Worker, $"Running work cycle for {job.GetType().Name}");
+            this._logger.LogTrace(RefreshContext.Worker, $"Running work cycle for {job.GetType().Name}");
             try
             {
                 job.ExecuteJob(context);

--- a/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
+++ b/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
@@ -26,13 +26,10 @@ public class TestRefreshGameServer : RefreshGameServer
 
     protected override void SetupConfiguration()
     {
-        this.Server.AddConfig(this._config = new GameServerConfig());
-        this.Server.AddConfig(new RichPresenceConfig());
-        this.Server.AddConfig(this._integrationConfig = new IntegrationConfig());
-        this.Server.AddConfig(new ContactInfoConfig());
+        new ConfigStore().AddToBunkum(this.Server);
     }
 
-    public GameServerConfig GameServerConfig => this._config!;
+    public GameServerConfig GameServerConfig => this._configStore.GameServer;
 
     public override void Start()
     {
@@ -71,7 +68,7 @@ public class TestRefreshGameServer : RefreshGameServer
         this.Server.AddService<CategoryService>();
         this.Server.AddService<MatchService>();
         this.Server.AddService<ImportService>();
-        this.Server.AddService(new PresenceService(this.Logger, this._integrationConfig!));
+        this.Server.AddService(new PresenceService(this.Logger, this._configStore.Integration!));
         this.Server.AddService<PlayNowService>();
         this.Server.AddService<CommandService>();
         this.Server.AddService<GuidCheckerService>();

--- a/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
+++ b/RefreshTests.GameServer/GameServer/TestRefreshGameServer.cs
@@ -24,9 +24,9 @@ public class TestRefreshGameServer : RefreshGameServer
     public TestRefreshGameServer(BunkumHttpListener listener, Func<GameDatabaseProvider> provider, IDataStore? dataStore = null) : base(listener, provider, null, dataStore ?? new InMemoryDataStore())
     {}
 
-    protected override void SetupConfiguration()
+    protected override ConfigStore CreateConfigStore()
     {
-        new ConfigStore().AddToBunkum(this.Server);
+        return new ConfigStore();
     }
 
     public GameServerConfig GameServerConfig => this._configStore.GameServer;


### PR DESCRIPTION
- Allows tests to easily generate empty configs. Prevents them from using filesystem configs entirely.
- Configuration loading is behind a lock now. This nullifies the weird random failures caused by unit tests generating config files but doesn't actually serve too much purpose as the codepath isn't hit by unit tests anymore. Kept as it shouldn't technically harm anything.
- Reduces the complexity of config management in `RefreshGameServer` and `TestRefreshGameServer`
- Allows the new `Refresh.WorkerManager` server to easily utilize all the configs from the main GameServer project