### PR TITLE
Remove offset from received timestamps when writing them to DB

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Contests.cs
+++ b/Refresh.Database/GameDatabaseContext.Contests.cs
@@ -17,8 +17,9 @@ public partial class GameDatabaseContext // Contests
             ContestId = contestId,
             Organizer = organizer,
             CreationDate = this._time.Now,
-            StartDate = createInfo.StartDate!.Value,
-            EndDate = createInfo.EndDate!.Value,
+            // EF doesn't support timestamps with offsets
+            StartDate = createInfo.StartDate!.Value.UtcDateTime,
+            EndDate = createInfo.EndDate!.Value.UtcDateTime,
             ContestTitle = createInfo.ContestTitle!,
             BannerUrl = createInfo.BannerUrl ?? "",
             ContestTag = createInfo.ContestTag ?? $"#{contestId}",
@@ -80,9 +81,9 @@ public partial class GameDatabaseContext // Contests
                 contest.Organizer = newOrganizer;
             
             if(body.StartDate != null)
-                contest.StartDate = body.StartDate.Value;
+                contest.StartDate = body.StartDate.Value.UtcDateTime;
             if(body.EndDate != null)
-                contest.EndDate = body.EndDate.Value;
+                contest.EndDate = body.EndDate.Value.UtcDateTime;
             if(body.ContestTag != null)
                 contest.ContestTag = body.ContestTag;
             if(body.BannerUrl != null)

--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -320,7 +320,7 @@ public partial class GameDatabaseContext // Users
         {
             user.Role = role;
             user.BanReason = reason;
-            user.BanExpiryDate = expiryDate;
+            user.BanExpiryDate = expiryDate.UtcDateTime; // EF doesn't support timestamps with offsets
         });
     }
 

--- a/RefreshTests.GameServer/Tests/Moderation/PunishmentTests.cs
+++ b/RefreshTests.GameServer/Tests/Moderation/PunishmentTests.cs
@@ -1,0 +1,42 @@
+using Refresh.Database.Models.Users;
+
+namespace RefreshTests.GameServer.Tests.Moderation;
+
+public class PunishmentTests : GameServerTest
+{
+    [Test]
+    public void CanPunishWithOffsetExpiryDate()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameUser mod = context.CreateUser();
+        DateTime now = context.Time.Now.DateTime;
+
+        // Restrict
+        Assert.That(() =>
+        {
+            context.Database.RestrictUser(user, "too many skill issues", new(now.AddHours(4), new(2, 0, 0)));
+        }, Throws.Nothing);
+        
+        context.Database.Refresh();
+        GameUser? restrictedUser = context.Database.GetUserByObjectId(user.UserId);
+        Assert.That(restrictedUser, Is.Not.Null);
+        Assert.That(restrictedUser!.Role, Is.EqualTo(GameUserRole.Restricted));
+        Assert.That(restrictedUser!.BanExpiryDate, Is.Not.Null);
+        Assert.That(restrictedUser!.BanExpiryDate!.Value.DateTime.Equals(now.AddHours(2)), Is.True);
+
+        // Ban
+        Assert.That(() =>
+        {
+            // Passing user here, for some reason, makes the ban not get written but also doesn't cause a throw
+            context.Database.BanUser(restrictedUser, "even more skill issues", new(now.AddHours(8), new(4, 0, 0)));
+        }, Throws.Nothing);
+        
+        context.Database.Refresh();
+        GameUser? bannedUser = context.Database.GetUserByObjectId(restrictedUser.UserId);
+        Assert.That(bannedUser, Is.Not.Null);
+        Assert.That(bannedUser!.Role, Is.EqualTo(GameUserRole.Banned));
+        Assert.That(bannedUser!.BanExpiryDate, Is.Not.Null);
+        Assert.That(bannedUser!.BanExpiryDate!.Value.DateTime.Equals(now.AddHours(4)), Is.True);
+    }
+}


### PR DESCRIPTION
Closes #1028 by setting `GameContest.StartDate`, `GameContest.EndDate` and `GameUser.BanExpiryDate` to the UTC variant of the `DateTimeOffset`s received from API requests. Also includes tests for both cases.