### PR TITLE
Add support for simple background migration jobs

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Workers.cs
+++ b/Refresh.Database/GameDatabaseContext.Workers.cs
@@ -52,13 +52,18 @@ public partial class GameDatabaseContext // Workers
 
     public void UpdateOrCreateJobState(string jobId, object state)
     {
-        PersistentJobState jobState = new()
+        PersistentJobState? jobState = this.JobStates.FirstOrDefault(s => s.JobId == jobId);
+        if (jobState == null)
         {
-            JobId = jobId,
-            State = JsonConvert.SerializeObject(state, Formatting.None),
-        };
+            jobState = new PersistentJobState
+            {
+                JobId = jobId,
+            };
 
-        this.JobStates.Update(jobState);
+            this.JobStates.Add(jobState);
+        }
+        
+        jobState.State = JsonConvert.SerializeObject(state, Formatting.None);
         this.SaveChanges();
     }
 }

--- a/Refresh.Database/GameDatabaseContext.Workers.cs
+++ b/Refresh.Database/GameDatabaseContext.Workers.cs
@@ -40,4 +40,25 @@ public partial class GameDatabaseContext // Workers
         
         return true;
     }
+
+    public object? GetJobState(string jobId, Type type)
+    {
+        PersistentJobState? state = this.JobStates.FirstOrDefault(s => s.JobId == jobId);
+        if (state == null)
+            return null;
+
+        return JsonConvert.DeserializeObject(state.State, type);
+    }
+
+    public void UpdateOrCreateJobState(string jobId, object state)
+    {
+        PersistentJobState jobState = new()
+        {
+            JobId = jobId,
+            State = JsonConvert.SerializeObject(state, Formatting.None),
+        };
+
+        this.JobStates.Update(jobState);
+        this.SaveChanges();
+    }
 }

--- a/Refresh.Database/GameDatabaseContext.cs
+++ b/Refresh.Database/GameDatabaseContext.cs
@@ -73,6 +73,7 @@ public partial class GameDatabaseContext : DbContext, IDatabaseContext
     internal DbSet<ProfilePinRelation> ProfilePinRelations { get; set; }
     internal DbSet<GameSkillReward> GameSkillRewards { get; set; }
     internal DbSet<WorkerInfo> Workers { get; set; }
+    internal DbSet<PersistentJobState> JobStates { get; set; }
     
 #pragma warning disable CS8618 // Non-nullable variable must contain a non-null value when exiting constructor. Consider declaring it as nullable.
     internal GameDatabaseContext(Logger logger, IDateTimeProvider time, IDatabaseConfig dbConfig)

--- a/Refresh.Database/Migrations/20250722045529_AddJobStateTable.cs
+++ b/Refresh.Database/Migrations/20250722045529_AddJobStateTable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250722045529_AddJobStateTable")]
+    /// <inheritdoc />
+    public partial class AddJobStateTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "JobStates",
+                columns: table => new
+                {
+                    JobId = table.Column<string>(type: "text", nullable: false),
+                    State = table.Column<string>(type: "jsonb", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_JobStates", x => x.JobId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "JobStates");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -1437,6 +1437,20 @@ namespace Refresh.Database.Migrations
                     b.ToTable("QueuedRegistrations");
                 });
 
+            modelBuilder.Entity("Refresh.Database.Models.Workers.PersistentJobState", b =>
+                {
+                    b.Property<string>("JobId")
+                        .HasColumnType("text");
+
+                    b.Property<string>("State")
+                        .IsRequired()
+                        .HasColumnType("jsonb");
+
+                    b.HasKey("JobId");
+
+                    b.ToTable("JobStates");
+                });
+
             modelBuilder.Entity("Refresh.Database.Models.Workers.WorkerInfo", b =>
                 {
                     b.Property<int>("WorkerId")

--- a/Refresh.Database/Models/Workers/PersistentJobState.cs
+++ b/Refresh.Database/Models/Workers/PersistentJobState.cs
@@ -1,0 +1,7 @@
+﻿namespace Refresh.Database.Models.Workers;
+
+public class PersistentJobState
+{
+    [Key, Required] public string JobId { get; set; } = null!;
+    [Column(TypeName = "jsonb"), Required] public string State { get; set; } = null!;
+}

--- a/Refresh.Workers/Refresh.Workers.csproj
+++ b/Refresh.Workers/Refresh.Workers.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="RefreshTests.GameServer" />
         <ProjectReference Include="..\Refresh.Core\Refresh.Core.csproj" />
     </ItemGroup>
 

--- a/Refresh.Workers/State/IJobStoresState.cs
+++ b/Refresh.Workers/State/IJobStoresState.cs
@@ -1,0 +1,8 @@
+﻿namespace Refresh.Workers.State;
+
+public interface IJobStoresState
+{
+    public string JobId { get; set; }
+    public object JobState { get; protected internal set; }
+    public Type JobStateType { get; }
+}

--- a/Refresh.Workers/State/IJobStoresState.cs
+++ b/Refresh.Workers/State/IJobStoresState.cs
@@ -2,7 +2,7 @@
 
 public interface IJobStoresState
 {
-    public string JobId { get; set; }
-    public object JobState { get; protected internal set; }
+    public string JobId { get; }
+    public object JobState { get; set; }
     public Type JobStateType { get; }
 }

--- a/Refresh.Workers/State/MigrationJobState.cs
+++ b/Refresh.Workers/State/MigrationJobState.cs
@@ -1,0 +1,11 @@
+﻿namespace Refresh.Workers.State;
+
+public class MigrationJobState
+{
+    public bool StateInitialized;
+    public int Total;
+    public int Processed;
+
+    public bool Complete => this.Remaining <= 0;
+    public int Remaining => this.Total - this.Processed;
+}

--- a/RefreshTests.GameServer/GameServer/TestMigrationJob.cs
+++ b/RefreshTests.GameServer/GameServer/TestMigrationJob.cs
@@ -1,0 +1,20 @@
+﻿using Refresh.Database.Models.Levels;
+using Refresh.Workers;
+
+namespace RefreshTests.GameServer.GameServer;
+
+public class TestMigrationJob : MigrationJob<GameLevel>
+{
+    protected override void Migrate(WorkContext context, GameLevel[] batch)
+    {
+        foreach (GameLevel level in batch)
+        {
+            level.Title += " test";
+        }
+    }
+
+    protected override IQueryable<GameLevel> SortAndFilter(IQueryable<GameLevel> query)
+    {
+        return query.OrderBy(l => l.LevelId);
+    }
+}

--- a/RefreshTests.GameServer/Tests/Workers/MigrationTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/MigrationTests.cs
@@ -1,0 +1,32 @@
+﻿using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Levels;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Query;
+using Refresh.Workers.State;
+
+namespace RefreshTests.GameServer.Tests.Workers;
+
+public class MigrationTests : GameServerTest
+{
+    [Test]
+    public void MigrationJobWorks()
+    {
+        using TestContext context = this.GetServer();
+        TestMigrationJob job = new();
+        GameUser user = context.CreateUser();
+
+        for (int i = 0; i < 100; i++)
+        {
+            context.CreateLevel(user);
+        }
+
+        IEnumerable<GameLevel> allLevels = context.Database.GetNewestLevels(100, 0, null, new LevelFilterSettings(TokenGame.Website)).Items;
+        Assert.That(allLevels.All(l => l.Title == "Level"), Is.True);
+
+        job.JobState = new MigrationJobState();
+        job.ExecuteJob(context.GetWorkContext());
+        
+        allLevels = context.Database.GetNewestLevels(100, 0, null, new LevelFilterSettings(TokenGame.Website)).Items;
+        Assert.That(allLevels.All(l => l.Title == "Level test"), Is.True);
+    }
+}


### PR DESCRIPTION
This introduces support for background migration jobs that run alongside Refresh, have access to all of our database code, and don't block on startup.

They can filter and order a table, then iterate over the results. An example migration is provided for the unit tests.

This is good for migrations that we can't easily write with raw SQL or EF migration code, or can take a long time. They're also database agnostic as they're written in C#.