### PR TITLE
Fix GameLevelResponse icon setting

### DIFF
--- a/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
@@ -187,7 +187,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
             response.Tags = string.Join(',', dataContext.Database.GetTagsForLevel(old).Select(t => t.Tag.ToLbpString()));
         }
         
-        response.IconHash = dataContext.Database.GetAssetFromHash(old.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? response.IconHash;
+        response.IconHash = dataContext.Database.GetAssetFromHash(old.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? old.IconHash;
         return response;
     }
     


### PR DESCRIPTION
Fixes a typo/regression I made where the `GameMinimalLevelResponse` and `GameLevelResponse` icon hashes would be left blank in some cases.