### PR TITLE
Prevent moderators from updating and punishing other mods and admins

### DIFF
--- a/Refresh.Core/Extensions/GameUserExtensions.cs
+++ b/Refresh.Core/Extensions/GameUserExtensions.cs
@@ -14,4 +14,17 @@ public static class GameUserExtensions
 
         return false;
     }
+
+    public static bool MayModifyUser(this GameUser user, GameUser targetUser)
+    {
+        // Users who are not at least a moderator may not update anyone else.
+        if (user.Role < GameUserRole.Moderator)
+            return false;
+
+        // Only admins may modify everyone, even other admins. Moderators may not modify other moderators and no admins either.
+        if (user.Role < GameUserRole.Admin && targetUser.Role >= GameUserRole.Moderator)
+            return false;
+
+        return true;
+    }
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserPunishmentApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserPunishmentApiEndpoints.cs
@@ -55,7 +55,7 @@ public class AdminUserPunishmentApiEndpoints : EndpointGroup
     [ApiV3Endpoint("admin/users/{idType}/{id}/pardon", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
     [DocSummary("Pardons all punishments for the given user.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    [DocError(typeof(ApiValidationError), ApiValidationError.MayNotModifyUserDueToLowRoleErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.UserIsAlreadyPardonedErrorWhen)]
     public ApiOkResponse PardonUser(RequestContext context, GameDatabaseContext database, GameUser user,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
         [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
@@ -63,8 +63,8 @@ public class AdminUserPunishmentApiEndpoints : EndpointGroup
         GameUser? targetUser = database.GetUserByIdAndType(idType, id);
         if (targetUser == null) return ApiNotFoundError.UserMissingError;
 
-        if (!user.MayModifyUser(targetUser))
-            return ApiValidationError.MayNotModifyUserDueToLowRoleError;
+        if (targetUser.Role > GameUserRole.Restricted)
+            return ApiValidationError.UserIsAlreadyPardonedError;
         
         database.SetUserRole(targetUser, GameUserRole.User);
         return new ApiOkResponse();

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserPunishmentApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserPunishmentApiEndpoints.cs
@@ -17,44 +17,56 @@ public class AdminUserPunishmentApiEndpoints : EndpointGroup
     [ApiV3Endpoint("admin/users/{idType}/{id}/ban", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
     [DocSummary("Bans a user for the specified reason until the given date.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.MayNotModifyUserDueToLowRoleErrorWhen)]
     [DocRequestBody(typeof(ApiPunishUserRequest))]
-    public ApiOkResponse BanUser(RequestContext context, GameDatabaseContext database, ApiPunishUserRequest body,
+    public ApiOkResponse BanUser(RequestContext context, GameDatabaseContext database, ApiPunishUserRequest body, GameUser user,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
         [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByIdAndType(idType, id);
-        if (user == null) return ApiNotFoundError.UserMissingError;
+        GameUser? targetUser = database.GetUserByIdAndType(idType, id);
+        if (targetUser == null) return ApiNotFoundError.UserMissingError;
         
-        database.BanUser(user, body.Reason, body.ExpiryDate);
+        if (!user.MayModifyUser(targetUser))
+            return ApiValidationError.MayNotModifyUserDueToLowRoleError;
+
+        database.BanUser(targetUser, body.Reason, body.ExpiryDate);
         return new ApiOkResponse();
     }
     
     [ApiV3Endpoint("admin/users/{idType}/{id}/restrict", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
     [DocSummary("Restricts a user for the specified reason until the given date.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.MayNotModifyUserDueToLowRoleErrorWhen)]
     [DocRequestBody(typeof(ApiPunishUserRequest))]
-    public ApiOkResponse RestrictUser(RequestContext context, GameDatabaseContext database, ApiPunishUserRequest body,
+    public ApiOkResponse RestrictUser(RequestContext context, GameDatabaseContext database, ApiPunishUserRequest body, GameUser user,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
         [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByIdAndType(idType, id);
-        if (user == null) return ApiNotFoundError.UserMissingError;
+        GameUser? targetUser = database.GetUserByIdAndType(idType, id);
+        if (targetUser == null) return ApiNotFoundError.UserMissingError;
         
-        database.RestrictUser(user, body.Reason, body.ExpiryDate);
+        if (!user.MayModifyUser(targetUser))
+            return ApiValidationError.MayNotModifyUserDueToLowRoleError;
+
+        database.RestrictUser(targetUser, body.Reason, body.ExpiryDate);
         return new ApiOkResponse();
     }
     
     [ApiV3Endpoint("admin/users/{idType}/{id}/pardon", HttpMethods.Post), MinimumRole(GameUserRole.Moderator)]
     [DocSummary("Pardons all punishments for the given user.")]
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.UserMissingErrorWhen)]
-    public ApiOkResponse PardonUser(RequestContext context, GameDatabaseContext database,
+    [DocError(typeof(ApiValidationError), ApiValidationError.MayNotModifyUserDueToLowRoleErrorWhen)]
+    public ApiOkResponse PardonUser(RequestContext context, GameDatabaseContext database, GameUser user,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
         [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
     {
-        GameUser? user = database.GetUserByIdAndType(idType, id);
-        if (user == null) return ApiNotFoundError.UserMissingError;
+        GameUser? targetUser = database.GetUserByIdAndType(idType, id);
+        if (targetUser == null) return ApiNotFoundError.UserMissingError;
+
+        if (!user.MayModifyUser(targetUser))
+            return ApiValidationError.MayNotModifyUserDueToLowRoleError;
         
-        database.SetUserRole(user, GameUserRole.User);
+        database.SetUserRole(targetUser, GameUserRole.User);
         return new ApiOkResponse();
     }
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
@@ -71,6 +71,9 @@ public class ApiValidationError : ApiError
     public const string WrongRoleUpdateMethodErrorWhen = "The specified role cannot be assigned to the user using this endpoint.";
     public static readonly ApiValidationError WrongRoleUpdateMethodError = new(WrongRoleUpdateMethodErrorWhen);
 
+    public const string UserIsAlreadyPardonedErrorWhen = "This user has no punishments, they are already pardoned.";
+    public static readonly ApiValidationError UserIsAlreadyPardonedError = new(UserIsAlreadyPardonedErrorWhen);
+
     public const string RoleMissingErrorWhen = "The specified role does not exist.";
     public static readonly ApiValidationError RoleMissingError = new(RoleMissingErrorWhen);
 

--- a/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
@@ -65,6 +65,9 @@ public class ApiValidationError : ApiError
     public const string MayNotOverwriteRoleErrorWhen = "You may not overwrite user roles because you are not an admin";
     public static readonly ApiValidationError MayNotOverwriteRoleError = new(MayNotOverwriteRoleErrorWhen);
 
+    public const string MayNotModifyUserDueToLowRoleErrorWhen = "You may not modify this user because their role is above yours, or the same as yours incase you're not an admin.";
+    public static readonly ApiValidationError MayNotModifyUserDueToLowRoleError = new(MayNotModifyUserDueToLowRoleErrorWhen);
+
     public const string WrongRoleUpdateMethodErrorWhen = "The specified role cannot be assigned to the user using this endpoint.";
     public static readonly ApiValidationError WrongRoleUpdateMethodError = new(WrongRoleUpdateMethodErrorWhen);
 


### PR DESCRIPTION
Doesn't prevent mods from doing anything else against other mods and admins (they may still moderate their levels and other similar content), but mods may no longer restrict, ban, delete, update, rename and reset the password of other mods and admins. Admins may still do anything to other admins.
This PR also adds tests for the above.

Edit: This now also prevents unpunished users from being pardoned, since that always sets the target user's role to user, meaning that users with a higher role could have their role set back to user this way.