### PR TITLE
Fix submitting level scores from PSP

### DIFF
--- a/Refresh.Interfaces.Game/Endpoints/Levels/LeaderboardEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/LeaderboardEndpoints.cs
@@ -107,7 +107,7 @@ public class LeaderboardEndpoints : EndpointGroup
         if (level == null) return NotFound;
 
         // A user has to play a level in order to submit a score
-        if (!database.HasUserPlayedLevel(level, user))
+        if (!database.HasUserPlayedLevel(level, user) && !context.IsPSP())
         {
             return Unauthorized;
         }


### PR DESCRIPTION
LBP PSP submits level scores *before* sending /play requests, this caused the server to send a 401 response which prevented the game from connecting