### PR TITLE
Don't allow renaming users to already taken usernames, fix not being able to rename fake users

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -347,10 +347,22 @@ public partial class GameDatabaseContext // Users
     public DatabaseList<GameUser> GetAllUsersWithRole(GameUserRole role)
         => new(this.GameUsersIncluded.Where(u => u.Role == role));
 
-    public void RenameUser(GameUser user, string newUsername)
+    public void RenameUser(GameUser user, string newUsername, bool force = false)
     {
-        string oldUsername = user.Username;
+        if (!force)
+        {
+            if (!newUsername.StartsWith(SystemUsers.SystemPrefix) && !this.IsUsernameValid(newUsername))
+            {
+                throw new ArgumentException("Username is invalid!", nameof(newUsername));
+            }
 
+            if (this.IsUsernameTaken(newUsername))
+            {
+                throw new ArgumentException("Username is already taken!", nameof(newUsername));
+            }
+        }
+
+        string oldUsername = user.Username;
         user.Username = newUsername;
         this.GameUsers.Update(user);
         this.SaveChanges();

--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -194,7 +194,7 @@ internal class CommandLineManager
                 Fail("Username must contain content");
             
             GameUser user = this.GetUserOrFail(options);
-            this._server.RenameUser(user, options.RenameUser);
+            this._server.RenameUser(user, options.RenameUser, options.Force);
         }
         else if (options.DeleteUser)
         {

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -285,10 +285,10 @@ public class RefreshGameServer : RefreshServer
         return context.ReallowUser(username);
     }
 
-    public void RenameUser(GameUser user, string newUsername)
+    public void RenameUser(GameUser user, string newUsername, bool force = false)
     {
         using GameDatabaseContext context = this.GetContext();
-        context.RenameUser(user, newUsername);
+        context.RenameUser(user, newUsername, force);
     }
     
     public void DeleteUser(GameUser user)

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
@@ -221,11 +221,15 @@ public class AdminUserApiEndpoints : EndpointGroup
                 return ApiNotFoundError.IconMissingError;
         }
 
-        if (body.Username != null) 
+        // Do nothing if the username entered is actually the same as the one already set
+        if (body.Username != null && body.Username != targetUser.Username) 
         {
             if (!body.Username.StartsWith(SystemUsers.SystemPrefix) && !database.IsUsernameValid(body.Username))
                 return new ApiValidationError(ApiValidationError.InvalidUsernameErrorWhen
                     + " Are you sure you used a PSN/RPCN username, or prepended it with ! if it's a fake user?");
+            
+            if (database.IsUsernameTaken(body.Username))
+                return new ApiValidationError("This username is already taken!");
             
             database.RenameUser(targetUser, body.Username);
         }

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
@@ -170,6 +170,7 @@ public class AdminUserApiEndpoints : EndpointGroup
     [DocError(typeof(ApiValidationError), ApiValidationError.WrongRoleUpdateMethodErrorWhen)]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.IconMissingErrorWhen)]
     [DocError(typeof(ApiValidationError), ApiValidationError.InvalidUsernameErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.UsernameTakenErrorWhen)]
     public ApiResponse<ApiExtendedGameUserResponse> UpdateUser(RequestContext context, GameDatabaseContext database,
         GameUser user, ApiAdminUpdateUserRequest body, DataContext dataContext, 
         [DocSummary("The type of identifier used to look up the user. Can be either 'uuid' or 'username'.")] string idType, 
@@ -229,7 +230,7 @@ public class AdminUserApiEndpoints : EndpointGroup
                     + " Are you sure you used a PSN/RPCN username, or prepended it with ! if it's a fake user?");
             
             if (database.IsUsernameTaken(body.Username))
-                return new ApiValidationError("This username is already taken!");
+                return ApiValidationError.UsernameTakenError;
             
             database.RenameUser(targetUser, body.Username);
         }

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
@@ -223,9 +223,9 @@ public class AdminUserApiEndpoints : EndpointGroup
 
         if (body.Username != null) 
         {
-            if (!database.IsUsernameValid(body.Username))
+            if (!body.Username.StartsWith(SystemUsers.SystemPrefix) && !database.IsUsernameValid(body.Username))
                 return new ApiValidationError(ApiValidationError.InvalidUsernameErrorWhen
-                    + " Are you sure you used a PSN/RPCN username?");
+                    + " Are you sure you used a PSN/RPCN username, or prepended it with ! if it's a fake user?");
             
             database.RenameUser(targetUser, body.Username);
         }

--- a/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
@@ -79,6 +79,9 @@ public class ApiValidationError : ApiError
 
     public const string InvalidUsernameErrorWhen = "The username must be valid. The requirements are 3 to 16 alphanumeric characters, plus hyphens and underscores.";
     public static readonly ApiValidationError InvalidUsernameError = new(InvalidUsernameErrorWhen);
+
+    public const string UsernameTakenErrorWhen = "This username is already taken!";
+    public static readonly ApiValidationError UsernameTakenError = new(UsernameTakenErrorWhen);
     
     // TODO: Split off error messages which are actually 401 or anything else that isn't 400
     public ApiValidationError(string message) : base(message) {}


### PR DESCRIPTION
Adds validation to both the recently added admin API endpoint and also the database method which ensures that users cannot be renamed to already taken usernames. New usernames also have to be valid, or prepended with `!` (to allow renaming fake users).