### PR TITLE
Include own level relations in level responses

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -650,6 +650,9 @@ public partial class GameDatabaseContext // Relations
 
     public int GetTotalCompletionsForLevel(GameLevel level) =>
         this.GameScores.Count(s => s.Level == level);
+    
+    public int GetTotalCompletionsForLevelByUser(GameLevel level, GameUser user) =>
+        this.GameScores.Count(s => s.LevelId == level.LevelId && s.PublisherId == user.UserId);
 
     #endregion
 

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelOwnRelationsResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelOwnRelationsResponse.cs
@@ -1,0 +1,37 @@
+using Refresh.Core.Types.Data;
+using Refresh.Database.Models.Levels;
+
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Levels;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiGameLevelOwnRelationsResponse : IApiResponse
+{
+    public required bool IsHearted { get; set; }
+    public required bool IsQueued { get; set; }
+    public required int LevelRating { get; set; }
+
+    /// <summary>
+    /// Returns the total amount of plays; ambiguous name because a unique play count would be nonsense
+    /// because this is only about one user. Probably rename this in APIv4 anyway.
+    /// </summary>
+    public required int MyPlaysCount { get; set; }
+    public required int CompletionCount { get; set; }
+    public required int PhotoCount { get; set; }
+
+    public static ApiGameLevelOwnRelationsResponse? FromOld(GameLevel level, DataContext dataContext)
+    {
+        if (dataContext.User == null) 
+            return null;
+
+        return new()
+        {
+            // TODO: Probably cache these stats aswell
+            IsHearted = dataContext.Database.IsLevelFavouritedByUser(level, dataContext.User),
+            IsQueued = dataContext.Database.IsLevelQueuedByUser(level, dataContext.User),
+            LevelRating = (int?)dataContext.Database.GetRatingByUser(level, dataContext.User) ?? 0,
+            MyPlaysCount = dataContext.Database.GetTotalPlaysForLevelByUser(level, dataContext.User),
+            CompletionCount = dataContext.Database.GetTotalCompletionsForLevelByUser(level, dataContext.User),
+            PhotoCount = dataContext.Database.GetTotalPhotosInLevelByUser(level, dataContext.User)
+        };
+    }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelOwnRelationsResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelOwnRelationsResponse.cs
@@ -11,8 +11,7 @@ public class ApiGameLevelOwnRelationsResponse : IApiResponse
     public required int LevelRating { get; set; }
 
     /// <summary>
-    /// Returns the total amount of plays; ambiguous name because a unique play count would be nonsense
-    /// because this is only about one user. Probably rename this in APIv4 anyway.
+    /// Returns the total amount of plays. Probably rename this in APIv4 for clarity.
     /// </summary>
     public required int MyPlaysCount { get; set; }
     public required int CompletionCount { get; set; }

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelRelationsResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelRelationsResponse.cs
@@ -1,9 +1,0 @@
-namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Levels;
-
-[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class ApiGameLevelRelationsResponse : IApiResponse
-{
-    public required bool IsHearted { get; set; }
-    public required bool IsQueued { get; set; }
-    public required int MyPlaysCount { get; set; }
-}

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Levels/ApiGameLevelResponse.cs
@@ -55,6 +55,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
     public required bool IsCopyable { get; set; }
     public required float Score { get; set; }
     public required IEnumerable<Tag> Tags { get; set; }
+    public required ApiGameLevelOwnRelationsResponse? OwnRelations { get; set; }
 
     public static ApiGameLevelResponse? FromOld(GameLevel? level, DataContext dataContext)
     {
@@ -102,6 +103,7 @@ public class ApiGameLevelResponse : IApiResponse, IDataConvertableFrom<ApiGameLe
             Reviews = level.Statistics.ReviewCount,
             Tags = dataContext.Database.GetTagsForLevel(level),
             IsModded = level.IsModded,
+            OwnRelations = ApiGameLevelOwnRelationsResponse.FromOld(level, dataContext),
         };
     }
 

--- a/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
@@ -132,17 +132,20 @@ public class LevelApiEndpoints : EndpointGroup
     [ApiV3Endpoint("levels/id/{id}/relations"), MinimumRole(GameUserRole.Restricted)]
     [DocSummary("Gets your relations to a level by it's ID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
-    public ApiResponse<ApiGameLevelRelationsResponse> GetLevelRelationsOfUser(RequestContext context, GameDatabaseContext database, GameUser user,
+    public ApiResponse<ApiGameLevelOwnRelationsResponse> GetLevelRelationsOfUser(RequestContext context, GameDatabaseContext database, GameUser user,
         [DocSummary("The ID of the level")] int id)
     {
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
-        return new ApiGameLevelRelationsResponse
+        return new ApiGameLevelOwnRelationsResponse
         {
             IsHearted = database.IsLevelFavouritedByUser(level, user),
             IsQueued = database.IsLevelQueuedByUser(level, user),
-            MyPlaysCount = database.GetTotalPlaysForLevelByUser(level, user)
+            LevelRating = (int?)database.GetRatingByUser(level, user) ?? 0,
+            MyPlaysCount = database.GetTotalPlaysForLevelByUser(level, user),
+            CompletionCount = database.GetTotalCompletionsForLevelByUser(level, user),
+            PhotoCount = database.GetTotalPhotosInLevelByUser(level, user)
         };
     }
 

--- a/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
@@ -132,21 +132,13 @@ public class LevelApiEndpoints : EndpointGroup
     [ApiV3Endpoint("levels/id/{id}/relations"), MinimumRole(GameUserRole.Restricted)]
     [DocSummary("Gets your relations to a level by it's ID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
-    public ApiResponse<ApiGameLevelOwnRelationsResponse> GetLevelRelationsOfUser(RequestContext context, GameDatabaseContext database, GameUser user,
+    public ApiResponse<ApiGameLevelOwnRelationsResponse> GetLevelRelationsOfUser(RequestContext context, DataContext dataContext, GameUser user,
         [DocSummary("The ID of the level")] int id)
     {
-        GameLevel? level = database.GetLevelById(id);
+        GameLevel? level = dataContext.Database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
-        return new ApiGameLevelOwnRelationsResponse
-        {
-            IsHearted = database.IsLevelFavouritedByUser(level, user),
-            IsQueued = database.IsLevelQueuedByUser(level, user),
-            LevelRating = (int?)database.GetRatingByUser(level, user) ?? 0,
-            MyPlaysCount = database.GetTotalPlaysForLevelByUser(level, user),
-            CompletionCount = database.GetTotalCompletionsForLevelByUser(level, user),
-            PhotoCount = database.GetTotalPhotosInLevelByUser(level, user)
-        };
+        return ApiGameLevelOwnRelationsResponse.FromOld(level, dataContext);
     }
 
     [ApiV3Endpoint("levels/id/{id}/heart", HttpMethods.Post)]

--- a/RefreshTests.GameServer/Tests/ApiV3/LevelApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/LevelApiTests.cs
@@ -145,7 +145,7 @@ public class LevelApiTests : GameServerTest
     }
 
     [Test]
-    public void OnlyIncludesOwnUserRelationsWhenSignedIn()
+    public void OnlyIncludesOwnLevelRelationsWhenSignedIn()
     {
         using TestContext context = this.GetServer();
         GameUser me = context.CreateUser();


### PR DESCRIPTION
Makes `ApiGameLevelResponse` include an `ApiGameLevelOwnRelationsResponse` attribute, which is not null if the user is signed in. This way clients like refresh-web can also show various statistics, like whether the user has played or hearted a level, on level listings without having to call the dedicated `relations` endpoint for every level. This also means not having to wait for the relations request on level detail pages. Actually using these included stats, instead of requesting them separately, will require a PR for refresh-web.

This PR also introduces a few new statistics to `ApiGameLevelOwnRelationsResponse`, like the user's level rating and their total completion count.