### PR TITLE
Fix incorrect ?op attribute behavior

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -646,7 +646,7 @@ public partial class GameDatabaseContext // Levels
             Dictionary<string, string> levelAttributes = LevelPrefixes.ExtractAttributes(level.Description);
             
             // Get original publisher from ?op.{username} or ?op:{username} otherwise Unknown
-            level.OriginalPublisher = levelAttributes.GetValueOrDefault("op") ?? SystemUsers.UnknownUserName; 
+            level.OriginalPublisher = levelAttributes.GetValueOrDefault("op"); 
         }
 
         if (save)

--- a/Refresh.Database/Migrations/20250725200929_FixIncorrectOpAttributeBehavior.cs
+++ b/Refresh.Database/Migrations/20250725200929_FixIncorrectOpAttributeBehavior.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20250725200929_FixIncorrectOpAttributeBehavior")]
+    /// <inheritdoc />
+    public partial class FixIncorrectOpAttributeBehavior : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE \"GameLevels\" SET \"OriginalPublisher\" = null WHERE \"OriginalPublisher\" = '!Unknown'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // no-op, this is part of a bugfix
+        }
+    }
+}

--- a/RefreshTests.GameServer/Tests/Levels/ReuploadDetectionTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/ReuploadDetectionTests.cs
@@ -35,7 +35,7 @@ public class ReuploadDetectionTests : GameServerTest
         using (Assert.EnterMultipleScope())
         {
             Assert.That(level.IsReUpload, Is.True);
-            Assert.That(level.OriginalPublisher, Is.EqualTo(SystemUsers.UnknownUserName));
+            Assert.That(level.OriginalPublisher, Is.Null);
         }
     }
     


### PR DESCRIPTION
The code for attributes was incorrectly setting the publisher to the `!Unknown` system username which was causing levels to appear as published by `!!Unknown` in-game. This fixes that behavior and adds a migration to fix levels broken by this.