### PR TITLE
Expose VitaIconHash and BetaIconHash to the API

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -184,6 +184,12 @@ public partial class GameDatabaseContext // Users
 
             if (data.IconHash != null)
                 user.IconHash = data.IconHash;
+            
+            if (data.VitaIconHash != null)
+                user.VitaIconHash = data.VitaIconHash;
+            
+            if (data.BetaIconHash != null)
+                user.BetaIconHash = data.BetaIconHash;
 
             if (data.Description != null)
                 user.Description = data.Description;

--- a/Refresh.Database/Query/IApiEditUserRequest.cs
+++ b/Refresh.Database/Query/IApiEditUserRequest.cs
@@ -5,6 +5,8 @@ namespace Refresh.Database.Query;
 public interface IApiEditUserRequest
 {
     string? IconHash { get; set; }
+    string? VitaIconHash { get; set; }
+    string? BetaIconHash { get; set; }
     string? Description { get; set; }
     bool? AllowIpAuthentication { get; set; }
     bool? PsnAuthenticationAllowed { get; set; }

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Request/ApiUpdateUserRequest.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Request/ApiUpdateUserRequest.cs
@@ -7,6 +7,8 @@ namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
 public class ApiUpdateUserRequest : IApiEditUserRequest
 {
     public string? IconHash { get; set; }
+    public string? VitaIconHash { get; set; }
+    public string? BetaIconHash { get; set; }
     public string? Description { get; set; }
     public bool? AllowIpAuthentication { get; set; }
     

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
@@ -16,6 +16,8 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
     public required string UserId { get; set; }
     public required string Username { get; set; }
     public required string IconHash { get; set; }
+    public required string VitaIconHash { get; set; }
+    public required string BetaIconHash { get; set; }
     public required string Description { get; set; }
     public required ApiGameLocationResponse Location { get; set; }
     public required DateTimeOffset JoinDate { get; set; }
@@ -57,7 +59,9 @@ public class ApiExtendedGameUserResponse : IApiResponse, IDataConvertableFrom<Ap
         {
             UserId = user.UserId.ToString()!,
             Username = user.Username,
-            IconHash = dataContext.Database.GetAssetFromHash(user.IconHash)?.GetAsIcon(TokenGame.Website, dataContext) ?? user.IconHash,
+            IconHash = dataContext.GetIconFromHash(user.IconHash),
+            VitaIconHash = dataContext.GetIconFromHash(user.VitaIconHash),
+            BetaIconHash = dataContext.GetIconFromHash(user.BetaIconHash),
             Description = user.Description,
             Location = ApiGameLocationResponse.FromLocation(user.LocationX, user.LocationY)!,
             JoinDate = user.JoinDate,

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiGameUserResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiGameUserResponse.cs
@@ -15,6 +15,8 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
     public required string UserId { get; set; }
     public required string Username { get; set; }
     public required string IconHash { get; set; }
+    public required string VitaIconHash { get; set; }
+    public required string BetaIconHash { get; set; }
 
     public required string YayFaceHash { get; set; }
     public required string BooFaceHash { get; set; }
@@ -39,6 +41,8 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
             Username = user.Username,
 
             IconHash = dataContext.GetIconFromHash(user.IconHash),
+            VitaIconHash = dataContext.GetIconFromHash(user.VitaIconHash),
+            BetaIconHash = dataContext.GetIconFromHash(user.BetaIconHash),
             YayFaceHash = dataContext.GetIconFromHash(user.YayFaceHash),
             BooFaceHash = dataContext.GetIconFromHash(user.BooFaceHash),
             MehFaceHash = dataContext.GetIconFromHash(user.MehFaceHash),

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiMinimalUserResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiMinimalUserResponse.cs
@@ -9,7 +9,8 @@ public class ApiMinimalUserResponse : IApiResponse, IDataConvertableFrom<ApiMini
     public required string UserId { get; set; }
     public required string Username { get; set; }
     public required string IconHash { get; set; }
-
+    public required string VitaIconHash { get; set; }
+    public required string BetaIconHash { get; set; }
     
     public static ApiMinimalUserResponse? FromOld(GameUser? old, DataContext dataContext)
     {
@@ -19,7 +20,9 @@ public class ApiMinimalUserResponse : IApiResponse, IDataConvertableFrom<ApiMini
         {
             UserId = old.UserId.ToString(),
             Username = old.Username,
-            IconHash = old.IconHash,
+            IconHash = dataContext.GetIconFromHash(old.IconHash),
+            VitaIconHash = dataContext.GetIconFromHash(old.VitaIconHash),
+            BetaIconHash = dataContext.GetIconFromHash(old.BetaIconHash),
         };
     }
 

--- a/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
@@ -59,6 +59,12 @@ public class UserApiEndpoints : EndpointGroup
     {
         if (body.IconHash != null && database.GetAssetFromHash(body.IconHash) == null)
             return ApiNotFoundError.Instance;
+        
+        if (body.VitaIconHash != null && database.GetAssetFromHash(body.VitaIconHash) == null)
+            return ApiNotFoundError.Instance;
+        
+        if (body.BetaIconHash != null && database.GetAssetFromHash(body.BetaIconHash) == null)
+            return ApiNotFoundError.Instance;
 
         if (body.EmailAddress != null && !smtpService.CheckEmailDomainValidity(body.EmailAddress))
             return ApiValidationError.EmailDoesNotActuallyExistError;


### PR DESCRIPTION
Also allows users to edit their own Vita and Beta profile pictures through the API, and makes more use of `DataContext.GetIconFromHash` for user responses.