### PR TITLE
Don't try to block commands while uploading a level

### DIFF
--- a/Refresh.Core/Services/CommandService.cs
+++ b/Refresh.Core/Services/CommandService.cs
@@ -21,30 +21,6 @@ public class CommandService : EndpointService
         this._levelListService = levelListService;
     }
 
-    private readonly HashSet<ObjectId> _usersPublishing = [];
-
-    /// <summary>
-    /// Start tracking the user, eg. they started publishing
-    /// </summary>
-    /// <param name="id">The user ID</param>
-    public void StartPublishing(ObjectId id)
-    {
-        //Unconditionally add the user to the set
-        this._usersPublishing.Add(id);
-    }
-
-    /// <summary>
-    /// Stop tracking the user, eg. they stopped publishing
-    /// </summary>
-    /// <param name="id">The user ID</param>
-    public void StopPublishing(ObjectId id)
-    {
-        //Unconditionally remove the user from the set
-        this._usersPublishing.Remove(id);
-    }
-
-    public bool IsPublishing(ObjectId id) => this._usersPublishing.Contains(id);
-
     /// <summary>
     /// Parse a command string into a command object
     /// </summary>

--- a/Refresh.Interfaces.Game/Endpoints/ModerationEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/ModerationEndpoints.cs
@@ -59,31 +59,24 @@ public class ModerationEndpoints : EndpointGroup
             body = body.Replace("&amp;", "&");
         }
 
-        if (commandService.IsPublishing(user.UserId))
-        {
-            context.Logger.LogInfo(BunkumCategory.UserLevels, $"Publish filter: '{body}'");
-        }
-        else
-        {
-            context.Logger.LogInfo(BunkumCategory.Filter, $"<{user}>: {body}");
+        context.Logger.LogInfo(BunkumCategory.Filter, $"<{user}>: {body}");
 
-            //If the text starts with a `/`, its a command, also only allow verified users to use commands
-            if (body.StartsWith('/') && user.EmailAddressVerified)
+        //If the text starts with a `/`, its a command, also only allow verified users to use commands
+        if (body.StartsWith('/') && user.EmailAddressVerified)
+        {
+            try
             {
-                try
-                {
-                    CommandInvocation command = commandService.ParseCommand(body);
+                CommandInvocation command = commandService.ParseCommand(body);
 
-                    context.Logger.LogInfo(BunkumCategory.Commands, $"User used command '{command.Name.ToString()}' with args '{command.Arguments.ToString()}'");
+                context.Logger.LogInfo(BunkumCategory.Commands, $"User used command '{command.Name.ToString()}' with args '{command.Arguments.ToString()}'");
 
-                    commandService.HandleCommand(command, database, user, token);
-                    return "(Command)";
-                }
-                catch(Exception ex)
-                {
-                    context.Logger.LogWarning(BunkumCategory.Commands, $"Error running command {body}. ex {ex}");
-                    //do nothing
-                }
+                commandService.HandleCommand(command, database, user, token);
+                return "(Command)";
+            }
+            catch(Exception ex)
+            {
+                context.Logger.LogWarning(BunkumCategory.Commands, $"Error running command {body}. ex {ex}");
+                //do nothing
             }
         }
         


### PR DESCRIPTION
This gets rid of the mechanism which uses `CommandService` to block commands while publishing a level.
 
We can't catch all cases of `/filter` requests which are not chat messages (e.g. LBP3 sends the level strings to filter before its `/startPublish` request, and LBP2 can also send level strings during create mode).
More importantly, if the game successfully does a `/startPublish` request, but its `/publish` request fails in any way or the user tries to update a level instead of publishing a new one, their commands would continue to silently get blocked, which has already caused confusion (see #937).

The latter issue could be fixed and worked around by making some changes to the `/publish` endpoint method and the `CommandService`, but since we also can't tell whether a `/filter` request does actually contain a chat message or something else half the time, making the mechanism not very effective to begin with, I think it makes more sense to just get rid of it entirely.

Closes #937.