### PR TITLE
Implement hearting users over the API

### DIFF
--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiExtendedGameUserResponse.cs
@@ -69,6 +69,7 @@ public class ApiExtendedGameUserResponse : ApiGameUserResponse, IApiResponse, ID
             UnescapeXmlSequences = user.UnescapeXmlSequences,
             FilesizeQuotaUsage = user.FilesizeQuotaUsage,
             Statistics = ApiGameUserStatisticsResponse.FromOld(user, dataContext)!,
+            OwnRelations = ApiGameUserOwnRelationsResponse.FromOld(user, dataContext),
             ActiveRoom = ApiGameRoomResponse.FromOld(dataContext.Match.RoomAccessor.GetRoomByUser(user), dataContext),
             LevelVisibility = user.LevelVisibility,
             ProfileVisibility = user.ProfileVisibility,

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiGameUserOwnRelationsResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiGameUserOwnRelationsResponse.cs
@@ -1,0 +1,21 @@
+using Refresh.Core.Types.Data;
+using Refresh.Database.Models.Users;
+
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Users;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiGameUserOwnRelationsResponse : IApiResponse
+{
+    public required bool IsHearted { get; set; }
+
+    public static ApiGameUserOwnRelationsResponse? FromOld(GameUser user, DataContext dataContext)
+    {
+        if (dataContext.User == null) 
+            return null;
+
+        return new()
+        {
+            IsHearted = dataContext.Database.IsUserFavouritedByUser(user, dataContext.User),
+        };
+    }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiGameUserResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Users/ApiGameUserResponse.cs
@@ -26,6 +26,7 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
     public required GameUserRole Role { get; set; }
     
     public required ApiGameUserStatisticsResponse Statistics { get; set; }
+    public required ApiGameUserOwnRelationsResponse? OwnRelations { get; set; }
     public required ApiGameRoomResponse? ActiveRoom { get; set; }
 
     [ContractAnnotation("null => null; notnull => notnull")]
@@ -51,6 +52,7 @@ public class ApiGameUserResponse : IApiResponse, IDataConvertableFrom<ApiGameUse
             LastLoginDate = user.LastLoginDate,
             Role = user.Role,
             Statistics = ApiGameUserStatisticsResponse.FromOld(user, dataContext)!,
+            OwnRelations = ApiGameUserOwnRelationsResponse.FromOld(user, dataContext),
             ActiveRoom = ApiGameRoomResponse.FromOld(dataContext.Match.RoomAccessor.GetRoomByUser(user), dataContext),
         };
     }

--- a/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
@@ -181,10 +181,12 @@ public class LevelApiEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
-        database.QueueLevel(level, user);
+        bool success = database.QueueLevel(level, user);
 
-        // Update pin progress for queueing a level through the API
-        database.IncrementUserPinProgress((long)ServerPins.QueueLevelOnWebsite, 1, user, false, TokenPlatform.Website);
+        // Only give pin if the level was queued without having already been queued.
+        // Won't protect against spam, but this way the pin objective is more accurately implemented.
+        if (success)
+            database.IncrementUserPinProgress((long)ServerPins.QueueLevelOnWebsite, 1, user, false, TokenPlatform.Website);
 
         return new ApiOkResponse();
     }

--- a/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
@@ -9,6 +9,8 @@ using Refresh.Core.Configuration;
 using Refresh.Core.Services;
 using Refresh.Core.Types.Data;
 using Refresh.Database;
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Pins;
 using Refresh.Database.Models.Users;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
@@ -44,6 +46,35 @@ public class UserApiEndpoints : EndpointGroup
         if(user == null) return ApiNotFoundError.UserMissingError;
         
         return ApiGameUserResponse.FromOld(user, dataContext);
+    }
+
+    // TODO: Also allow specifying user by username
+    [ApiV3Endpoint("users/uuid/{uuid}/heart", HttpMethods.Post)]
+    [DocSummary("Hearts a user by their UUID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    public ApiResponse<ApiOkResponse> HeartUserByUuid(RequestContext context, GameDatabaseContext database,
+        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext, GameUser user)
+    {
+        GameUser? target = database.GetUserByUuid(uuid);
+        if(target == null) return ApiNotFoundError.UserMissingError;
+        
+        database.FavouriteUser(target, user);
+        database.IncrementUserPinProgress((long)ServerPins.HeartPlayerOnWebsite, 1, user, false, TokenPlatform.Website);
+
+        return new ApiOkResponse();
+    }
+
+    [ApiV3Endpoint("users/uuid/{uuid}/unheart", HttpMethods.Post)]
+    [DocSummary("Unhearts a user by their UUID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    public ApiResponse<ApiOkResponse> UnheartUserByUuid(RequestContext context, GameDatabaseContext database,
+        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext, GameUser user)
+    {
+        GameUser? target = database.GetUserByUuid(uuid);
+        if(target == null) return ApiNotFoundError.UserMissingError;
+        
+        database.UnfavouriteUser(target, user);
+        return new ApiOkResponse();
     }
     
     [ApiV3Endpoint("users/me"), MinimumRole(GameUserRole.Restricted)]

--- a/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
@@ -343,4 +343,23 @@ public class UserApiTests : GameServerTest
             index++;
         }
     }
+
+    [Test]
+    public void OnlyIncludesOwnUserRelationsWhenSignedIn()
+    {
+        using TestContext context = this.GetServer();
+        GameUser otherUser = context.CreateUser();
+        GameUser me = context.CreateUser();
+
+        // Try fetching the user without being signed in
+        ApiResponse<ApiGameUserResponse>? response = context.Http.GetData<ApiGameUserResponse>($"/api/v3/users/name/{otherUser.Username}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.OwnRelations, Is.Null);
+        
+        // Sign in and then get user again
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, me);
+        response = client.GetData<ApiGameUserResponse>($"/api/v3/users/name/{otherUser.Username}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.OwnRelations, Is.Not.Null);
+    }
 }


### PR DESCRIPTION
Adds endpoints for hearting and unhearting users over the API. Hearting a user like this will also increment the hearting user's progress of the corresponding pin, meaning that this PR will close issue #395. Also adds an `OwnRelations` attribute to `ApiGameUserResponse`, which currently only contains whether the user in question is hearted.