### PR TITLE
Optimize some level responses

### DIFF
--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Xml.Serialization;
 using Refresh.Common.Constants;
 using Refresh.Core.Types.Data;
-using Refresh.Core.Types.Matching;
 using Refresh.Database.Models;
 using Refresh.Database.Models.Assets;
 using Refresh.Database.Models.Authentication;
@@ -87,15 +86,17 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     
     public static GameLevelResponse FromHash(string hash, DataContext dataContext)
     {
+        GameMinimalLevelResponse minimal = GameMinimalLevelResponse.FromHash(hash, dataContext);
+
         return new GameLevelResponse
         {
-            LevelId = dataContext.Game == TokenGame.LittleBigPlanet3 ? GameLevel.LevelIdFromHash(hash) : int.MaxValue,
+            LevelId = minimal.LevelId,
             IsAdventure = false,
-            Title = $"Hashed Level - {hash}",
+            Title = minimal.Title,
             IconHash = "0",
             GameVersion = 0,
             RootResource = hash,
-            Description = "This is a hashed level from the Dry Archive. We can't provide any information about it.",
+            Description = minimal.Description,
             Location = new GameLocation(),
             Handle = new SerializedUserHandle
             {

--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
@@ -1,58 +1,28 @@
 using System.Diagnostics;
 using System.Xml.Serialization;
-using Refresh.Common.Constants;
 using Refresh.Core.Types.Data;
-using Refresh.Database.Models;
 using Refresh.Database.Models.Assets;
 using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Levels;
 using Refresh.Database.Models.Playlists;
 using Refresh.Interfaces.Game.Types.Levels;
 using Refresh.Interfaces.Game.Types.Reviews;
-using Refresh.Interfaces.Game.Types.UserData;
 
 namespace Refresh.Interfaces.Game.Endpoints.DataTypes.Response;
 
 [XmlRoot("slot")]
 [XmlType("slot")]
-public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLevel>, IDataConvertableFrom<GameLevelResponse, GamePlaylist>
+public class GameLevelResponse : GameMinimalLevelResponse, IDataConvertableFrom<GameLevelResponse, GameLevel>, IDataConvertableFrom<GameLevelResponse, GamePlaylist>
 {
-    [XmlElement("id")] public required int LevelId { get; set; }
+    [XmlElement("firstPublished")] public long PublishDate { get; set; } // unix seconds
+    [XmlElement("lastUpdated")] public long UpdateDate { get; set; }
     
-    [XmlElement("isAdventurePlanet")] public required bool IsAdventure { get; set; }
-
-    [XmlElement("name")] public required string Title { get; set; }
-    [XmlElement("icon")] public required string IconHash { get; set; }
-    [XmlElement("description")] public required string Description { get; set; }
-    [XmlElement("location")] public required GameLocation Location { get; set; }
-
-    [XmlElement("game")] public required int GameVersion { get; set; }
-    [XmlElement("rootLevel")] public required string RootResource { get; set; }
-
-    [XmlElement("firstPublished")] public required long PublishDate { get; set; } // unix seconds
-    [XmlElement("lastUpdated")] public required long UpdateDate { get; set; }
+    [XmlElement("enforceMinMaxPlayers")] public bool EnforceMinMaxPlayers { get; set; }
     
-    [XmlElement("minPlayers")] public required int MinPlayers { get; set; }
-    [XmlElement("maxPlayers")] public required int MaxPlayers { get; set; }
-    [XmlElement("enforceMinMaxPlayers")] public required bool EnforceMinMaxPlayers { get; set; }
-    
-    [XmlElement("sameScreenGame")] public required bool SameScreenGame { get; set; }
+    [XmlElement("sameScreenGame")] public bool SameScreenGame { get; set; }
 
-    [XmlAttribute("type")] public string? Type { get; set; } = GameSlotType.User.ToGameType();
+    [XmlElement("completionCount")] public int CompletionCount { get; set; }
 
-    [XmlElement("npHandle")] public SerializedUserHandle Handle { get; set; } = null!;
-    
-    [XmlElement("heartCount")] public required int HeartCount { get; set; }
-    
-    [XmlElement("playCount")] public required int TotalPlayCount { get; set; }
-    [XmlElement("completionCount")] public required int CompletionCount { get; set; }
-    [XmlElement("uniquePlayCount")] public required int UniquePlayCount { get; set; }
-    [XmlElement("lbp3PlayCount")] public required int Lbp3PlayCount { get; set; }
-
-    [XmlElement("yourDPadRating")] public int YourRating { get; set; }
-    [XmlElement("thumbsup")] public required int YayCount { get; set; }
-    [XmlElement("thumbsdown")] public required int BooCount { get; set; }
-    [XmlElement("yourRating")] public int YourStarRating { get; set; }
 
     [XmlElement("yourlbp1PlayCount")] public int YourLbp1PlayCount { get; set; }
     [XmlElement("yourlbp2PlayCount")] public int YourLbp2PlayCount { get; set; }
@@ -61,103 +31,32 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
     [XmlArrayItem("customReward")]
     public List<GameSkillReward> SkillRewards { get; set; } = [];
 
-    [XmlElement("mmpick")] public required bool TeamPicked { get; set; }
     [XmlElement("resource")] public List<string> XmlResources { get; set; } = new();
-    [XmlElement("playerCount")] public int PlayerCount { get; set; }
-    
-    [XmlElement("leveltype")] public required string LevelType { get; set; }
-    
-    [XmlElement("initiallyLocked")] public bool IsLocked { get; set; }
-    [XmlElement("isSubLevel")] public bool IsSubLevel { get; set; }
-    [XmlElement("shareable")] public int IsCopyable { get; set; }
-    [XmlElement("moveRequired")] public bool RequiresMoveController { get; set; }
     [XmlElement("backgroundGUID")] public string? BackgroundGuid { get; set; }
     [XmlElement("links")] public string? Links { get; set; }
-    [XmlElement("averageRating")] public double AverageStarRating { get; set; }
     [XmlElement("sizeOfResources")] public int SizeOfResourcesInBytes { get; set; }
-    [XmlElement("reviewCount")] public int ReviewCount { get; set; }
-    [XmlElement("reviewsEnabled")] public bool ReviewsEnabled { get; set; } = true;
+
     [XmlElement("yourReview")] public SerializedGameReview? YourReview { get; set; }
-    [XmlElement("commentCount")] public int CommentCount { get; set; } = 0;
-    [XmlElement("commentsEnabled")] public bool CommentsEnabled { get; set; } = true;
     [XmlElement("photoCount")] public int PhotoCount { get; set; }
     [XmlElement("authorPhotoCount")] public int PublisherPhotoCount { get; set; }
-    [XmlElement("tags")] public string Tags { get; set; } = "";
-    
-    public static GameLevelResponse FromHash(string hash, DataContext dataContext)
+
+    private static GameLevelResponse FromMinimal(GameMinimalLevelResponse minimal)
     {
-        GameMinimalLevelResponse minimal = GameMinimalLevelResponse.FromHash(hash, dataContext);
-
-        return new GameLevelResponse
+        return new()
         {
-            LevelId = minimal.LevelId,
-            IsAdventure = false,
-            Title = minimal.Title,
-            IconHash = "0",
-            GameVersion = 0,
-            RootResource = hash,
-            Description = minimal.Description,
-            Location = new GameLocation(),
-            Handle = new SerializedUserHandle
-            {
-                Username = SystemUsers.HashedUserName,
-                IconHash = "0",
-            },
-            Type = GameSlotType.User.ToGameType(),
-            TeamPicked = false,
-            MinPlayers = 1,
-            MaxPlayers = 4,
-            HeartCount = 0,
-            TotalPlayCount = 0,
-            CompletionCount = 0,
-            UniquePlayCount = 0,
-            Lbp3PlayCount = 0,
-            YayCount = 0,
-            BooCount = 0,
-            AverageStarRating = 0,
-            YourStarRating = 0,
-            YourRating = 0,
-            PlayerCount = 0,
-            ReviewsEnabled = false,
-            ReviewCount = 0,
-            CommentsEnabled = false,
-            CommentCount = 0,
-            PhotoCount = 0,
-            PublisherPhotoCount = 0,
-            IsLocked = false,
-            IsSubLevel = false,
-            IsCopyable = 0,
-            RequiresMoveController = false,
-            PublishDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            UpdateDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            EnforceMinMaxPlayers = false,
-            SameScreenGame = false,
-            SkillRewards = [],
-            LevelType = "",
-        };
-    }
-
-    public static GameLevelResponse? FromOld(GameLevel? old, DataContext dataContext)
-    {
-        GameMinimalLevelResponse? minimal = GameMinimalLevelResponse.FromOld(old, dataContext);
-        if (old == null || minimal == null) return null;
-
-        Debug.Assert(old.Statistics != null);
-
-        GameLevelResponse response = new()
-        {
-            // Provided by GameMinimalLevelResponse
             LevelId = minimal.LevelId,
             IsAdventure = minimal.IsAdventure,
             Title = minimal.Title,
             IconHash = minimal.IconHash,
-            Description = minimal.Description,
-            Location = minimal.Location,
             GameVersion = minimal.GameVersion,
             RootResource = minimal.RootResource,
-            Handle = minimal.Handle!,
+            Description = minimal.Description,
+            Location = minimal.Location,
+            Handle = minimal.Handle,
             Type = minimal.Type,
-            LevelType = minimal.LevelType,
+            TeamPicked = minimal.TeamPicked,
+            MinPlayers = minimal.MinPlayers,
+            MaxPlayers = minimal.MaxPlayers,
             HeartCount = minimal.HeartCount,
             TotalPlayCount = minimal.TotalPlayCount,
             UniquePlayCount = minimal.UniquePlayCount,
@@ -165,31 +64,58 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
             YayCount = minimal.YayCount,
             BooCount = minimal.BooCount,
             AverageStarRating = minimal.AverageStarRating,
-            YourRating = minimal.YourRating,
             YourStarRating = minimal.YourStarRating,
-            ReviewCount = minimal.ReviewCount,
-            CommentCount = minimal.CommentCount,
+            YourRating = minimal.YourRating,
             PlayerCount = minimal.PlayerCount,
-            TeamPicked = minimal.TeamPicked,
-            IsCopyable = minimal.IsCopyable,
+            ReviewsEnabled = minimal.ReviewsEnabled,
+            ReviewCount = minimal.ReviewCount,
+            CommentsEnabled = minimal.CommentsEnabled,
+            CommentCount = minimal.CommentCount,
             IsLocked = minimal.IsLocked,
             IsSubLevel = minimal.IsSubLevel,
+            IsCopyable = minimal.IsCopyable,
             RequiresMoveController = minimal.RequiresMoveController,
-            Tags = minimal.Tags,
-
-            // Not provided by GameMinimalLevelResponse
-            CompletionCount = old.Statistics.CompletionCount,
-            PublishDate = old.PublishDate.ToUnixTimeMilliseconds(),
-            UpdateDate = old.UpdateDate.ToUnixTimeMilliseconds(),
-            MinPlayers = old.MinPlayers,
-            MaxPlayers = old.MaxPlayers,
-            EnforceMinMaxPlayers = old.EnforceMinMaxPlayers,
-            SameScreenGame = old.SameScreenGame,
-            BackgroundGuid = old.BackgroundGuid,
-            Links = "",
-            PhotoCount = old.Statistics.PhotoInLevelCount,
-            PublisherPhotoCount = old.Statistics.PhotoByPublisherCount,
+            LevelType = minimal.LevelType,
         };
+    }
+    
+    public static new GameLevelResponse FromHash(string hash, DataContext dataContext)
+    {
+        GameLevelResponse response = FromMinimal(GameMinimalLevelResponse.FromHash(hash, dataContext));
+
+        response.CompletionCount = 0;
+        response.PublishDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        response.UpdateDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        response.MinPlayers = 1;
+        response.MaxPlayers = 4;
+        response.EnforceMinMaxPlayers = false;
+        response.SameScreenGame = false;
+        response.Links = "";
+        response.PhotoCount = 0;
+        response.PublisherPhotoCount = 0;
+
+        return response;
+    }
+
+    public static new GameLevelResponse? FromOld(GameLevel? old, DataContext dataContext)
+    {
+        GameMinimalLevelResponse? minimal = GameMinimalLevelResponse.FromOld(old, dataContext);
+        if (minimal == null) return null;
+
+        GameLevelResponse response = FromMinimal(minimal);
+        Debug.Assert(old?.Statistics != null);
+
+        response.CompletionCount = old.Statistics.CompletionCount;
+        response.PublishDate = old.PublishDate.ToUnixTimeMilliseconds();
+        response.UpdateDate = old.UpdateDate.ToUnixTimeMilliseconds();
+        response.MinPlayers = old.MinPlayers;
+        response.MaxPlayers = old.MaxPlayers;
+        response.EnforceMinMaxPlayers = old.EnforceMinMaxPlayers;
+        response.SameScreenGame = old.SameScreenGame;
+        response.BackgroundGuid = old.BackgroundGuid;
+        response.Links = "";
+        response.PhotoCount = old.Statistics.PhotoInLevelCount;
+        response.PublisherPhotoCount = old.Statistics.PhotoByPublisherCount;
         
         if (dataContext.User != null)
         {
@@ -224,66 +150,29 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         return response;
     }
 
-    public static IEnumerable<GameLevelResponse> FromOldList(IEnumerable<GameLevel> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
+    public static new IEnumerable<GameLevelResponse> FromOldList(IEnumerable<GameLevel> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
     
-    public static GameLevelResponse? FromOld(GamePlaylist? old, DataContext dataContext)
+    public static new GameLevelResponse? FromOld(GamePlaylist? old, DataContext dataContext)
     {
-        if (old == null)
-            return null;
-        
-        return new GameLevelResponse
-        {
-            LevelId = old.PlaylistId,
-            IsAdventure = false,
-            Title = old.Name,
-            IconHash = old.IconHash,
-            Description = old.Description,
-            Location = new GameLocation(old.LocationX, old.LocationY),
-            // Playlists are only ever serialized like this in LBP1-like builds
-            GameVersion = TokenGame.LittleBigPlanet1.ToSerializedGame(),
-            Type = GameSlotType.Playlist.ToGameType(),
-            Handle = SerializedUserHandle.FromUser(old.Publisher, dataContext),
-            RootResource = "0",
-            PublishDate = old.CreationDate.ToUnixTimeMilliseconds(),
-            UpdateDate = old.LastUpdateDate.ToUnixTimeMilliseconds(),
-            MinPlayers = 0,
-            MaxPlayers = 0,
-            EnforceMinMaxPlayers = false,
-            SameScreenGame = false,
-            HeartCount = 0, 
-            TotalPlayCount = 0,
-            CompletionCount = 0,
-            UniquePlayCount = 0,
-            Lbp3PlayCount = 0,
-            YourRating = 0,
-            YayCount = 0, 
-            BooCount = 0,
-            YourStarRating = 0,
-            YourLbp1PlayCount = 0,
-            YourLbp2PlayCount = 0,
-            YourLbp3PlayCount = 0, 
-            SkillRewards = [],
-            TeamPicked = false, 
-            XmlResources = [],
-            PlayerCount = 0, 
-            LevelType = GameLevelType.Normal.ToGameString(),
-            IsLocked = false,
-            IsSubLevel = false,
-            IsCopyable = 0,
-            RequiresMoveController = false,
-            BackgroundGuid = null,
-            Links = null,
-            AverageStarRating = 0,
-            SizeOfResourcesInBytes = 0,
-            ReviewCount = 0,
-            ReviewsEnabled = true,
-            CommentCount = 0,
-            CommentsEnabled = true,
-            PhotoCount = 0,
-            PublisherPhotoCount = 0,
-            Tags = string.Empty,
-        };
+        GameMinimalLevelResponse? minimal = GameMinimalLevelResponse.FromOld(old, dataContext);
+        if (minimal == null) return null;
+
+        GameLevelResponse response = FromMinimal(minimal);
+        Debug.Assert(old?.Statistics != null);
+
+        response.CompletionCount = 0;
+        response.PublishDate = old.CreationDate.ToUnixTimeMilliseconds();
+        response.UpdateDate = old.LastUpdateDate.ToUnixTimeMilliseconds();
+        response.MinPlayers = 0;
+        response.MaxPlayers = 0;
+        response.EnforceMinMaxPlayers = false;
+        response.SameScreenGame = false;
+        response.Links = "";
+        response.PhotoCount = 0;
+        response.PublisherPhotoCount = 0;
+
+        return response;
     }
 
-    public static IEnumerable<GameLevelResponse> FromOldList(IEnumerable<GamePlaylist> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
+    public static new IEnumerable<GameLevelResponse> FromOldList(IEnumerable<GamePlaylist> oldList, DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 }

--- a/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Endpoints/DataTypes/Response/GameLevelResponse.cs
@@ -208,7 +208,7 @@ public class GameLevelResponse : IDataConvertableFrom<GameLevelResponse, GameLev
         if (dataContext.Game is TokenGame.LittleBigPlanetVita or TokenGame.BetaBuild)
         {
             GameAsset? rootResourceAsset = dataContext.Database.GetAssetFromHash(response.RootResource);
-            if (rootResourceAsset != null && dataContext.Game == TokenGame.LittleBigPlanetVita)
+            if (rootResourceAsset != null)
             {
                 rootResourceAsset.TraverseDependenciesRecursively(dataContext.Database, (_, asset) =>
                 {

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
@@ -10,7 +10,7 @@ using Refresh.Database;
 using Refresh.Database.Models.Levels;
 using Refresh.Database.Models.Playlists;
 using Refresh.Database.Models.Users;
-using Refresh.Interfaces.Game.Endpoints.DataTypes.Response;
+using Refresh.Interfaces.Game.Types.Levels;
 using Refresh.Interfaces.Game.Types.Lists;
 using Refresh.Interfaces.Game.Types.Playlists;
 
@@ -83,7 +83,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
     [GameEndpoint("playlists/{playlistId}/slots", HttpMethods.Get, ContentType.Xml)]
     [NullStatusCode(NotFound)]
     [MinimumRole(GameUserRole.Restricted)]
-    public SerializedLevelList? GetPlaylistLevels(RequestContext context, DataContext dataContext, GameUser user, int playlistId)
+    public SerializedMinimalLevelList? GetPlaylistLevels(RequestContext context, DataContext dataContext, GameUser user, int playlistId)
     {
         GamePlaylist? playlist = dataContext.Database.GetPlaylistById(playlistId);
         if (playlist == null)
@@ -91,9 +91,9 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
 
         DatabaseList<GameLevel> levels = dataContext.Database.GetLevelsInPlaylist(playlist, dataContext.Game, 0, 100);
 
-        return new SerializedLevelList
+        return new SerializedMinimalLevelList
         {
-            Items = GameLevelResponse.FromOldList(levels.Items.ToArray(), dataContext).ToList(),
+            Items = GameMinimalLevelResponse.FromOldList(levels.Items.ToArray(), dataContext).ToList(),
             Total = levels.TotalItems,
             NextPageStart = levels.NextPageIndex
         };

--- a/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
@@ -53,7 +53,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     [XmlElement("moveRequired")] public bool RequiresMoveController { get; set; }
     [XmlElement("tags")] public string Tags { get; set; } = "";
  
-    private GameMinimalLevelResponse() {}
+    protected GameMinimalLevelResponse() {}
     
     /// <summary>
     /// Constructs a placeholder level response from a root level hash

--- a/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
@@ -1,28 +1,30 @@
+using System.Diagnostics;
 using System.Xml.Serialization;
+using Refresh.Common.Constants;
 using Refresh.Core.Types.Data;
 using Refresh.Core.Types.Matching;
 using Refresh.Database.Models;
 using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Comments;
 using Refresh.Database.Models.Levels;
 using Refresh.Database.Models.Playlists;
-using Refresh.Interfaces.Game.Endpoints.DataTypes.Response;
 using Refresh.Interfaces.Game.Types.UserData;
 
 namespace Refresh.Interfaces.Game.Types.Levels;
 
-public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelResponse, GameLevel>, IDataConvertableFrom<GameMinimalLevelResponse, GamePlaylist>, IDataConvertableFrom<GameMinimalLevelResponse, GameLevelResponse>
+public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelResponse, GameLevel>, IDataConvertableFrom<GameMinimalLevelResponse, GamePlaylist>
 {
     //NOTE: THIS MUST BE AT THE TOP OF THE XML RESPONSE OR ELSE LBP PSP WILL CRASH
     [XmlElement("id")] public required int LevelId { get; set; }
     
     [XmlElement("isAdventurePlanet")] public required bool IsAdventure { get; set; }
     [XmlElement("name")] public required string Title { get; set; } = string.Empty;
-    [XmlElement("icon")] public required string IconHash { get; set; } = string.Empty;
+    [XmlElement("icon")] public string IconHash { get; set; } = string.Empty;
     [XmlElement("game")] public required int GameVersion { get; set; }
     [XmlElement("rootLevel")] public required string RootResource { get; set; } = string.Empty;
     [XmlElement("description")] public required string Description { get; set; } = string.Empty;
     [XmlElement("location")] public required GameLocation Location { get; set; } = GameLocation.Zero;
-    [XmlElement("npHandle")] public required SerializedUserHandle? Handle { get; set; }
+    [XmlElement("npHandle")] public SerializedUserHandle? Handle { get; set; } = null!;
     [XmlAttribute("type")] public required string? Type { get; set; }
     [XmlElement("leveltype")] public required string LevelType { get; set; }
     [XmlElement("mmpick")] public required bool TeamPicked { get; set; }
@@ -61,53 +63,132 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
     /// <returns></returns>
     public static GameMinimalLevelResponse FromHash(string hash, DataContext dataContext)
     {
-        return FromOld(GameLevelResponse.FromHash(hash, dataContext), dataContext)!;
-    }
-
-    public static GameMinimalLevelResponse? FromOld(GameLevel? level, DataContext dataContext)
-    {
-        if(level == null) return null;
-        return FromOld(GameLevelResponse.FromOld(level, dataContext), dataContext);
-    }
-
-
-    public static GameMinimalLevelResponse? FromOld(GameLevelResponse? level, DataContext dataContext)
-    {
-        if(level == null) return null;
-
         return new GameMinimalLevelResponse
         {
-            Title = level.Title,
-            IsAdventure = level.IsAdventure,
-            IconHash = dataContext.Database.GetAssetFromHash(level.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? level.IconHash,
-            GameVersion = level.GameVersion,
-            RootResource = level.RootResource,
-            Description = level.Description,
-            Location = level.Location,
-            LevelId = level.LevelId,
-            Handle = level.Handle,
-            Type = level.Type,
-            LevelType = level.LevelType,
-            TeamPicked = level.TeamPicked,
-            YayCount = level.YayCount,
-            BooCount = level.BooCount,
-            HeartCount = level.HeartCount,
-            MaxPlayers = level.MaxPlayers,
-            MinPlayers = level.MinPlayers,
-            TotalPlayCount = level.TotalPlayCount,
-            UniquePlayCount = level.UniquePlayCount,
-            Lbp3PlayCount = level.Lbp3PlayCount,
-            YourStarRating = level.YourStarRating,
-            YourRating = level.YourRating,
-            AverageStarRating = level.AverageStarRating,
-            CommentCount = level.CommentCount,
-            IsLocked = level.IsLocked,
-            IsSubLevel = level.IsSubLevel,
-            IsCopyable = level.IsCopyable,
-            RequiresMoveController = level.RequiresMoveController,
-            PlayerCount = dataContext.Match.GetPlayerCountForLevel(RoomSlotType.Online, level.LevelId),
-            Tags = level.Tags,
+            LevelId = dataContext.Game == TokenGame.LittleBigPlanet3 ? GameLevel.LevelIdFromHash(hash) : int.MaxValue,
+            IsAdventure = false,
+            Title = $"Hashed Level - {hash}",
+            IconHash = "0",
+            GameVersion = 0,
+            RootResource = hash,
+            Description = "This is a hashed level from the Dry Archive. We can't provide any information about it.",
+            Location = new GameLocation(),
+            Handle = new SerializedUserHandle
+            {
+                Username = SystemUsers.HashedUserName,
+                IconHash = "0",
+            },
+            Type = GameSlotType.User.ToGameType(),
+            TeamPicked = false,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            HeartCount = 0,
+            TotalPlayCount = 0,
+            UniquePlayCount = 0,
+            Lbp3PlayCount = 0,
+            YayCount = 0,
+            BooCount = 0,
+            AverageStarRating = 0,
+            YourStarRating = 0,
+            YourRating = 0,
+            PlayerCount = 0,
+            ReviewsEnabled = false,
+            ReviewCount = 0,
+            CommentsEnabled = false,
+            CommentCount = 0,
+            IsLocked = false,
+            IsSubLevel = false,
+            IsCopyable = 0,
+            RequiresMoveController = false,
+            LevelType = "",
         };
+    }
+
+    public static GameMinimalLevelResponse? FromOld(GameLevel? old, DataContext dataContext)
+    {
+        if(old == null) return null;
+
+        if(old.Statistics == null)
+            dataContext.Database.RecalculateLevelStatistics(old);
+        
+        Debug.Assert(old.Statistics != null);
+
+        bool isStoryLevel = old.StoryId != 0;
+
+        GameMinimalLevelResponse response = new()
+        {
+            LevelId = isStoryLevel ? old.StoryId : old.LevelId,
+            IsAdventure = old.IsAdventure,
+            Title = old.Title,
+            Description = old.Description,
+            Location = new GameLocation(old.LocationX, old.LocationY),
+            GameVersion = old.GameVersion.ToSerializedGame(),
+            RootResource = old.RootResource,
+            MinPlayers = old.MinPlayers,
+            MaxPlayers = old.MaxPlayers,
+            HeartCount = old.Statistics.FavouriteCount,
+            TotalPlayCount = old.Statistics.PlayCount,
+            UniquePlayCount = old.Statistics.UniquePlayCount,
+            Lbp3PlayCount = old.Statistics.UniquePlayCount,
+            YayCount = old.Statistics.YayCount,
+            BooCount = old.Statistics.BooCount,
+            TeamPicked = old.TeamPicked,
+            LevelType = old.LevelType.ToGameString(),
+            IsCopyable = old.IsCopyable ? 1 : 0,
+            IsLocked = old.IsLocked,
+            IsSubLevel = old.IsSubLevel,
+            RequiresMoveController = old.RequiresMoveController,
+            AverageStarRating = old.CalculateAverageStarRating(),
+            ReviewCount = old.Statistics.ReviewCount,
+            CommentCount = old.Statistics.CommentCount,
+            Type = old.SlotType.ToGameType(),
+        };
+        
+        // If we're not a reupload, show the real publisher
+        // If we're the real publisher of a reupload, show the real publisher to give them editing capabilities
+        if ((old.Publisher != null && !old.IsReUpload) || (dataContext.User != null && old.Publisher == dataContext.User && old.IsReUpload))
+        {
+            response.Handle = SerializedUserHandle.FromUser(old.Publisher, dataContext);
+        }
+        // Otherwise, show our special reupload username
+        else
+        {
+            string publisher;
+            if (!old.IsReUpload)
+                publisher = SystemUsers.DeletedUserName;
+            else
+                publisher = string.IsNullOrEmpty(old.OriginalPublisher)
+                    ? SystemUsers.UnknownUserName
+                    : SystemUsers.SystemPrefix + old.OriginalPublisher;
+
+            if (publisher.Length > 16) // Trim publisher name to fit in the maximum limit LBP will show
+                publisher = string.Concat(publisher.AsSpan(0, 15), "-");
+            
+            
+            response.Handle = new SerializedUserHandle
+            {
+                IconHash = "0",
+                Username = publisher,
+            };
+        }
+        
+        if (dataContext.User != null)
+        {
+            RatingType? rating = dataContext.Database.GetRatingByUser(old, dataContext.User);
+
+            response.YourRating = rating?.ToDPad() ?? (int)RatingType.Neutral;
+            response.YourStarRating = rating?.ToLBP1() ?? 0;
+        }
+        
+        response.PlayerCount = dataContext.Match.GetPlayerCountForLevel(RoomSlotType.Online, response.LevelId);
+
+        if (dataContext.Game == TokenGame.LittleBigPlanet1)
+        {
+            response.Tags = string.Join(',', dataContext.Database.GetTagsForLevel(old).Select(t => t.Tag.ToLbpString()));
+        }
+        
+        response.IconHash = dataContext.Database.GetAssetFromHash(old.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? response.IconHash;
+        return response;
     }
     
     public static GameMinimalLevelResponse? FromOld(GamePlaylist? old, DataContext dataContext)
@@ -156,8 +237,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
 
     public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GameLevel> oldList,
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
-    public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GameLevelResponse> oldList,
-        DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
+
     public static IEnumerable<GameMinimalLevelResponse> FromOldList(IEnumerable<GamePlaylist> oldList, 
         DataContext dataContext) => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
 

--- a/RefreshTests.GameServer/Tests/Levels/PublishEndpointsTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/PublishEndpointsTests.cs
@@ -651,7 +651,7 @@ public class PublishEndpointsTests : GameServerTest
         using TestContext context = this.GetServer();
         GameUser user = context.CreateUser();
 
-        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanetVita, TokenPlatform.Vita, user);
 
         GameLevelRequest level = new()
         {


### PR DESCRIPTION
This makes `GameLevelResponse.FromOld()` depend on `GameMinimalLevelResponse.FromOld()` instead of the other way, to avoid making database calls for information like the user's own review which will not be used for `GameMinimalLevelResponse` anyway, while having as little duplicate code in both methods as possible. Also a few database calls in these methods will only be done if the user is in a game which supports the attributes these calls are for (for example, the user's review won't be gotten if they are in LBP1 or PSP, and the level's skill rewards won't be gotten if the user is not in LBP Vita or a beta build). Also makes LBP3 playlist endpoints return `SerializedMinimalLevelList` instead of `SerializedLevelList`.