### PR TITLE
Deduplicate API endpoints which specify a user in their route

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.Database/GameDatabaseContext.Photos.cs
@@ -193,16 +193,12 @@ public partial class GameDatabaseContext // Photos
 
     public void DeletePhotosPostedByUser(GameUser user)
     {
-        IEnumerable<GamePhoto> photos = this.GamePhotos.Where(s => s.PublisherId == user.UserId);
-        
-        this.WriteEnsuringStatistics(user, () =>
+        IEnumerable<GamePhoto> photos = this.GamePhotos.Where(s => s.PublisherId == user.UserId).ToArray();
+
+        foreach (GamePhoto photo in photos)
         {
-            foreach (GamePhoto photo in photos)
-            {
-                this.RemovePhoto(photo);
-            }
-            
-            user.Statistics!.PhotosByUserCount = 0;
-        });
+            // RemovePhoto already takes care of decrementing (effectively resetting) the publisher's photo count
+            this.RemovePhoto(photo);
+        }
     }
 }

--- a/Refresh.Interfaces.APIv3/Documentation/Descriptions/SharedParamDescriptions.cs
+++ b/Refresh.Interfaces.APIv3/Documentation/Descriptions/SharedParamDescriptions.cs
@@ -1,5 +1,8 @@
 namespace Refresh.Interfaces.APIv3.Documentation.Descriptions;
 
+/// <summary>
+/// Descriptions for commonly used API params.
+/// </summary>
 public static class SharedParamDescriptions
 {
     public const string UserIdParam = "The UUID or (user)name of the user.";

--- a/Refresh.Interfaces.APIv3/Documentation/Descriptions/SharedParamDescriptions.cs
+++ b/Refresh.Interfaces.APIv3/Documentation/Descriptions/SharedParamDescriptions.cs
@@ -1,0 +1,7 @@
+namespace Refresh.Interfaces.APIv3.Documentation.Descriptions;
+
+public static class SharedParamDescriptions
+{
+    public const string UserIdParam = "The UUID or (user)name of the user.";
+    public const string UserIdTypeParam = "The type of ID used to specify the user. Can be 'uuid', 'username' or 'name'.";
+}

--- a/Refresh.Interfaces.APIv3/Documentation/Descriptions/SharedParamDescriptions.cs
+++ b/Refresh.Interfaces.APIv3/Documentation/Descriptions/SharedParamDescriptions.cs
@@ -5,6 +5,6 @@ namespace Refresh.Interfaces.APIv3.Documentation.Descriptions;
 /// </summary>
 public static class SharedParamDescriptions
 {
-    public const string UserIdParam = "The UUID or (user)name of the user.";
+    public const string UserIdParam = "The UUID or username of the user.";
     public const string UserIdTypeParam = "The type of ID used to specify the user. Can be 'uuid', 'username' or 'name'.";
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminAssetApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminAssetApiEndpoints.cs
@@ -6,6 +6,7 @@ using Refresh.Core.Types.Data;
 using Refresh.Database;
 using Refresh.Database.Models.Assets;
 using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Data;
@@ -15,15 +16,16 @@ namespace Refresh.Interfaces.APIv3.Endpoints.Admin;
 
 public class AdminAssetApiEndpoints : EndpointGroup
 {
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/assets"), MinimumRole(GameUserRole.Moderator)]
+    [ApiV3Endpoint("admin/users/{idType}/{id}/assets"), MinimumRole(GameUserRole.Moderator)]
     [DocSummary("Retrieves a list of assets uploaded by the user.")]
     [DocQueryParam("assetType", "The asset type to filter by. Can be excluded to list all types.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     [DocError(typeof(ApiValidationError), "The asset type could not be parsed.")]
     public ApiListResponse<ApiMinimalGameAssetResponse> GetAssetsByUser(RequestContext context, GameDatabaseContext database, DataContext dataContext,
-        [DocSummary("The UUID of the user.")] string uuid)
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByUuid(uuid);
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         (int skip, int count) = context.GetPageData(1000);

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminLeaderboardApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminLeaderboardApiEndpoints.cs
@@ -6,6 +6,7 @@ using Refresh.Core.Authentication.Permission;
 using Refresh.Database;
 using Refresh.Database.Models.Levels.Scores;
 using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 
@@ -27,26 +28,14 @@ public class AdminLeaderboardApiEndpoints : EndpointGroup
         return new ApiOkResponse();
     }
     
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/scores", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all scores set by a user. Gets user by their UUID.")]
+    [ApiV3Endpoint("admin/users/{idType}/{id}/scores", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
+    [DocSummary("Deletes all scores set by a user, specified by UUID or username.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeleteScoresSetByUuid(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The UUID of the user")] string uuid)
+    public ApiOkResponse DeleteScoresSetByUser(RequestContext context, GameDatabaseContext database,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByUuid(uuid);
-        if (user == null) return ApiNotFoundError.UserMissingError;
-        
-        database.DeleteScoresSetByUser(user);
-        return new ApiOkResponse();
-    }
-    
-    [ApiV3Endpoint("admin/users/name/{username}/scores", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all scores set by a user. Gets user by their username.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeleteScoresSetByUsername(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The username of the user")] string username)
-    {
-        GameUser? user = database.GetUserByUsername(username);
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         database.DeleteScoresSetByUser(user);

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminPhotoApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminPhotoApiEndpoints.cs
@@ -6,6 +6,7 @@ using Refresh.Core.Authentication.Permission;
 using Refresh.Database;
 using Refresh.Database.Models.Photos;
 using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 
@@ -13,26 +14,14 @@ namespace Refresh.Interfaces.APIv3.Endpoints.Admin;
 
 public class AdminPhotoApiEndpoints : EndpointGroup
 {
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/photos", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all photos posted by a user. Gets user by their UUID.")]
+    [ApiV3Endpoint("admin/users/{idType}/{id}/photos", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
+    [DocSummary("Deletes all photos posted by a user. Gets user by their UUID or username.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeletePhotosPostedByUuid(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The UUID of the user")] string uuid)
+    public ApiOkResponse DeletePhotosPostedByUser(RequestContext context, GameDatabaseContext database,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByUuid(uuid);
-        if (user == null) return ApiNotFoundError.UserMissingError;
-        
-        database.DeletePhotosPostedByUser(user);
-        return new ApiOkResponse();
-    }
-    
-    [ApiV3Endpoint("admin/users/name/{username}/photos", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all photos posted by a user. Gets user by their username.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeletePhotosPostedByUsername(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The username of the user")] string username)
-    {
-        GameUser? user = database.GetUserByUsername(username);
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         database.DeletePhotosPostedByUser(user);

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminReviewApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminReviewApiEndpoints.cs
@@ -6,6 +6,7 @@ using Refresh.Core.Authentication.Permission;
 using Refresh.Database;
 using Refresh.Database.Models.Comments;
 using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 
@@ -55,78 +56,42 @@ public class AdminReviewApiEndpoints : EndpointGroup
         return new ApiOkResponse();
     }
     
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/comments/profile", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all profile comments posted by a user. Gets user by their UUID.")]
+    [ApiV3Endpoint("admin/users/{idType}/{id}/comments/profile", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
+    [DocSummary("Deletes all profile comments posted by a user. Gets user by their UUID or username.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeleteProfileCommentsByUuid(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The UUID of the user")] string uuid)
+    public ApiOkResponse DeleteProfileCommentsByUser(RequestContext context, GameDatabaseContext database,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByUuid(uuid);
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         database.DeleteProfileCommentsPostedByUser(user);
         return new ApiOkResponse();
     }
     
-    [ApiV3Endpoint("admin/users/name/{username}/comments/profile", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all profile comments posted by a user. Gets user by their username.")]
+    [ApiV3Endpoint("admin/users/{idType}/{id}/comments/level", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
+    [DocSummary("Deletes all level comments posted by a user. Gets user by their UUID or username.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeleteProfileCommentsByUsername(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The username of the user")] string username)
+    public ApiOkResponse DeleteLevelCommentsByUser(RequestContext context, GameDatabaseContext database,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByUsername(username);
-        if (user == null) return ApiNotFoundError.UserMissingError;
-        
-        database.DeleteProfileCommentsPostedByUser(user);
-        return new ApiOkResponse();
-    }
-    
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/comments/level", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all level comments posted by a user. Gets user by their UUID.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeleteLevelCommentsByUuid(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The UUID of the user")] string uuid)
-    {
-        GameUser? user = database.GetUserByUuid(uuid);
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
 
         database.DeleteLevelCommentsPostedByUser(user);
         return new ApiOkResponse();
     }
     
-    [ApiV3Endpoint("admin/users/name/{username}/comments/level", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all level comments posted by a user. Gets user by their username.")]
+    [ApiV3Endpoint("admin/users/{idType}/{id}/reviews", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
+    [DocSummary("Deletes all reviews posted by a user. Gets user by their UUID or username.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeleteLevelCommentsByUsername(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The username of the user")] string username)
+    public ApiOkResponse DeleteReviewsPostedByUser(RequestContext context, GameDatabaseContext database,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByUsername(username);
-        if (user == null) return ApiNotFoundError.UserMissingError;
-        
-        database.DeleteLevelCommentsPostedByUser(user);
-        return new ApiOkResponse();
-    }
-    
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/reviews", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all reviews posted by a user. Gets user by their UUID.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeleteReviewsPostedByUuid(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The UUID of the user")] string uuid)
-    {
-        GameUser? user = database.GetUserByUuid(uuid);
-        if (user == null) return ApiNotFoundError.UserMissingError;
-        
-        database.DeleteReviewsPostedByUser(user);
-        return new ApiOkResponse();
-    }
-    
-    [ApiV3Endpoint("admin/users/name/{username}/reviews", HttpMethods.Delete), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Deletes all reviews posted by a user. Gets user by their username.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse DeleteReviewsPostedByUsername(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The username of the user")] string username)
-    {
-        GameUser? user = database.GetUserByUsername(username);
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         database.DeleteReviewsPostedByUser(user);

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserPunishmentApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserPunishmentApiEndpoints.cs
@@ -5,6 +5,7 @@ using Bunkum.Protocols.Http;
 using Refresh.Core.Authentication.Permission;
 using Refresh.Database;
 using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
@@ -13,67 +14,47 @@ namespace Refresh.Interfaces.APIv3.Endpoints.Admin;
 
 public class AdminUserPunishmentApiEndpoints : EndpointGroup
 {
-    private static ApiOkResponse BanUser(GameUser? user, GameDatabaseContext database, ApiPunishUserRequest body)
+    [ApiV3Endpoint("admin/users/{idType}/{id}/ban", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
+    [DocSummary("Bans a user for the specified reason until the given date.")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    [DocRequestBody(typeof(ApiPunishUserRequest))]
+    public ApiOkResponse BanUser(RequestContext context, GameDatabaseContext database, ApiPunishUserRequest body,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         database.BanUser(user, body.Reason, body.ExpiryDate);
         return new ApiOkResponse();
     }
     
-    private static ApiOkResponse RestrictUser(GameUser? user, GameDatabaseContext database, ApiPunishUserRequest body)
+    [ApiV3Endpoint("admin/users/{idType}/{id}/restrict", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
+    [DocSummary("Restricts a user for the specified reason until the given date.")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    [DocRequestBody(typeof(ApiPunishUserRequest))]
+    public ApiOkResponse RestrictUser(RequestContext context, GameDatabaseContext database, ApiPunishUserRequest body,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         database.RestrictUser(user, body.Reason, body.ExpiryDate);
         return new ApiOkResponse();
     }
     
-    private static ApiOkResponse PardonUser(GameUser? user, GameDatabaseContext database)
+    [ApiV3Endpoint("admin/users/{idType}/{id}/pardon", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
+    [DocSummary("Pardons all punishments for the given user.")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    public ApiOkResponse PardonUser(RequestContext context, GameDatabaseContext database,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         database.SetUserRole(user, GameUserRole.User);
         return new ApiOkResponse();
     }
-
-    [ApiV3Endpoint("admin/users/name/{username}/ban", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Bans a user for the specified reason until the given date.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    [DocRequestBody(typeof(ApiPunishUserRequest))]
-    public ApiOkResponse BanByUsername(RequestContext context, GameDatabaseContext database, string username, ApiPunishUserRequest body) 
-        => BanUser(database.GetUserByUsername(username), database, body);
-    
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/ban", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Bans a user for the specified reason until the given date.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    [DocRequestBody(typeof(ApiPunishUserRequest))]
-    public ApiOkResponse BanByUuid(RequestContext context, GameDatabaseContext database, string uuid, ApiPunishUserRequest body) 
-        => BanUser(database.GetUserByUuid(uuid), database, body);
-    
-    [ApiV3Endpoint("admin/users/name/{username}/restrict", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Restricts a user for the specified reason until the given date.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    [DocRequestBody(typeof(ApiPunishUserRequest))]
-    public ApiOkResponse RestrictByUsername(RequestContext context, GameDatabaseContext database, string username, ApiPunishUserRequest body) 
-        => RestrictUser(database.GetUserByUsername(username), database, body);
-    
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/restrict", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Restricts a user for the specified reason until the given date.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    [DocRequestBody(typeof(ApiPunishUserRequest))]
-    public ApiOkResponse RestrictByUuid(RequestContext context, GameDatabaseContext database, string uuid, ApiPunishUserRequest body) 
-        => RestrictUser(database.GetUserByUuid(uuid), database, body);
-    
-    [ApiV3Endpoint("admin/users/name/{username}/pardon", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Pardons all punishments for the given user.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse PardonByUsername(RequestContext context, GameDatabaseContext database, string username) 
-        => PardonUser(database.GetUserByUsername(username), database);
-    
-    [ApiV3Endpoint("admin/users/uuid/{uuid}/pardon", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
-    [DocSummary("Pardons all punishments for the given user.")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse PardonByUuid(RequestContext context, GameDatabaseContext database, string uuid) 
-        => PardonUser(database.GetUserByUuid(uuid), database);
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/CommentApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/CommentApiEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.Database.Models.Comments;
 using Refresh.Database.Models.Levels;
 using Refresh.Database.Models.Users;
 using Refresh.Interfaces.APIv3.Documentation.Attributes;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
@@ -20,13 +21,15 @@ namespace Refresh.Interfaces.APIv3.Endpoints;
 public class CommentApiEndpoints : EndpointGroup
 {
     #region Profile
-    [ApiV3Endpoint("users/uuid/{uuid}/comments"), Authentication(false)]
+    [ApiV3Endpoint("users/{idType}/{id}/comments"), Authentication(false)]
     [DocSummary("Gets comments posted under the specified user's profile.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     [DocUsesPageData]
-    public ApiListResponse<ApiProfileCommentResponse> GetCommentsOnProfile(RequestContext context, DataContext dataContext, string uuid)
+    public ApiListResponse<ApiProfileCommentResponse> GetCommentsOnProfile(RequestContext context, DataContext dataContext,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? profile = dataContext.Database.GetUserByUuid(uuid);
+        GameUser? profile = dataContext.Database.GetUserByIdAndType(idType, id);
         if (profile == null) return ApiNotFoundError.UserMissingError;
 
         (int skip, int count) = context.GetPageData();
@@ -35,13 +38,15 @@ public class CommentApiEndpoints : EndpointGroup
         return DatabaseListExtensions.FromOldList<ApiProfileCommentResponse, GameProfileComment>(comments, dataContext);
     }
 
-    [ApiV3Endpoint("users/uuid/{uuid}/comments", HttpMethods.Post)]
+    [ApiV3Endpoint("users/{idType}/{id}/comments", HttpMethods.Post)]
     [DocSummary("Posts the given comment under the specified user's profile.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     public ApiResponse<ApiProfileCommentResponse> PostCommentOnProfile(RequestContext context,
-        DataContext dataContext, string uuid, GameUser user, ApiCommentPostRequest body)
+        DataContext dataContext, GameUser user, ApiCommentPostRequest body,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? profile = dataContext.Database.GetUserByUuid(uuid);
+        GameUser? profile = dataContext.Database.GetUserByIdAndType(idType, id);
         if (profile == null) return ApiNotFoundError.UserMissingError;
 
         // Trim content

--- a/Refresh.Interfaces.APIv3/Endpoints/MatchingApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/MatchingApiEndpoints.cs
@@ -8,6 +8,7 @@ using Refresh.Core.Types.Matching;
 using Refresh.Database;
 using Refresh.Database.Models.Users;
 using Refresh.Interfaces.APIv3.Documentation.Attributes;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Users.Rooms;
@@ -16,33 +17,16 @@ namespace Refresh.Interfaces.APIv3.Endpoints;
 
 public class MatchingApiEndpoints : EndpointGroup
 {
-    [ApiV3Endpoint("rooms/username/{username}"), Authentication(false)]
-    [DocSummary("Finds a room by a player's username")]
+    [ApiV3Endpoint("rooms/{userIdType}/{id}"), Authentication(false)]
+    [DocSummary("Finds a room by a player's username or UUID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     [DocError(typeof(ApiNotFoundError), "The room could not be found")]
-    public ApiResponse<ApiGameRoomResponse> GetRoomByUsername(RequestContext context, MatchService service,
-        GameDatabaseContext database,
-        [DocSummary("The username of the player")]
-        string username, DataContext dataContext)
+    public ApiResponse<ApiGameRoomResponse> GetRoomByUser(RequestContext context, MatchService service,
+        GameDatabaseContext database, DataContext dataContext,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string userIdType)
     {
-        GameUser? user = database.GetUserByUsername(username);
-        if (user == null) return ApiNotFoundError.UserMissingError;
-
-        GameRoom? room = service.RoomAccessor.GetRoomByUser(user);
-        if(room == null) return ApiNotFoundError.Instance;
-        
-        return ApiGameRoomResponse.FromOld(room, dataContext);
-    }
-    
-    [ApiV3Endpoint("rooms/uuid/{uuid}"), Authentication(false)]
-    [DocSummary("Finds a room by a player's UUID")]
-    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    [DocError(typeof(ApiNotFoundError), "The room could not be found")]
-    public ApiResponse<ApiGameRoomResponse> GetRoomByUserUuid(RequestContext context, MatchService service,
-        GameDatabaseContext database,
-        [DocSummary("The UUID of the player")] string uuid, DataContext dataContext)
-    {
-        GameUser? user = database.GetUserByUuid(uuid);
+        GameUser? user = database.GetUserByIdAndType(userIdType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
 
         GameRoom? room = service.RoomAccessor.GetRoomByUser(user);

--- a/Refresh.Interfaces.APIv3/Endpoints/PhotoApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/PhotoApiEndpoints.cs
@@ -9,6 +9,7 @@ using Refresh.Database.Models.Levels;
 using Refresh.Database.Models.Photos;
 using Refresh.Database.Models.Users;
 using Refresh.Interfaces.APIv3.Documentation.Attributes;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Users.Photos;
@@ -34,10 +35,16 @@ public class PhotoApiEndpoints : EndpointGroup
         return new ApiOkResponse();
     }
     
-    private static ApiListResponse<ApiGamePhotoResponse> PhotosByUser(RequestContext context,
-        GameDatabaseContext database, GameUser? user, IDataStore dataStore, DataContext dataContext)
+    [ApiV3Endpoint("photos/by/{idType}/{id}"), Authentication(false)]
+    [DocUsesPageData, DocSummary("Gets photos uploaded by a user specified by their username or UUID")]
+    [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
+    public ApiListResponse<ApiGamePhotoResponse> PhotosByUsername(RequestContext context, GameDatabaseContext database,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext) 
     {
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.Instance;
+
         (int skip, int count) = context.GetPageData();
 
         DatabaseList<GamePhoto> photos = database.GetPhotosByUser(user, count, skip);
@@ -45,61 +52,23 @@ public class PhotoApiEndpoints : EndpointGroup
         return photosResponse;
     }
     
-    private static ApiListResponse<ApiGamePhotoResponse> PhotosWithUser(RequestContext context,
-        GameDatabaseContext database, GameUser? user, IDataStore dataStore, DataContext dataContext)
+    [ApiV3Endpoint("photos/with/{idType}/{id}"), Authentication(false)]
+    [DocUsesPageData, DocSummary("Gets photos depicting a user specified by their username or UUID")]
+    [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
+    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUsername(RequestContext context,
+        GameDatabaseContext database, DataContext dataContext,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.Instance;
+
         (int skip, int count) = context.GetPageData();
 
         DatabaseList<GamePhoto> photos = database.GetPhotosWithUser(user, count, skip);
         DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseListExtensions.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
         return photosResponse;
     }
-    
-    private static ApiListResponse<ApiGamePhotoResponse> PhotosInLevel(RequestContext context,
-        GameDatabaseContext database, GameLevel? level, IDataStore dataStore, DataContext dataContext)
-    {
-        if (level == null) return ApiNotFoundError.Instance;
-        (int skip, int count) = context.GetPageData();
-
-        DatabaseList<GamePhoto> photos = database.GetPhotosInLevel(level, count, skip);
-        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseListExtensions.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
-        return photosResponse;
-    }
-    
-    [ApiV3Endpoint("photos/by/username/{username}"), Authentication(false)]
-    [DocUsesPageData, DocSummary("Gets photos by a user by their username")]
-    [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosByUsername(RequestContext context, GameDatabaseContext database,
-        IDataStore dataStore,
-        [DocSummary("The username of the user")]
-        string username, DataContext dataContext) 
-        => PhotosByUser(context, database, database.GetUserByUsername(username), dataStore, dataContext);
-    
-    [ApiV3Endpoint("photos/with/username/{username}"), Authentication(false)]
-    [DocUsesPageData, DocSummary("Gets photos including a user by their username")]
-    [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUsername(RequestContext context,
-        GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The username of the user")]
-        string username, DataContext dataContext)
-        => PhotosWithUser(context, database, database.GetUserByUsername(username), dataStore, dataContext);
-
-    [ApiV3Endpoint("photos/by/uuid/{uuid}"), Authentication(false)]
-    [DocUsesPageData, DocSummary("Gets photos by a user by their uuid")]
-    [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosByUserUuid(RequestContext context, GameDatabaseContext database,
-        IDataStore dataStore,
-        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext)
-        => PhotosByUser(context, database, database.GetUserByUuid(uuid), dataStore, dataContext);
-
-    [ApiV3Endpoint("photos/with/uuid/{uuid}"), Authentication(false)]
-    [DocUsesPageData, DocSummary("Gets photos including a user by their uuid")]
-    [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUserUuid(RequestContext context,
-        GameDatabaseContext database, IDataStore dataStore,
-        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext)
-        => PhotosWithUser(context, database, database.GetUserByUuid(uuid), dataStore, dataContext);
 
     [ApiV3Endpoint("levels/id/{id}/photos"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets photos taken in a level by its id")]
@@ -107,7 +76,16 @@ public class PhotoApiEndpoints : EndpointGroup
     public ApiListResponse<ApiGamePhotoResponse> PhotosInLevelById(RequestContext context, GameDatabaseContext database,
         IDataStore dataStore,
         [DocSummary("The ID of the level")] int id, DataContext dataContext)
-        => PhotosInLevel(context, database, database.GetLevelById(id), dataStore, dataContext);
+    {
+        GameLevel? level = database.GetLevelById(id);
+        if (level == null) return ApiNotFoundError.Instance;
+        
+        (int skip, int count) = context.GetPageData();
+
+        DatabaseList<GamePhoto> photos = database.GetPhotosInLevel(level, count, skip);
+        DatabaseList<ApiGamePhotoResponse> photosResponse = DatabaseListExtensions.FromOldList<ApiGamePhotoResponse, GamePhoto>(photos, dataContext);
+        return photosResponse;
+    }
     
     [ApiV3Endpoint("photos"), Authentication(false)]
     [DocUsesPageData, DocSummary("Get all photos taken recently")]

--- a/Refresh.Interfaces.APIv3/Endpoints/PhotoApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/PhotoApiEndpoints.cs
@@ -35,14 +35,14 @@ public class PhotoApiEndpoints : EndpointGroup
         return new ApiOkResponse();
     }
     
-    [ApiV3Endpoint("photos/by/{idType}/{id}"), Authentication(false)]
+    [ApiV3Endpoint("photos/by/{userIdType}/{id}"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets photos uploaded by a user specified by their username or UUID")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosByUsername(RequestContext context, GameDatabaseContext database,
+    public ApiListResponse<ApiGamePhotoResponse> PhotosByUser(RequestContext context, GameDatabaseContext database,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
-        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext) 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string userIdType, DataContext dataContext) 
     {
-        GameUser? user = database.GetUserByIdAndType(idType, id);
+        GameUser? user = database.GetUserByIdAndType(userIdType, id);
         if (user == null) return ApiNotFoundError.Instance;
 
         (int skip, int count) = context.GetPageData();
@@ -52,15 +52,15 @@ public class PhotoApiEndpoints : EndpointGroup
         return photosResponse;
     }
     
-    [ApiV3Endpoint("photos/with/{idType}/{id}"), Authentication(false)]
+    [ApiV3Endpoint("photos/with/{userIdType}/{id}"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets photos depicting a user specified by their username or UUID")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUsername(RequestContext context,
+    public ApiListResponse<ApiGamePhotoResponse> PhotosWithUser(RequestContext context,
         GameDatabaseContext database, DataContext dataContext,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
-        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string userIdType)
     {
-        GameUser? user = database.GetUserByIdAndType(idType, id);
+        GameUser? user = database.GetUserByIdAndType(userIdType, id);
         if (user == null) return ApiNotFoundError.Instance;
 
         (int skip, int count) = context.GetPageData();

--- a/Refresh.Interfaces.APIv3/Endpoints/ReviewApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ReviewApiEndpoints.cs
@@ -10,6 +10,7 @@ using Refresh.Database.Models.Comments;
 using Refresh.Database.Models.Levels;
 using Refresh.Database.Models.Users;
 using Refresh.Interfaces.APIv3.Documentation.Attributes;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
@@ -38,15 +39,15 @@ public class ReviewApiEndpoints : EndpointGroup
         return ret;
     }
 
-    [ApiV3Endpoint("users/{userIdType}/{userId}/reviews"), Authentication(false)]
+    [ApiV3Endpoint("users/{idType}/{id}/reviews"), Authentication(false)]
     [DocUsesPageData, DocSummary("Gets a list of the reviews posted by a user.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     public ApiListResponse<ApiGameReviewResponse> GetReviewsByUser(RequestContext context,
-        GameDatabaseContext database, IDataStore dataStore, DataContext dataContext,
-        [DocSummary("The type of identifier used to look up the user. Can be either 'uuid' or 'username'.")] string userIdType,
-        [DocSummary("The UUID or username of the user, depending on the specified ID type.")] string userId)
+        GameDatabaseContext database, DataContext dataContext,
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByIdAndType(userIdType, userId);
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if (user == null) return ApiNotFoundError.UserMissingError;
         
         (int skip, int count) = context.GetPageData();

--- a/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
@@ -25,7 +25,7 @@ public class UserApiEndpoints : EndpointGroup
     [ApiV3Endpoint("users/{idType}/{id}"), Authentication(false)]
     [DocSummary("Tries to find a user by name or UUID")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiResponse<ApiGameUserResponse> GetUserByUuid(RequestContext context, GameDatabaseContext database,
+    public ApiResponse<ApiGameUserResponse> GetUser(RequestContext context, GameDatabaseContext database,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
         [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext)
     {
@@ -39,7 +39,7 @@ public class UserApiEndpoints : EndpointGroup
     [ApiV3Endpoint("users/{idType}/{id}/heart", HttpMethods.Post)]
     [DocSummary("Hearts a user by their name or UUID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse HeartUserByUuid(RequestContext context, GameDatabaseContext database,
+    public ApiOkResponse HeartUser(RequestContext context, GameDatabaseContext database,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
         [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext, GameUser user)
     {
@@ -57,9 +57,9 @@ public class UserApiEndpoints : EndpointGroup
     }
 
     [ApiV3Endpoint("users/{idType}/{id}/unheart", HttpMethods.Post)]
-    [DocSummary("Unhearts a user by their UUID")]
+    [DocSummary("Unhearts a user by their name or UUID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse UnheartUserByUuid(RequestContext context, GameDatabaseContext database,
+    public ApiOkResponse UnheartUser(RequestContext context, GameDatabaseContext database,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
         [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext, GameUser user)
     {

--- a/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
@@ -12,6 +12,7 @@ using Refresh.Database;
 using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Pins;
 using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Documentation.Descriptions;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
@@ -21,41 +22,28 @@ namespace Refresh.Interfaces.APIv3.Endpoints;
 
 public class UserApiEndpoints : EndpointGroup
 {
-    [ApiV3Endpoint("users/name/{username}"), Authentication(false)]
-    [DocSummary("Tries to find a user by the username")]
-    [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
-    public ApiResponse<ApiGameUserResponse> GetUserByName(RequestContext context, GameDatabaseContext database,
-        IDataStore dataStore,
-        [DocSummary("The username of the user")]
-        string username, DataContext dataContext)
-    {
-        GameUser? user = database.GetUserByUsername(username, false);
-        if(user == null) return ApiNotFoundError.UserMissingError;
-        
-        return ApiGameUserResponse.FromOld(user, dataContext);
-    }
-    
-    [ApiV3Endpoint("users/uuid/{uuid}"), Authentication(false)]
-    [DocSummary("Tries to find a user by the UUID")]
+    [ApiV3Endpoint("users/{idType}/{id}"), Authentication(false)]
+    [DocSummary("Tries to find a user by name or UUID")]
     [DocError(typeof(ApiNotFoundError), "The user cannot be found")]
     public ApiResponse<ApiGameUserResponse> GetUserByUuid(RequestContext context, GameDatabaseContext database,
-        IDataStore dataStore,
-        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext)
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext)
     {
-        GameUser? user = database.GetUserByUuid(uuid);
+        GameUser? user = database.GetUserByIdAndType(idType, id);
         if(user == null) return ApiNotFoundError.UserMissingError;
         
         return ApiGameUserResponse.FromOld(user, dataContext);
     }
 
     // TODO: Also allow specifying user by username
-    [ApiV3Endpoint("users/uuid/{uuid}/heart", HttpMethods.Post)]
-    [DocSummary("Hearts a user by their UUID")]
+    [ApiV3Endpoint("users/{idType}/{id}/heart", HttpMethods.Post)]
+    [DocSummary("Hearts a user by their name or UUID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     public ApiOkResponse HeartUserByUuid(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext, GameUser user)
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext, GameUser user)
     {
-        GameUser? target = database.GetUserByUuid(uuid);
+        GameUser? target = database.GetUserByIdAndType(idType, id);
         if(target == null) return ApiNotFoundError.UserMissingError;
         
         bool success = database.FavouriteUser(target, user);
@@ -68,13 +56,14 @@ public class UserApiEndpoints : EndpointGroup
         return new ApiOkResponse();
     }
 
-    [ApiV3Endpoint("users/uuid/{uuid}/unheart", HttpMethods.Post)]
+    [ApiV3Endpoint("users/{idType}/{id}/unheart", HttpMethods.Post)]
     [DocSummary("Unhearts a user by their UUID")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
     public ApiOkResponse UnheartUserByUuid(RequestContext context, GameDatabaseContext database,
-        [DocSummary("The UUID of the user")] string uuid, DataContext dataContext, GameUser user)
+        [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext, GameUser user)
     {
-        GameUser? target = database.GetUserByUuid(uuid);
+        GameUser? target = database.GetUserByIdAndType(idType, id);
         if(target == null) return ApiNotFoundError.UserMissingError;
         
         database.UnfavouriteUser(target, user);

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -142,6 +142,35 @@ public class TestContext : IDisposable
         return level;
     }
 
+    public void CreatePhotoWithSubject(GameUser author, string imageHash)
+    {
+        // TODO: Return newly created GamePhoto
+        if (this.Database.GetAssetFromHash(imageHash) == null)
+        {
+            this.Database.AddAssetToDatabase(new()
+            {
+                AssetHash = imageHash,
+            });
+        }
+        
+        this.Database.UploadPhoto(new()
+        {
+            AuthorName = author.Username,
+            SmallHash = imageHash,
+            MediumHash = imageHash,
+            LargeHash = imageHash,
+            PhotoSubjects = 
+            [
+                new()
+                {
+                    Username = author.Username,
+                    DisplayName = author.Username,
+                    BoundsList = "10,10,10,10"
+                }
+            ]
+        }, author);
+    }
+
     public void FillLeaderboard(GameLevel level, int count, byte type)
     {
         for (byte i = 0; i < count; i++)

--- a/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
@@ -61,8 +61,9 @@ public class AdminUserEditApiTests : GameServerTest
         using TestContext context = this.GetServer();
         GameUser mod = context.CreateUser(role: GameUserRole.Moderator);
         HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
-
         GameUser player = context.CreateUser(role: GameUserRole.User);
+
+        // UUID
         ApiAdminUpdateUserRequest request = new()
         {
             Description = "poo"
@@ -71,14 +72,7 @@ public class AdminUserEditApiTests : GameServerTest
         Assert.That(response?.Data, Is.Not.Null);
         Assert.That(response!.Data!.Description, Is.EqualTo(request.Description));
 
-        request = new()
-        {
-            Description = "pee"
-        };
-        response = client.PatchData<ApiExtendedGameUserResponse>($"/api/v3/admin/users/username/{player.Username}", request);
-        Assert.That(response?.Data, Is.Not.Null);
-        Assert.That(response!.Data!.Description, Is.EqualTo(request.Description));
-
+        // name
         request = new()
         {
             Description = "lmao"

--- a/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
@@ -56,6 +56,39 @@ public class AdminUserEditApiTests : GameServerTest
     }
 
     [Test]
+    public void EditsUserByUuidAndName()
+    {
+        using TestContext context = this.GetServer();
+        GameUser mod = context.CreateUser(role: GameUserRole.Moderator);
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
+
+        GameUser player = context.CreateUser(role: GameUserRole.User);
+        ApiAdminUpdateUserRequest request = new()
+        {
+            Description = "poo"
+        };
+        ApiResponse<ApiExtendedGameUserResponse>? response = client.PatchData<ApiExtendedGameUserResponse>($"/api/v3/admin/users/uuid/{player.UserId}", request);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Description, Is.EqualTo(request.Description));
+
+        request = new()
+        {
+            Description = "pee"
+        };
+        response = client.PatchData<ApiExtendedGameUserResponse>($"/api/v3/admin/users/username/{player.Username}", request);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Description, Is.EqualTo(request.Description));
+
+        request = new()
+        {
+            Description = "lmao"
+        };
+        response = client.PatchData<ApiExtendedGameUserResponse>($"/api/v3/admin/users/name/{player.Username}", request);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Description, Is.EqualTo(request.Description));
+    }
+
+    [Test]
     [TestCase(GameUserRole.Restricted)]
     [TestCase(GameUserRole.User)]
     [TestCase(GameUserRole.Curator)]

--- a/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
@@ -9,7 +9,7 @@ using RefreshTests.GameServer.Extensions;
 
 namespace RefreshTests.GameServer.Tests.ApiV3;
 
-public class ModerationApiTests : GameServerTest
+public class AdminUserEditApiTests : GameServerTest
 {
     [Test]
     [TestCase(GameUserRole.Restricted)]

--- a/RefreshTests.GameServer/Tests/ApiV3/AdminUserManagementApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/AdminUserManagementApiTests.cs
@@ -20,6 +20,7 @@ public class AdminUserManagementApiTests : GameServerTest
         GameUser mod = context.CreateUser(role: GameUserRole.Moderator);
         HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
 
+        // UUID
         GameUser player1 = context.CreateUser(role: GameUserRole.User);
         ApiResetPasswordRequest request = new()
         {
@@ -33,31 +34,19 @@ public class AdminUserManagementApiTests : GameServerTest
         Assert.That(updated1, Is.Not.Null);
         Assert.That(updated1!.ShouldResetPassword, Is.True);
 
+        // Name
         GameUser player2 = context.CreateUser(role: GameUserRole.User);
         request = new()
         {
             PasswordSha512 = HexHelper.BytesToHexString(SHA512.HashData("poo"u8))
         };
-        response = await client.PutAsync($"/api/v3/admin/users/uuid/{player2.UserId}/resetPassword", new StringContent(request.AsJson()));
+        response = await client.PutAsync($"/api/v3/admin/users/name/{player2.Username}/resetPassword", new StringContent(request.AsJson()));
         Assert.That(response.IsSuccessStatusCode, Is.True);
 
         context.Database.Refresh();
         GameUser? updated2 = context.Database.GetUserByObjectId(player2.UserId);
         Assert.That(updated2, Is.Not.Null);
         Assert.That(updated2!.ShouldResetPassword, Is.True);
-
-        GameUser player3 = context.CreateUser(role: GameUserRole.User);
-        request = new()
-        {
-            PasswordSha512 = HexHelper.BytesToHexString(SHA512.HashData("poo"u8))
-        };
-        response = await client.PutAsync($"/api/v3/admin/users/uuid/{player3.UserId}/resetPassword", new StringContent(request.AsJson()));
-        Assert.That(response.IsSuccessStatusCode, Is.True);
-
-        context.Database.Refresh();
-        GameUser? updated3 = context.Database.GetUserByObjectId(player3.UserId);
-        Assert.That(updated3, Is.Not.Null);
-        Assert.That(updated3!.ShouldResetPassword, Is.True);
     }
 
     [Test]
@@ -107,26 +96,5 @@ public class AdminUserManagementApiTests : GameServerTest
         updated = context.Database.GetUserByObjectId(updated.UserId);
         Assert.That(updated, Is.Not.Null);
         Assert.That(updated!.Lbp3PlanetsHash.IsBlankHash(), Is.True);
-
-        // username
-        context.Database.UpdateUserData(updated, new SerializedUpdateData()
-        {
-            PlanetsHash = "lol"
-        }, TokenGame.LittleBigPlanetVita);
-
-        context.Database.Refresh();
-
-        planetResponse = client.GetData<ApiAdminUserPlanetsResponse>($"/api/v3/admin/users/username/{updated.Username}/planets");
-        Assert.That(planetResponse?.Data, Is.Not.Null);
-        Assert.That(planetResponse!.Data!.VitaPlanetsHash, Is.EqualTo("lol"));
-
-        resetResponse = await client.DeleteAsync($"/api/v3/admin/users/username/{updated.Username}/planets");
-        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
-
-        context.Database.Refresh();
-
-        updated = context.Database.GetUserByObjectId(updated.UserId);
-        Assert.That(updated, Is.Not.Null);
-        Assert.That(updated!.VitaPlanetsHash.IsBlankHash(), Is.True);
     }
 }

--- a/RefreshTests.GameServer/Tests/ApiV3/AdminUserManagementApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/AdminUserManagementApiTests.cs
@@ -1,0 +1,132 @@
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Users;
+using RefreshTests.GameServer.Extensions;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request.Authentication;
+using Refresh.Common.Helpers;
+using System.Security.Cryptography;
+using Refresh.Interfaces.Game.Types.UserData;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Admin;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
+using Refresh.Common.Extensions;
+
+namespace RefreshTests.GameServer.Tests.ApiV3;
+
+public class AdminUserManagementApiTests : GameServerTest
+{
+    [Test]
+    public async Task ResetsUsersPasswordByUuidAndName()
+    {
+        using TestContext context = this.GetServer();
+        GameUser mod = context.CreateUser(role: GameUserRole.Moderator);
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
+
+        GameUser player1 = context.CreateUser(role: GameUserRole.User);
+        ApiResetPasswordRequest request = new()
+        {
+            PasswordSha512 = HexHelper.BytesToHexString(SHA512.HashData("poo"u8))
+        };
+        HttpResponseMessage response = await client.PutAsync($"/api/v3/admin/users/uuid/{player1.UserId}/resetPassword", new StringContent(request.AsJson()));
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+
+        context.Database.Refresh();
+        GameUser? updated1 = context.Database.GetUserByObjectId(player1.UserId);
+        Assert.That(updated1, Is.Not.Null);
+        Assert.That(updated1!.ShouldResetPassword, Is.True);
+
+        GameUser player2 = context.CreateUser(role: GameUserRole.User);
+        request = new()
+        {
+            PasswordSha512 = HexHelper.BytesToHexString(SHA512.HashData("poo"u8))
+        };
+        response = await client.PutAsync($"/api/v3/admin/users/uuid/{player2.UserId}/resetPassword", new StringContent(request.AsJson()));
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+
+        context.Database.Refresh();
+        GameUser? updated2 = context.Database.GetUserByObjectId(player2.UserId);
+        Assert.That(updated2, Is.Not.Null);
+        Assert.That(updated2!.ShouldResetPassword, Is.True);
+
+        GameUser player3 = context.CreateUser(role: GameUserRole.User);
+        request = new()
+        {
+            PasswordSha512 = HexHelper.BytesToHexString(SHA512.HashData("poo"u8))
+        };
+        response = await client.PutAsync($"/api/v3/admin/users/uuid/{player3.UserId}/resetPassword", new StringContent(request.AsJson()));
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+
+        context.Database.Refresh();
+        GameUser? updated3 = context.Database.GetUserByObjectId(player3.UserId);
+        Assert.That(updated3, Is.Not.Null);
+        Assert.That(updated3!.ShouldResetPassword, Is.True);
+    }
+
+    [Test]
+    public async Task GetsAndResetsUserPlanetsByUuidAndName()
+    {
+        using TestContext context = this.GetServer();
+        GameUser mod = context.CreateUser(role: GameUserRole.Moderator);
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
+        GameUser player = context.CreateUser(role: GameUserRole.User);
+
+        // UUID
+        context.Database.UpdateUserData(player, new SerializedUpdateData()
+        {
+            PlanetsHash = "lol"
+        }, TokenGame.LittleBigPlanet2);
+        
+        ApiResponse<ApiAdminUserPlanetsResponse>? planetResponse = client.GetData<ApiAdminUserPlanetsResponse>($"/api/v3/admin/users/uuid/{player.UserId}/planets");
+        Assert.That(planetResponse?.Data, Is.Not.Null);
+        Assert.That(planetResponse!.Data!.Lbp2PlanetsHash, Is.EqualTo("lol"));
+
+        HttpResponseMessage resetResponse = await client.DeleteAsync($"/api/v3/admin/users/uuid/{player.UserId}/planets");
+        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
+
+        context.Database.Refresh();
+
+        GameUser? updated = context.Database.GetUserByObjectId(player.UserId);
+        Assert.That(updated, Is.Not.Null);
+        Assert.That(updated!.Lbp2PlanetsHash.IsBlankHash(), Is.True);
+        
+        // name
+        context.Database.UpdateUserData(updated, new SerializedUpdateData()
+        {
+            PlanetsHash = "lol"
+        }, TokenGame.LittleBigPlanet3);
+
+        context.Database.Refresh();
+
+        planetResponse = client.GetData<ApiAdminUserPlanetsResponse>($"/api/v3/admin/users/name/{updated.Username}/planets");
+        Assert.That(planetResponse?.Data, Is.Not.Null);
+        Assert.That(planetResponse!.Data!.Lbp3PlanetsHash, Is.EqualTo("lol"));
+
+        resetResponse = await client.DeleteAsync($"/api/v3/admin/users/name/{updated.Username}/planets");
+        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
+
+        context.Database.Refresh();
+
+        updated = context.Database.GetUserByObjectId(updated.UserId);
+        Assert.That(updated, Is.Not.Null);
+        Assert.That(updated!.Lbp3PlanetsHash.IsBlankHash(), Is.True);
+
+        // username
+        context.Database.UpdateUserData(updated, new SerializedUpdateData()
+        {
+            PlanetsHash = "lol"
+        }, TokenGame.LittleBigPlanetVita);
+
+        context.Database.Refresh();
+
+        planetResponse = client.GetData<ApiAdminUserPlanetsResponse>($"/api/v3/admin/users/username/{updated.Username}/planets");
+        Assert.That(planetResponse?.Data, Is.Not.Null);
+        Assert.That(planetResponse!.Data!.VitaPlanetsHash, Is.EqualTo("lol"));
+
+        resetResponse = await client.DeleteAsync($"/api/v3/admin/users/username/{updated.Username}/planets");
+        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
+
+        context.Database.Refresh();
+
+        updated = context.Database.GetUserByObjectId(updated.UserId);
+        Assert.That(updated, Is.Not.Null);
+        Assert.That(updated!.VitaPlanetsHash.IsBlankHash(), Is.True);
+    }
+}

--- a/RefreshTests.GameServer/Tests/ApiV3/LeaderboardApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/LeaderboardApiTests.cs
@@ -1,0 +1,32 @@
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Levels;
+using Refresh.Database.Models.Users;
+
+namespace RefreshTests.GameServer.Tests.ApiV3;
+
+public class LeaderboardApiTests : GameServerTest
+{
+    [Test]
+    public async Task DeletesScoresByPublisherUuidAndName()
+    {
+        using TestContext context = this.GetServer();
+        GameUser mod = context.CreateUser(role: GameUserRole.Moderator);
+        GameLevel level = context.CreateLevel(mod);
+        GameUser publisher = context.CreateUser(role: GameUserRole.User);
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
+
+        // UUID
+        context.SubmitScore(4000001, 1, level, publisher, TokenGame.LittleBigPlanet1, TokenPlatform.RPCS3, [publisher]);
+        Assert.That(context.Database.GetTopScoresForLevel(level, 100, 0, 1).TotalItems, Is.EqualTo(1)); // TODO: Use total score by publisher
+        HttpResponseMessage resetResponse = await client.DeleteAsync($"/api/v3/admin/users/uuid/{publisher.UserId}/scores");
+        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTopScoresForLevel(level, 100, 0, 1).TotalItems, Is.Zero);
+
+        // name
+        context.SubmitScore(4000001, 1, level, publisher, TokenGame.LittleBigPlanet1, TokenPlatform.RPCS3, [publisher]);
+        Assert.That(context.Database.GetTopScoresForLevel(level, 100, 0, 1).TotalItems, Is.EqualTo(1));
+        resetResponse = await client.DeleteAsync($"/api/v3/admin/users/name/{publisher.Username}/scores");
+        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTopScoresForLevel(level, 100, 0, 1).TotalItems, Is.Zero);
+    }
+}

--- a/RefreshTests.GameServer/Tests/ApiV3/MatchingApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/MatchingApiTests.cs
@@ -23,14 +23,12 @@ public class MatchingApiTests : GameServerTest
         match.Initialize();
         GameRoom room = match.CreateRoomByPlayer(player, TokenPlatform.PS3, TokenGame.LittleBigPlanet2, NatType.Open);
         
+        // UUID
         ApiResponse<ApiGameRoomResponse>? response = context.Http.GetData<ApiGameRoomResponse>($"/api/v3/rooms/uuid/{player.UserId}");
         Assert.That(response?.Data, Is.Not.Null);
         Assert.That(response!.Data!.RoomId.ToString(), Is.EqualTo(room.RoomId.ToString()));
 
-        response = context.Http.GetData<ApiGameRoomResponse>($"/api/v3/rooms/username/{player.Username}");
-        Assert.That(response?.Data, Is.Not.Null);
-        Assert.That(response!.Data!.RoomId.ToString(), Is.EqualTo(room.RoomId.ToString()));
-
+        // name
         response = context.Http.GetData<ApiGameRoomResponse>($"/api/v3/rooms/name/{player.Username}");
         Assert.That(response?.Data, Is.Not.Null);
         Assert.That(response!.Data!.RoomId.ToString(), Is.EqualTo(room.RoomId.ToString()));

--- a/RefreshTests.GameServer/Tests/ApiV3/MatchingApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/MatchingApiTests.cs
@@ -1,0 +1,38 @@
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Users;
+using Refresh.Core.Configuration;
+using Refresh.Core.Services;
+using Refresh.Core.Types.Matching;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Users.Rooms;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
+using RefreshTests.GameServer.Extensions;
+
+namespace RefreshTests.GameServer.Tests.ApiV3;
+
+public class MatchingApiTests : GameServerTest
+{
+    [Test]
+    public void GetsRoomByUserUuidAndName()
+    {
+        using TestContext context = this.GetServer();
+        GameUser player = context.CreateUser();
+        GameServerConfig config = context.Server.Value.GameServerConfig;
+        config.PermitShowingOnlineUsers = true;
+
+        MatchService match = context.GetService<MatchService>();
+        match.Initialize();
+        GameRoom room = match.CreateRoomByPlayer(player, TokenPlatform.PS3, TokenGame.LittleBigPlanet2, NatType.Open);
+        
+        ApiResponse<ApiGameRoomResponse>? response = context.Http.GetData<ApiGameRoomResponse>($"/api/v3/rooms/uuid/{player.UserId}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.RoomId.ToString(), Is.EqualTo(room.RoomId.ToString()));
+
+        response = context.Http.GetData<ApiGameRoomResponse>($"/api/v3/rooms/username/{player.Username}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.RoomId.ToString(), Is.EqualTo(room.RoomId.ToString()));
+
+        response = context.Http.GetData<ApiGameRoomResponse>($"/api/v3/rooms/name/{player.Username}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.RoomId.ToString(), Is.EqualTo(room.RoomId.ToString()));
+    }
+}

--- a/RefreshTests.GameServer/Tests/ApiV3/PhotoApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/PhotoApiTests.cs
@@ -1,0 +1,79 @@
+using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
+using RefreshTests.GameServer.Extensions;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Users.Photos;
+using Refresh.Database.Models.Authentication;
+
+namespace RefreshTests.GameServer.Tests.ApiV3;
+
+public class PhotoApiTests : GameServerTest
+{
+    private const string TEST_IMAGE_HASH = "0ec63b140374ba704a58fa0c743cb357683313dd";
+
+    [Test]
+    public void GetsPhotosByUserUuidAndName()
+    {
+        using TestContext context = this.GetServer();
+        GameUser player = context.CreateUser();
+        context.CreatePhotoWithSubject(player, TEST_IMAGE_HASH);
+        
+        ApiListResponse<ApiGamePhotoResponse>? response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/by/uuid/{player.UserId}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Count, Is.EqualTo(1));
+
+        response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/by/username/{player.Username}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Count, Is.EqualTo(1));
+
+        response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/by/name/{player.Username}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GetsPhotosWithUserUuidAndName()
+    {
+        using TestContext context = this.GetServer();
+        GameUser player = context.CreateUser();
+        context.CreatePhotoWithSubject(player, TEST_IMAGE_HASH);
+        
+        ApiListResponse<ApiGamePhotoResponse>? response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/with/uuid/{player.UserId}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Count, Is.EqualTo(1));
+
+        response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/with/username/{player.Username}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Count, Is.EqualTo(1));
+
+        response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/with/name/{player.Username}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeletesAllPhotosByUserUuidAndName()
+    {
+        using TestContext context = this.GetServer();
+        GameUser player = context.CreateUser(role: GameUserRole.User);
+        GameUser mod = context.CreateUser(role: GameUserRole.Moderator);
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
+
+        // UUID
+        context.CreatePhotoWithSubject(player, TEST_IMAGE_HASH);
+        HttpResponseMessage resetResponse = await client.DeleteAsync($"/api/v3/admin/users/uuid/{player.UserId}/photos");
+        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTotalPhotosByUser(player), Is.Zero);
+
+        // name
+        context.CreatePhotoWithSubject(player, TEST_IMAGE_HASH);
+        resetResponse = await client.DeleteAsync($"/api/v3/admin/users/name/{player.Username}/photos");
+        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTotalPhotosByUser(player), Is.Zero);
+
+        // username
+        context.CreatePhotoWithSubject(player, TEST_IMAGE_HASH);
+        resetResponse = await client.DeleteAsync($"/api/v3/admin/users/username/{player.Username}/photos");
+        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTotalPhotosByUser(player), Is.Zero);
+    }
+}

--- a/RefreshTests.GameServer/Tests/ApiV3/PhotoApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/PhotoApiTests.cs
@@ -21,10 +21,6 @@ public class PhotoApiTests : GameServerTest
         Assert.That(response?.Data, Is.Not.Null);
         Assert.That(response!.Data!.Count, Is.EqualTo(1));
 
-        response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/by/username/{player.Username}");
-        Assert.That(response?.Data, Is.Not.Null);
-        Assert.That(response!.Data!.Count, Is.EqualTo(1));
-
         response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/by/name/{player.Username}");
         Assert.That(response?.Data, Is.Not.Null);
         Assert.That(response!.Data!.Count, Is.EqualTo(1));
@@ -38,10 +34,6 @@ public class PhotoApiTests : GameServerTest
         context.CreatePhotoWithSubject(player, TEST_IMAGE_HASH);
         
         ApiListResponse<ApiGamePhotoResponse>? response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/with/uuid/{player.UserId}");
-        Assert.That(response?.Data, Is.Not.Null);
-        Assert.That(response!.Data!.Count, Is.EqualTo(1));
-
-        response = context.Http.GetList<ApiGamePhotoResponse>($"/api/v3/photos/with/username/{player.Username}");
         Assert.That(response?.Data, Is.Not.Null);
         Assert.That(response!.Data!.Count, Is.EqualTo(1));
 
@@ -67,12 +59,6 @@ public class PhotoApiTests : GameServerTest
         // name
         context.CreatePhotoWithSubject(player, TEST_IMAGE_HASH);
         resetResponse = await client.DeleteAsync($"/api/v3/admin/users/name/{player.Username}/photos");
-        Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
-        Assert.That(context.Database.GetTotalPhotosByUser(player), Is.Zero);
-
-        // username
-        context.CreatePhotoWithSubject(player, TEST_IMAGE_HASH);
-        resetResponse = await client.DeleteAsync($"/api/v3/admin/users/username/{player.Username}/photos");
         Assert.That(resetResponse.IsSuccessStatusCode, Is.True);
         Assert.That(context.Database.GetTotalPhotosByUser(player), Is.Zero);
     }


### PR DESCRIPTION
Deduplicates such API endpoints by not having 2 whole endpoint methods per endpoint (one for users specified by username, one for users specified by UUID) by using the new `GetUserByIdAndType` database method to allow multi-key lookups in a single endpoint method per endpoint.

TODO: Although I've manually tested some of these endpoints, unit tests would be good for this. These will be many new tests though, but I've already finished a few of them.

EDIT: The tests I've just added cover most but not all modified endpoints, but I think these should be enough already.