### PR TITLE
Implement LBP1 Beta endpoints

### DIFF
--- a/Refresh.Common/Extensions/RequestContextExtensions.cs
+++ b/Refresh.Common/Extensions/RequestContextExtensions.cs
@@ -10,11 +10,15 @@ public static class RequestContextExtensions
     public static (int, int) GetPageData(this RequestContext context, int maxCount = 100)
     {
         bool api = context.IsApi();
-        
-        bool parsed = int.TryParse(context.QueryString[api ? "skip" : "pageStart"], out int skip);
+        return context.GetPageData(context.QueryString[api ? "skip" : "pageStart"], context.QueryString[api ? "count" : "pageSize"], maxCount);
+    }
+
+    public static (int, int) GetPageData(this RequestContext context, string? skipStr, string? countStr, int maxCount = 100)
+    {
+        bool parsed = int.TryParse(skipStr, out int skip);
         if (parsed) skip--; // If we parsed, subtract the number of items to skip by one to prevent an off-by-one.
         
-        parsed = int.TryParse(context.QueryString[api ? "count" : "pageSize"], out int count);
+        parsed = int.TryParse(countStr, out int count);
         if (!parsed) count = 20; // Default items in a page
         
         count = Math.Clamp(count, 0, maxCount);

--- a/Refresh.Core/Types/Categories/Levels/CoolLevelsCategory.cs
+++ b/Refresh.Core/Types/Categories/Levels/CoolLevelsCategory.cs
@@ -9,7 +9,7 @@ namespace Refresh.Core.Types.Categories.Levels;
 
 public class CoolLevelsCategory : GameLevelCategory
 {
-    public CoolLevelsCategory() : base("coolLevels", ["lbpcool", "lbp2cool", "cool"], false)
+    public CoolLevelsCategory() : base("coolLevels", ["lbpcool", "lbp2cool", "cool", "hot"], false)
     {
         this.Name = "Cool Levels";
         this.Description = "Levels trending with players like you!";

--- a/Refresh.Database/Extensions/LevelEnumerableExtensions.cs
+++ b/Refresh.Database/Extensions/LevelEnumerableExtensions.cs
@@ -28,7 +28,10 @@ public static class LevelEnumerableExtensions
             TokenGame.LittleBigPlanet3 => levels.Where(l => l.GameVersion <= TokenGame.LittleBigPlanet3),
             TokenGame.LittleBigPlanetVita => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanetVita),
             TokenGame.LittleBigPlanetPSP => levels.Where(l => l.GameVersion == TokenGame.LittleBigPlanetPSP),
-            TokenGame.BetaBuild => levels.Where(l => l.GameVersion == TokenGame.BetaBuild),
+            // Allow story levels from lbp1-3 to appear in beta builds. Usually developer levels with invalid IDs already
+            // get filtered out by the game. Ignore potential edge cases where the game doesn't filter them, since we only
+            // include them for beta builds anyway.
+            TokenGame.BetaBuild => levels.Where(l => l.GameVersion == TokenGame.BetaBuild || l.StoryId != 0),
             TokenGame.Website => levels,
             _ => throw new ArgumentOutOfRangeException(nameof(gameVersion), gameVersion, null),
         };

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -408,23 +408,15 @@ public partial class GameDatabaseContext // Levels
     
     [Pure]
     public DatabaseList<GameLevel> GetLevelsByTag(int count, int skip, GameUser? user, Tag tag, LevelFilterSettings levelFilterSettings)
-    {
-        IQueryable<TagLevelRelation> tagRelations = this.TagLevelRelations;
-        
-        IEnumerable<GameLevel> filteredTaggedLevels = tagRelations
+        => new(this.TagLevelRelations
             .Include(x => x.Level.Publisher)
             .Include(x => x.Level.Statistics)
             .Where(x => x.Tag == tag)
-            .AsEnumerableIfRealm()
+            .OrderByDescending(r => r.Timestamp)
             .Select(x => x.Level)
             .Distinct()
-            .Where(l => l.StoryId == 0)
-            .OrderByDescending(l => l.PublishDate)
             .FilterByLevelFilterSettings(user, levelFilterSettings)
-            .FilterByGameVersion(levelFilterSettings.GameVersion);
-
-        return new DatabaseList<GameLevel>(filteredTaggedLevels, skip, count);
-    }
+            .FilterByGameVersion(levelFilterSettings.GameVersion), skip, count);
     
     [Pure]
     public DatabaseList<GameLevel> GetMostUniquelyPlayedLevels(int count, int skip, GameUser? user, LevelFilterSettings levelFilterSettings)

--- a/Refresh.Database/Models/Levels/Tag.cs
+++ b/Refresh.Database/Models/Levels/Tag.cs
@@ -81,7 +81,7 @@ public enum Tag : byte
     Beautiful = 74,
     Electric = 75,
     Frosty,
-    Ass,
+    Insane,
 }
 
 public static class TagExtensions
@@ -188,7 +188,7 @@ public static class TagExtensions
         // Custom tags for LBP1 beta builds, as those don't have any hardcoded tags and instead
         // use the /tags endpoint and slot responses to discover and show tags (including arbitrary ones)
         { "Frosty", Tag.Frosty },
-        { "ASS", Tag.Ass },
+        { "INSANE", Tag.Insane },
     }.ToFrozenDictionary();
 
     public static string? ToLbpString(this Tag tag) => StringMap.GetValueOrDefault(tag);

--- a/Refresh.Database/Models/Levels/Tag.cs
+++ b/Refresh.Database/Models/Levels/Tag.cs
@@ -80,7 +80,8 @@ public enum Tag : byte
     Ingenious = 73,
     Beautiful = 74,
     Electric = 75,
-    Freezatron,
+    Frosty,
+    Ass,
 }
 
 public static class TagExtensions
@@ -186,7 +187,8 @@ public static class TagExtensions
 
         // Custom tags for LBP1 beta builds, as those don't have any hardcoded tags and instead
         // use the /tags endpoint and slot responses to discover and show tags (including arbitrary ones)
-        { "Freezatron", Tag.Freezatron },
+        { "Frosty", Tag.Frosty },
+        { "ASS", Tag.Ass },
     }.ToFrozenDictionary();
 
     public static string? ToLbpString(this Tag tag) => StringMap.GetValueOrDefault(tag);

--- a/Refresh.Database/Models/Levels/Tag.cs
+++ b/Refresh.Database/Models/Levels/Tag.cs
@@ -80,6 +80,7 @@ public enum Tag : byte
     Ingenious = 73,
     Beautiful = 74,
     Electric = 75,
+    Freezatron,
 }
 
 public static class TagExtensions
@@ -182,6 +183,10 @@ public static class TagExtensions
         { "TAG_Ingenious", Tag.Ingenious },
         { "TAG_Beautiful", Tag.Beautiful },
         { "TAG_Electric", Tag.Electric },
+
+        // Custom tags for LBP1 beta builds, as those don't have any hardcoded tags and instead
+        // use the /tags endpoint and slot responses to discover and show tags (including arbitrary ones)
+        { "Freezatron", Tag.Freezatron },
     }.ToFrozenDictionary();
 
     public static string? ToLbpString(this Tag tag) => StringMap.GetValueOrDefault(tag);

--- a/Refresh.Interfaces.Game/Endpoints/Handshake/MetadataEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Handshake/MetadataEndpoints.cs
@@ -1,5 +1,6 @@
 using Bunkum.Core;
 using Bunkum.Core.Endpoints;
+using Bunkum.Core.Endpoints.Debugging;
 using Bunkum.Core.Responses;
 using Bunkum.Listener.Protocol;
 using Bunkum.Protocols.Http;
@@ -103,6 +104,7 @@ public class MetadataEndpoints : EndpointGroup
         });
 
     [GameEndpoint("t_conf")]
+    [GameEndpoint("telemetry.cfg")]
     [MinimumRole(GameUserRole.Restricted)]
     [NullStatusCode(Gone)]
     public string? TelemetryConfig(RequestContext context) 
@@ -209,6 +211,16 @@ public class MetadataEndpoints : EndpointGroup
     }
 
     [GameEndpoint("tags")]
+    [GameEndpoint("tags/popular")]
     [MinimumRole(GameUserRole.Restricted)]
     public string Tags(RequestContext context) => TagExtensions.AllTags;
+
+    // Stub this for now. Nothing will happen if this is unimplemented, and we likely won't use any data sent here for now.
+    [GameEndpoint("rankData", ContentType.Plaintext, HttpMethods.Post)]
+    [RequireEmailVerified]
+    [DebugRequestBody]
+    public Response SubmitRankData(RequestContext context, GameUser user, string body)
+    {
+        return NotImplemented;
+    }
 }

--- a/Refresh.Interfaces.Game/Endpoints/ReportingEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/ReportingEndpoints.cs
@@ -20,6 +20,7 @@ namespace Refresh.Interfaces.Game.Endpoints;
 
 public class ReportingEndpoints : EndpointGroup 
 {
+    // TODO: LBP1 beta builds upload all related assets after sending the report itself to this endpoint, handle that case
     [GameEndpoint("grief", HttpMethods.Post, ContentType.Xml)]
     [RequireEmailVerified]
     public Response UploadReport(RequestContext context, GameDatabaseContext database, GameReport body, GameUser user,
@@ -35,6 +36,7 @@ public class ReportingEndpoints : EndpointGroup
             case TokenGame.LittleBigPlanet1:
             case TokenGame.LittleBigPlanet2:
             case TokenGame.LittleBigPlanet3:
+            case TokenGame.BetaBuild:
                 imageSize = new Size(640, 360);
                 break;
             case TokenGame.LittleBigPlanetVita:

--- a/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
+++ b/Refresh.Interfaces.Game/Types/Levels/GameMinimalLevelResponse.cs
@@ -184,7 +184,7 @@ public class GameMinimalLevelResponse : IDataConvertableFrom<GameMinimalLevelRes
         
         response.PlayerCount = dataContext.Match.GetPlayerCountForLevel(RoomSlotType.Online, response.LevelId);
 
-        if (dataContext.Game == TokenGame.LittleBigPlanet1)
+        if (dataContext.Game is TokenGame.LittleBigPlanet1 or TokenGame.BetaBuild)
         {
             response.Tags = string.Join(',', dataContext.Database.GetTagsForLevel(old).Select(t => t.ToLbpString()));
         }


### PR DESCRIPTION
Implements endpoints and endpoint routes unique to the recently released LBP1 beta build and gives slightly more freedom to beta builds in general (include level tags, accept grief reports and don't filter out story levels from technically different games for beta builds). Also includes some custom tags for the LBP1 beta.