### PR TITLE
Optimize query for getting tags for a level

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -748,19 +748,16 @@ public partial class GameDatabaseContext // Relations
         });
     }
 
-    public IEnumerable<TagLevelRelation> GetTagsForLevel(GameLevel level)
-    {
-        IQueryable<TagLevelRelation> levelTags = this.TagLevelRelationsIncluded.Where(t => t.Level == level);
- 
-        IEnumerable<TagLevelRelation> tags = levelTags
-            .AsEnumerableIfRealm() // TODO: optimize for postgres when realm is deleted
-            .GroupBy(t => t.Tag).Select(g => g.First())
-            // ^ is equivalent to .DistinctBy(t => t._Tag)
-            .AsEnumerable()
-            .OrderByDescending(t => levelTags.Count(levelTag => levelTag.Tag == t.Tag));
+    public IQueryable<Tag> GetTagsForLevel(GameLevel level)
+        => this.TagLevelRelations.Where(t => t.LevelId == level.LevelId)
+            .GroupBy(t => t.Tag)
+            .Select(g => new { Tag = g.Key, Count = g.Count() })
+            .OrderByDescending(t => t.Count)
+            .Select(g => g.Tag);
 
-        return tags;
-    }
+    public IQueryable<TagLevelRelation> GetTagRelationsForLevel(GameLevel level)
+        => this.TagLevelRelationsIncluded.Where(t => t.LevelId == level.LevelId)
+            .OrderByDescending(t => t.Timestamp);
     
     #endregion
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelResponse.cs
@@ -100,7 +100,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
             PhotosTaken = level.Statistics.PhotoInLevelCount,
             LevelComments = level.Statistics.CommentCount,
             Reviews = level.Statistics.ReviewCount,
-            Tags = dataContext.Database.GetTagsForLevel(level).Select(t => t.Tag),
+            Tags = dataContext.Database.GetTagsForLevel(level),
             IsModded = level.IsModded,
         };
     }

--- a/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
@@ -184,7 +184,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
 
         if (dataContext.Game == TokenGame.LittleBigPlanet1)
         {
-            response.Tags = string.Join(',', dataContext.Database.GetTagsForLevel(old).Select(t => t.Tag.ToLbpString()));
+            response.Tags = string.Join(',', dataContext.Database.GetTagsForLevel(old).Select(t => t.ToLbpString()));
         }
         
         response.IconHash = dataContext.Database.GetAssetFromHash(old.IconHash)?.GetAsIcon(dataContext.Game, dataContext) ?? old.IconHash;


### PR DESCRIPTION
Optimizes the query used to get the tags for a level. After adding a few tag relations to a few levels on my server and then doing similar testing as in #842, I've got the following results:

With the new query:
```
[09/05/25 11:12:42] [Info] [Request] Served request to 127.0.0.1:36562: 200 OK on GET '/api/v3/levels/newest?count=100' (260ms)
[09/05/25 11:12:42] [Info] [Request] Served request to 127.0.0.1:36584: 200 OK on GET '/api/v3/levels/newest?count=100' (262ms)
[09/05/25 11:12:43] [Info] [Request] Served request to 127.0.0.1:36608: 200 OK on GET '/api/v3/levels/newest?count=100' (250ms)
[09/05/25 11:12:43] [Info] [Request] Served request to 127.0.0.1:36626: 200 OK on GET '/api/v3/levels/newest?count=100' (260ms)
[09/05/25 11:12:44] [Info] [Request] Served request to 127.0.0.1:36650: 200 OK on GET '/api/v3/levels/newest?count=100' (255ms)
```
With the old query:
```
[09/05/25 11:13:00] [Info] [Request] Served request to 127.0.0.1:34600: 200 OK on GET '/api/v3/levels/newest?count=100' (504ms)
[09/05/25 11:13:01] [Info] [Request] Served request to 127.0.0.1:34608: 200 OK on GET '/api/v3/levels/newest?count=100' (500ms)
[09/05/25 11:13:01] [Info] [Request] Served request to 127.0.0.1:34626: 200 OK on GET '/api/v3/levels/newest?count=100' (491ms)
[09/05/25 11:13:02] [Info] [Request] Served request to 127.0.0.1:34652: 200 OK on GET '/api/v3/levels/newest?count=100' (505ms)
[09/05/25 11:13:03] [Info] [Request] Served request to 127.0.0.1:34664: 200 OK on GET '/api/v3/levels/newest?count=100' (507ms)
```