### PR TITLE
Also check for gzip when considering request encodings

### DIFF
--- a/Refresh.GameServer/Middlewares/DeflateMiddleware.cs
+++ b/Refresh.GameServer/Middlewares/DeflateMiddleware.cs
@@ -41,8 +41,8 @@ public class DeflateMiddleware(GameServerConfig config) : IMiddleware
             return;
         
         string? encodings = context.RequestHeaders.Get("Accept-Encoding");
-        // If the accepted encodings aren't specified, or they don't contain deflate, or we don't need to use deflate on the data, do nothing.
-        if (encodings == null || !encodings.Contains("deflate") || context.ResponseStream.Length <= DeflateCutoff) 
+        // If the accepted encodings aren't specified, or they don't contain deflate/gzip, or we don't need to use deflate on the data, do nothing.
+        if (encodings == null || (!encodings.Contains("deflate") && !encodings.Contains("gzip")) || context.ResponseStream.Length <= DeflateCutoff) 
             return;
 
         // Update the headers marking that we are sending encoded data


### PR DESCRIPTION
As discussed on Discord. https://discord.com/channels/1049223665243389953/1049225857350254632/1400079015754334259

Pretty much, we haven't been properly compressing some requests for a while, because some requests ask for `gzip` when they are really asking for `deflate`. I'm 99% sure LBP just sends bullshit for the `Accept-Encoding` header half the time.

Lets see how this goes. This may or may not require a revert so I'll try and do some testing first. I'm unsure if this would be LLE/HLE in RPCS3 so it would be good to test on both RPCS3 and PS3. PSP and Vita would also be good to test but I don't have access to those platforms.

Potential solution for #700.