### PR TITLE
In-game recent activity fixes

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Activity.cs
+++ b/Refresh.Database/GameDatabaseContext.Activity.cs
@@ -28,10 +28,10 @@ public partial class GameDatabaseContext // Activity
 
         if (parameters is { ExcludeMyLevels: true, User: not null })
         {
-            //Filter the query to events which either arent level related, or which the level publisher doesnt contain the user
-            query = query
-                .AsEnumerable() // TODO: optimize me
-                .Where(e => e.StoredDataType != EventDataType.Level || this.GetLevelById(e.StoredSequentialId ?? int.MaxValue)?.Publisher?.UserId != parameters.User.UserId);
+            //Filter the query to events which either arent level related, or which the level publisher is not the user
+            query = query // TODO: This part of the query can still be more optimized
+                .ToArray() // this instead of AsEnumerable avoids a NpgsqlOperationInProgressException
+                .Where(e => e.StoredDataType != EventDataType.Level || (e.StoredSequentialId != null && this.GetLevelById(e.StoredSequentialId.Value)?.Publisher?.UserId != parameters.User.UserId));
         }
         
         if (parameters is { ExcludeFriends: true, User: not null })

--- a/Refresh.Interfaces.Game/Endpoints/ActivityEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/ActivityEndpoints.cs
@@ -2,6 +2,7 @@ using System.Xml;
 using System.Xml.Serialization;
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
+using Bunkum.Core.RateLimit;
 using Bunkum.Core.Responses;
 using Bunkum.Listener.Protocol;
 using Bunkum.Protocols.Http;
@@ -23,8 +24,14 @@ namespace Refresh.Interfaces.Game.Endpoints;
 
 public class ActivityEndpoints : EndpointGroup
 {
+    private const int RequestTimeoutDuration = 60;
+    private const int MaxRequestAmount = 80;
+    private const int RequestBlockDuration = 60;
+    private const string BucketName = "activity";
+
     [GameEndpoint("stream", ContentType.Xml)]
     [GameEndpoint("stream", ContentType.Xml, HttpMethods.Post)]
+    [RateLimitSettings(RequestTimeoutDuration, MaxRequestAmount, RequestBlockDuration, BucketName)]
     [NullStatusCode(BadRequest)]
     [MinimumRole(GameUserRole.Restricted)]
     public SerializedActivityPage? GetRecentActivity(RequestContext context, GameServerConfig config, GameDatabaseContext database, GameUser? user,
@@ -61,6 +68,7 @@ public class ActivityEndpoints : EndpointGroup
     }
 
     [GameEndpoint("stream/slot/{type}/{id}", ContentType.Xml)]
+    [RateLimitSettings(RequestTimeoutDuration, MaxRequestAmount, RequestBlockDuration, BucketName)]
     [NullStatusCode(BadRequest)]
     [MinimumRole(GameUserRole.Restricted)]
     public Response GetRecentActivityForLevel(RequestContext context, GameServerConfig config, GameDatabaseContext database, GameUser? user,
@@ -108,6 +116,7 @@ public class ActivityEndpoints : EndpointGroup
     }
 
     [GameEndpoint("stream/user2/{username}", ContentType.Xml)]
+    [RateLimitSettings(RequestTimeoutDuration, MaxRequestAmount, RequestBlockDuration, BucketName)]
     [NullStatusCode(BadRequest)]
     [MinimumRole(GameUserRole.Restricted)]
     public Response GetRecentActivityFromUser(RequestContext context, GameServerConfig config, GameDatabaseContext database, string username,

--- a/Refresh.Interfaces.Game/Endpoints/ActivityEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/ActivityEndpoints.cs
@@ -68,7 +68,12 @@ public class ActivityEndpoints : EndpointGroup
     {
         if (!config.PermitShowingOnlineUsers)
             return Unauthorized;
+
+        return NoContent;
         
+        // FIXME: enable below code to have this endpoint return actual recent activity as soon as we find out how to do so without
+        // the game rejecting the response and spamming this endpoint
+        /*
         GameLevel? level = type == "developer" ? database.GetStoryLevelById(id) : database.GetLevelById(id);
         if (level == null) return NotFound;
         
@@ -99,6 +104,7 @@ public class ActivityEndpoints : EndpointGroup
         }), dataContext);
         
         return new Response(page, ContentType.Xml);
+        */
     }
 
     [GameEndpoint("stream/user2/{username}", ContentType.Xml)]
@@ -109,7 +115,12 @@ public class ActivityEndpoints : EndpointGroup
     {
         if (!config.PermitShowingOnlineUsers)
             return Unauthorized;
+        
+        return NoContent;
 
+        // FIXME: enable below code to have this endpoint return actual recent activity as soon as we find out how to do so without
+        // the game rejecting the response and spamming this endpoint
+        /*
         GameUser? user = database.GetUserByUsername(username);
         if (user == null) return NotFound;
 
@@ -148,6 +159,7 @@ public class ActivityEndpoints : EndpointGroup
             ExcludeMyself = excludeMyself,
             User = user,
         }), dataContext), ContentType.Xml);
+        */
     }
     
     [GameEndpoint("news", ContentType.Xml)]

--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
@@ -146,9 +146,11 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         
         Debug.Assert(old.Statistics != null);
 
+        bool isStoryLevel = old.StoryId != 0;
+
         GameLevelResponse response = new()
         {
-            LevelId = old.LevelId,
+            LevelId = isStoryLevel ? old.StoryId : old.LevelId,
             IsAdventure = old.IsAdventure,
             Title = old.Title,
             IconHash = old.IconHash,

--- a/Refresh.Interfaces.Game/Types/Activity/Groups/SerializedActivityGroup.cs
+++ b/Refresh.Interfaces.Game/Types/Activity/Groups/SerializedActivityGroup.cs
@@ -44,6 +44,9 @@ public abstract class SerializedActivityGroup : IDataConvertableFrom<SerializedA
 
         if (old is DatabaseActivityLevelGroup levelOld)
         {
+            GameLevel level = levelOld.Level;
+            bool isStoryLevel = level.StoryId != 0;
+
             return new LevelSerializedActivityGroup
             {
                 Type = "level",
@@ -52,8 +55,8 @@ public abstract class SerializedActivityGroup : IDataConvertableFrom<SerializedA
                 Subgroups = subgroups,
                 LevelId = new SerializedLevelId
                 {
-                    LevelId = levelOld.Level.LevelId,
-                    Type = levelOld.Level.SlotType.ToGameType(),
+                    LevelId = isStoryLevel ? level.StoryId : level.LevelId,
+                    Type = level.SlotType.ToGameType(),
                 },
             };
         }

--- a/Refresh.Interfaces.Game/Types/Activity/SerializedEvents/SerializedEvent.cs
+++ b/Refresh.Interfaces.Game/Types/Activity/SerializedEvents/SerializedEvent.cs
@@ -92,6 +92,8 @@ public abstract class SerializedEvent : IDataConvertableFrom<SerializedEvent, Ev
         if (level == null)
             return null;
         
+        bool isStoryLevel = level.StoryId != 0;
+        
         return new SerializedLevelEvent
         {
             Timestamp = old.Timestamp.ToUnixTimeMilliseconds(),
@@ -99,7 +101,7 @@ public abstract class SerializedEvent : IDataConvertableFrom<SerializedEvent, Ev
             Actor = old.User.Username,
             LevelId = new SerializedLevelId()
             {
-                LevelId = level.LevelId,
+                LevelId = isStoryLevel ? level.StoryId : level.LevelId,
                 Type = level.SlotType.ToGameType(),
             },
         };


### PR DESCRIPTION
This PR allows story levels to show up in recent activity (and other places as a side-effect, like hearted levels lists), fixes an exception when using the game's `excludeMyself` filter for recent activity, and temporarily disables most of the code for the `/lbp/stream/slot/{type}/{id}` and `/lbp/stream/user2/{username}` endpoints to not have LBP spam them for now until someone finds the reason why the game spams them (I tried for a few hours, but couldn't). Also seperate rate-limiting for the game's activity endpoints incase the game ends up spamming them anyway.