### PR TITLE
Playlist API endpoints

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Playlists.cs
+++ b/Refresh.Database/GameDatabaseContext.Playlists.cs
@@ -108,19 +108,19 @@ public partial class GameDatabaseContext // Playlists
     public GamePlaylist? GetUserRootPlaylist(GameUser user)
         => this.GamePlaylistsIncluded.FirstOrDefault(p => p.IsRoot && p.PublisherId == user.UserId);
 
-    public void UpdatePlaylist(GamePlaylist playlist, ISerializedCreatePlaylistInfo updateInfo)
+    public GamePlaylist UpdatePlaylist(GamePlaylist playlist, ISerializedCreatePlaylistInfo updateInfo)
     {
         GameLocation location = updateInfo.Location ?? new GameLocation(playlist.LocationX, playlist.LocationY);
         
-        this.Write(() =>
-        {
-            playlist.Name = updateInfo.Name ?? playlist.Name;
-            playlist.Description = updateInfo.Description ?? playlist.Description;
-            playlist.IconHash = updateInfo.Icon ?? playlist.IconHash;
-            playlist.LocationX = location.X;
-            playlist.LocationY = location.Y;
-            playlist.LastUpdateDate = this._time.Now;
-        });
+        playlist.Name = updateInfo.Name ?? playlist.Name;
+        playlist.Description = updateInfo.Description ?? playlist.Description;
+        playlist.IconHash = updateInfo.Icon ?? playlist.IconHash;
+        playlist.LocationX = location.X;
+        playlist.LocationY = location.Y;
+        playlist.LastUpdateDate = this._time.Now;
+        this.SaveChanges();
+
+        return playlist;
     }
 
     public void DeletePlaylist(GamePlaylist playlist)

--- a/Refresh.Database/Query/ISerializedCreatePlaylistInfo.cs
+++ b/Refresh.Database/Query/ISerializedCreatePlaylistInfo.cs
@@ -4,8 +4,8 @@ namespace Refresh.Database.Query;
 
 public interface ISerializedCreatePlaylistInfo
 {
-    string Name { get; }
-    string Description { get; }
+    string? Name { get; }
+    string? Description { get; }
     string? Icon { get; }
     GameLocation? Location { get; }
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiNotFoundError.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiNotFoundError.cs
@@ -39,7 +39,16 @@ public class ApiNotFoundError : ApiError
 
     public const string VerifiedIpMissingErrorWhen = "The verified IP could not be found";
     public static readonly ApiNotFoundError VerifiedIpMissingError = new(VerifiedIpMissingErrorWhen);
-    
+
+    public const string PlaylistMissingErrorWhen = "The playlist could not be found";
+    public static readonly ApiNotFoundError PlaylistMissingError = new(PlaylistMissingErrorWhen);
+
+    public const string ParentPlaylistMissingErrorWhen = "The parent playlist could not be found";
+    public static readonly ApiNotFoundError ParentPlaylistMissingError = new(ParentPlaylistMissingErrorWhen);
+
+    public const string SubPlaylistMissingErrorWhen = "The sub-playlist could not be found";
+    public static readonly ApiNotFoundError SubPlaylistMissingError = new(SubPlaylistMissingErrorWhen);
+
     private ApiNotFoundError() : base("The requested resource was not found", NotFound)
     {}
     

--- a/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
@@ -17,6 +17,9 @@ public class ApiValidationError : ApiError
     public const string IpAddressParseErrorWhen = "The IP address could not be parsed by the server";
     public static readonly ApiValidationError IpAddressParseError = new(IpAddressParseErrorWhen);
 
+    public const string InvalidPlaylistIdWhen = "The playlist ID couldn't be parsed by the server";
+    public static readonly ApiValidationError InvalidPlaylistId = new(InvalidPlaylistIdWhen);
+
     public const string NoPhotoDeletionPermissionErrorWhen = "You do not have permission to delete someone else's photo";
     public static readonly ApiValidationError NoPhotoDeletionPermissionError = new(NoPhotoDeletionPermissionErrorWhen);
 
@@ -52,6 +55,12 @@ public class ApiValidationError : ApiError
 
     public const string BodyMustBeImageErrorWhen = "The asset must be a PNG/JPEG file";
     public static readonly ApiValidationError BodyMustBeImageError = new(BodyMustBeImageErrorWhen);
+
+    public const string IconMustBeImageErrorWhen = "The icon must be a PNG/JPEG file";
+    public static readonly ApiValidationError IconMustBeImageError = new(IconMustBeImageErrorWhen);
+
+    public const string IconMissingErrorWhen = "The icon is missing from the server";
+    public static readonly ApiValidationError IconMissingError = new(IconMissingErrorWhen);
     
     public const string ResourceExistsErrorWhen = "The resource you are attempting to create already exists.";
     public static readonly ApiValidationError ResourceExistsError = new(ResourceExistsErrorWhen);
@@ -88,7 +97,13 @@ public class ApiValidationError : ApiError
 
     public const string UsernameTakenErrorWhen = "This username is already taken!";
     public static readonly ApiValidationError UsernameTakenError = new(UsernameTakenErrorWhen);
-    
+
+    public const string NoPlaylistEditPermissionErrorWhen = "You do not have permission to update this playlist";
+    public static readonly ApiValidationError NoPlaylistEditPermissionError = new(NoPlaylistEditPermissionErrorWhen);
+
+    public const string NoPlaylistDeletePermissionErrorWhen = "You do not have permission to delete this playlist";
+    public static readonly ApiValidationError NoPlaylistDeletionPermissionError = new(NoPlaylistDeletePermissionErrorWhen);
+
     // TODO: Split off error messages which are actually 401 or anything else that isn't 400
     public ApiValidationError(string message) : base(message) {}
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiValidationError.cs
@@ -102,7 +102,7 @@ public class ApiValidationError : ApiError
     public static readonly ApiValidationError NoPlaylistEditPermissionError = new(NoPlaylistEditPermissionErrorWhen);
 
     public const string NoPlaylistDeletePermissionErrorWhen = "You do not have permission to delete this playlist";
-    public static readonly ApiValidationError NoPlaylistDeletionPermissionError = new(NoPlaylistDeletePermissionErrorWhen);
+    public static readonly ApiValidationError NoPlaylistDeletePermissionError = new(NoPlaylistDeletePermissionErrorWhen);
 
     // TODO: Split off error messages which are actually 401 or anything else that isn't 400
     public ApiValidationError(string message) : base(message) {}

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Request/ApiPlaylistCreationRequest.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Request/ApiPlaylistCreationRequest.cs
@@ -1,0 +1,13 @@
+using Refresh.Database.Models;
+using Refresh.Database.Query;
+
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiPlaylistCreationRequest : ISerializedCreatePlaylistInfo
+{
+    public string? Name { get; set; }
+    public string? Icon { get; set; }
+    public string? Description { get; set; }
+    public GameLocation? Location { get; set; }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Playlists/ApiGamePlaylistOwnRelationsResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Playlists/ApiGamePlaylistOwnRelationsResponse.cs
@@ -1,0 +1,20 @@
+using Refresh.Core.Types.Data;
+using Refresh.Database.Models.Playlists;
+
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Playlists;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiGamePlaylistOwnRelationsResponse
+{
+    public bool IsHearted { get; set; }
+
+    public static ApiGamePlaylistOwnRelationsResponse? FromOld(GamePlaylist? old, DataContext dataContext)
+    {
+        if (old == null || dataContext.User == null) return null;
+
+        return new()
+        {
+            IsHearted = dataContext.Database.IsPlaylistFavouritedByUser(old, dataContext.User),
+        };
+    }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Playlists/ApiGamePlaylistResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Playlists/ApiGamePlaylistResponse.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics;
+using Refresh.Core.Types.Data;
+using Refresh.Database.Models.Playlists;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Data;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Users;
+
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Playlists;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiGamePlaylistResponse : IApiResponse, IDataConvertableFrom<ApiGamePlaylistResponse, GamePlaylist>
+{
+    public required int PlaylistId { get; set; }
+    public required ApiGameUserResponse? Publisher { get; set; }
+
+    public required string Name { get; set; }
+    public required string IconHash { get; set; }
+    public required string Description { get; set; }
+    public required ApiGameLocationResponse Location { get; set; }
+
+    public required DateTimeOffset CreationDate { get; set; }
+    public required DateTimeOffset UpdateDate { get; set; }
+
+    public ApiGamePlaylistStatisticsResponse? Statistics { get; set; }
+    public ApiGamePlaylistOwnRelationsResponse? OwnRelations { get; set; }
+
+    public static ApiGamePlaylistResponse? FromOld(GamePlaylist? playlist, DataContext dataContext)
+    {
+        if (playlist == null) return null;
+
+        if (playlist.Statistics == null)
+            dataContext.Database.RecalculatePlaylistStatistics(playlist);
+
+        Debug.Assert(playlist.Statistics != null);
+
+        return new()
+        {
+            PlaylistId = playlist.PlaylistId,
+            Publisher = ApiGameUserResponse.FromOld(playlist.Publisher, dataContext),
+            Name = playlist.Name,
+            IconHash = dataContext.GetIconFromHash(playlist.IconHash),
+            Description = playlist.Description,
+            Location = ApiGameLocationResponse.FromLocation(playlist.LocationX, playlist.LocationY)!,
+            CreationDate = playlist.CreationDate,
+            UpdateDate = playlist.LastUpdateDate,
+            Statistics = ApiGamePlaylistStatisticsResponse.FromOld(playlist.Statistics, dataContext),
+            OwnRelations = ApiGamePlaylistOwnRelationsResponse.FromOld(playlist, dataContext),
+        };
+    }
+
+    public static IEnumerable<ApiGamePlaylistResponse> FromOldList(IEnumerable<GamePlaylist> oldList, DataContext dataContext) 
+        => oldList.Select(old => FromOld(old, dataContext)).ToList()!;
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Playlists/ApiGamePlaylistStatisticsResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/Playlists/ApiGamePlaylistStatisticsResponse.cs
@@ -1,0 +1,26 @@
+using Refresh.Core.Types.Data;
+using Refresh.Database.Models.Statistics;
+
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Playlists;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiGamePlaylistStatisticsResponse
+{
+    public required int Levels { get; set; }
+    public required int SubPlaylists { get; set; }
+    public required int ParentPlaylists { get; set; }
+    public required int Hearts { get; set; }
+
+    public static ApiGamePlaylistStatisticsResponse? FromOld(GamePlaylistStatistics? old, DataContext dataContext)
+    {
+        if (old == null) return null;
+
+        return new()
+        {
+            Levels = old.LevelCount,
+            SubPlaylists = old.SubPlaylistCount,
+            ParentPlaylists = old.ParentPlaylistCount,
+            Hearts = old.FavouriteCount,
+        };
+    }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/PlaylistApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/PlaylistApiEndpoints.cs
@@ -1,0 +1,243 @@
+using AttribDoc.Attributes;
+using Bunkum.Core;
+using Bunkum.Core.Endpoints;
+using Bunkum.Core.RateLimit;
+using Bunkum.Protocols.Http;
+using Refresh.Common.Constants;
+using Refresh.Core.Services;
+using Refresh.Core.Types.Data;
+using Refresh.Database;
+using Refresh.Database.Models.Assets;
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Levels;
+using Refresh.Database.Models.Playlists;
+using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Playlists;
+using static Refresh.Core.RateLimits.PlaylistEndpointLimits;
+
+namespace Refresh.Interfaces.APIv3.Endpoints;
+
+public class PlaylistApiEndpoints : EndpointGroup
+{
+    private ApiError? ValidatePlaylist(ApiPlaylistCreationRequest body, GuidCheckerService guidChecker, GameDatabaseContext database)
+    {
+        if (!body.Icon.IsBlankHash())
+        {
+            // playlists only have icons in LBP1 and LBP1-like beta builds, so arbitrarily pass LBP1
+            if (body.Icon!.StartsWith('g'))
+            {
+                if (!guidChecker.IsTextureGuid(TokenGame.LittleBigPlanet1, long.Parse(body.Icon)))
+                    return ApiValidationError.InvalidTextureGuidError;
+            }
+            else
+            {
+                GameAsset? icon = database.GetAssetFromHash(body.Icon);
+
+                if (icon == null) 
+                    return ApiValidationError.IconMissingError;
+
+                if (icon.AssetType is not GameAssetType.Jpeg and not GameAssetType.Png)
+                    return ApiValidationError.IconMustBeImageError;
+            }
+        }
+
+        // Trim name and description
+        if (body.Name != null && body.Name.Length > UgcLimits.TitleLimit) 
+            body.Name = body.Name[..UgcLimits.TitleLimit];
+
+        if (body.Description != null && body.Description.Length > UgcLimits.DescriptionLimit)
+            body.Description = body.Description[..UgcLimits.DescriptionLimit];
+
+        // Ensure the coordinates are in a valid range (TODO: store and load coordinates as ushort)
+        if (body.Location != null)
+        {
+            body.Location.X = Math.Clamp(body.Location.X, 0, ushort.MaxValue);
+            body.Location.Y = Math.Clamp(body.Location.Y, 0, ushort.MaxValue);
+        }
+
+        return null;
+    }
+
+    [ApiV3Endpoint("playlists", HttpMethods.Post)]
+    [DocSummary("Posts a new playlist")]
+    [DocError(typeof(ApiValidationError), ApiValidationError.InvalidPlaylistIdWhen)]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ParentPlaylistMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.NoPlaylistEditPermissionErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.IconMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.IconMustBeImageErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.InvalidTextureGuidErrorWhen)]
+    [RateLimitSettings(UploadTimeoutDuration, MaxCreateAmount, UploadBlockDuration, CreateBucket)]
+    [DocQueryParam("parentId", "If set, the new playlist will be added to the playlist specified by ID here instead of the root playlist. "
+        + "If the specified playlist doesn't exist or is not owned by the user calling this endpoint, nothing will happen.")]
+    public ApiResponse<ApiGamePlaylistResponse> CreatePlaylist(RequestContext context, DataContext dataContext,
+        GameUser user, ApiPlaylistCreationRequest body)
+    {
+        ApiError? error = this.ValidatePlaylist(body, dataContext.GuidChecker, dataContext.Database);
+        if (error != null) return error;
+
+        string? parentIdStr = context.QueryString.Get("parentId");
+        GamePlaylist? parent;
+
+        if (parentIdStr != null)
+        {
+            bool parsed = int.TryParse(parentIdStr, out int parentId);
+            if (!parsed) return ApiValidationError.InvalidPlaylistId;
+
+            parent = dataContext.Database.GetPlaylistById(parentId);
+            if (parent == null) return ApiNotFoundError.ParentPlaylistMissingError;
+
+            if (parent.PublisherId != user.UserId) 
+                return ApiValidationError.NoPlaylistEditPermissionError;
+        }
+        else
+        {
+            // Get the root playlist. If the user has none yet, create a new one.
+            parent = dataContext.Database.GetUserRootPlaylist(user) 
+                ?? dataContext.Database.CreateRootPlaylist(user);
+        }
+
+        GamePlaylist playlist = dataContext.Database.CreatePlaylist(user, body, false);
+        dataContext.Database.AddPlaylistToPlaylist(playlist, parent);
+
+        return ApiGamePlaylistResponse.FromOld(playlist, dataContext);
+    }
+
+    [ApiV3Endpoint("playlists/id/{id}", HttpMethods.Patch)]
+    [DocSummary("Updates an existing playlist specified by ID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.PlaylistMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.NoPlaylistEditPermissionErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.IconMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.IconMustBeImageErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.InvalidTextureGuidErrorWhen)]
+    [RateLimitSettings(UploadTimeoutDuration, MaxUpdateAmount, UploadBlockDuration, UpdateBucket)]
+    public ApiResponse<ApiGamePlaylistResponse> UpdatePlaylist(RequestContext context, DataContext dataContext,
+        GameUser user, ApiPlaylistCreationRequest body, int id)
+    {
+        GamePlaylist? playlist = dataContext.Database.GetPlaylistById(id);
+        if (playlist == null) return ApiNotFoundError.PlaylistMissingError;
+
+        if (user.UserId != playlist.PublisherId) 
+            return ApiValidationError.NoPlaylistEditPermissionError;
+
+        ApiError? error = this.ValidatePlaylist(body, dataContext.GuidChecker, dataContext.Database);
+        if (error != null) return error;
+
+        playlist = dataContext.Database.UpdatePlaylist(playlist, body);
+        return ApiGamePlaylistResponse.FromOld(playlist, dataContext);
+    }
+
+    [ApiV3Endpoint("playlists/id/{id}", HttpMethods.Delete)]
+    [DocSummary("Deletes an existing playlist specified by ID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.PlaylistMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.NoPlaylistDeletePermissionErrorWhen)]
+    public ApiOkResponse DeletePlaylist(RequestContext context, DataContext dataContext,
+        GameUser user, int id)
+    {
+        GamePlaylist? playlist = dataContext.Database.GetPlaylistById(id);
+        if (playlist == null) return ApiNotFoundError.PlaylistMissingError;
+
+        if (user.UserId != playlist.PublisherId) 
+            return ApiValidationError.NoPlaylistDeletePermissionError;
+
+        dataContext.Database.DeletePlaylist(playlist);
+        return new ApiOkResponse();
+    }
+
+    [ApiV3Endpoint("playlists/id/{id}"), Authentication(false)]
+    [DocSummary("Gets a playlist specified by ID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.PlaylistMissingErrorWhen)]
+    public ApiResponse<ApiGamePlaylistResponse> GetPlaylistById(RequestContext context, DataContext dataContext, int id)
+    {
+        GamePlaylist? playlist = dataContext.Database.GetPlaylistById(id);
+        if (playlist == null) return ApiNotFoundError.PlaylistMissingError;
+
+        return ApiGamePlaylistResponse.FromOld(playlist, dataContext);
+    }
+
+    [ApiV3Endpoint("playlists/id/{playlistId}/addLevel/id/{levelId}", HttpMethods.Post)]
+    [DocSummary("Adds a level by ID to a playlist by ID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ParentPlaylistMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.NoPlaylistEditPermissionErrorWhen)]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
+    public ApiOkResponse AddLevelToPlaylist(RequestContext context, DataContext dataContext,
+        GameUser user, int playlistId, int levelId)
+    {
+        GamePlaylist? playlist = dataContext.Database.GetPlaylistById(playlistId);
+        if (playlist == null) return ApiNotFoundError.ParentPlaylistMissingError;
+
+        if (user.UserId != playlist.PublisherId) 
+            return ApiValidationError.NoPlaylistEditPermissionError;
+
+        GameLevel? level = dataContext.Database.GetLevelById(levelId);
+        if (level == null) return ApiNotFoundError.LevelMissingError;
+
+        dataContext.Database.AddLevelToPlaylist(level, playlist);
+        return new ApiOkResponse();
+    }
+
+    [ApiV3Endpoint("playlists/id/{playlistId}/removeLevel/id/{levelId}", HttpMethods.Post)]
+    [DocSummary("Removes a level by ID from a playlist by ID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ParentPlaylistMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.NoPlaylistEditPermissionErrorWhen)]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
+    public ApiOkResponse RemoveLevelFromPlaylist(RequestContext context, DataContext dataContext,
+        GameUser user, int playlistId, int levelId)
+    {
+        GamePlaylist? playlist = dataContext.Database.GetPlaylistById(playlistId);
+        if (playlist == null) return ApiNotFoundError.ParentPlaylistMissingError;
+
+        if (user.UserId != playlist.PublisherId) 
+            return ApiValidationError.NoPlaylistEditPermissionError;
+
+        GameLevel? level = dataContext.Database.GetLevelById(levelId);
+        if (level == null) return ApiNotFoundError.LevelMissingError;
+
+        dataContext.Database.RemoveLevelFromPlaylist(level, playlist);
+        return new ApiOkResponse();
+    }
+
+    [ApiV3Endpoint("playlists/id/{playlistId}/addPlaylist/id/{subPlaylistId}", HttpMethods.Post)]
+    [DocSummary("Adds a playlist by ID to another playlist by ID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ParentPlaylistMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.NoPlaylistEditPermissionErrorWhen)]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.SubPlaylistMissingErrorWhen)]
+    public ApiOkResponse AddPlaylistToPlaylist(RequestContext context, DataContext dataContext,
+        GameUser user, int playlistId, int subPlaylistId)
+    {
+        GamePlaylist? parent = dataContext.Database.GetPlaylistById(playlistId);
+        if (parent == null) return ApiNotFoundError.ParentPlaylistMissingError;
+
+        if (user.UserId != parent.PublisherId) 
+            return ApiValidationError.NoPlaylistEditPermissionError;
+
+        GamePlaylist? child = dataContext.Database.GetPlaylistById(subPlaylistId);
+        if (child == null) return ApiNotFoundError.SubPlaylistMissingError;
+
+        dataContext.Database.AddPlaylistToPlaylist(child, parent);
+        return new ApiOkResponse();
+    }
+
+    [ApiV3Endpoint("playlists/id/{playlistId}/removePlaylist/id/{subPlaylistId}", HttpMethods.Post)]
+    [DocSummary("Removes a playlist by ID from a playlist by ID")]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.ParentPlaylistMissingErrorWhen)]
+    [DocError(typeof(ApiValidationError), ApiValidationError.NoPlaylistEditPermissionErrorWhen)]
+    [DocError(typeof(ApiNotFoundError), ApiNotFoundError.SubPlaylistMissingErrorWhen)]
+    public ApiOkResponse RemovePlaylistFromPlaylist(RequestContext context, DataContext dataContext,
+        GameUser user, int playlistId, int subPlaylistId)
+    {
+        GamePlaylist? parent = dataContext.Database.GetPlaylistById(playlistId);
+        if (parent == null) return ApiNotFoundError.ParentPlaylistMissingError;
+
+        if (user.UserId != parent.PublisherId) 
+            return ApiValidationError.NoPlaylistEditPermissionError;
+
+        GamePlaylist? child = dataContext.Database.GetPlaylistById(subPlaylistId);
+        if (child == null) return ApiNotFoundError.SubPlaylistMissingError;
+
+        dataContext.Database.RemovePlaylistFromPlaylist(child, parent);
+        return new ApiOkResponse();
+    }
+}

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
@@ -72,11 +72,7 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
         if (body.Description != null && body.Description.Length > UgcLimits.DescriptionLimit)
             body.Description = body.Description[..UgcLimits.DescriptionLimit];
         
-        dataContext.Database.UpdatePlaylist(playlist, body);
-        
-        // get playlist from database a second time to respond with it in its updated state
-        // to have it immediately update in-game
-        GamePlaylist newPlaylist = dataContext.Database.GetPlaylistById(playlistId)!;
+        GamePlaylist newPlaylist = dataContext.Database.UpdatePlaylist(playlist, body);
         return new Response(SerializedLbp3Playlist.FromOld(newPlaylist, dataContext), ContentType.Xml);
     }
 

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -14,6 +14,8 @@ using Refresh.Database.Models.Levels;
 using Refresh.Interfaces.Game.Types.UserData.Leaderboard;
 using Refresh.Workers;
 using Refresh.Interfaces.Game.Endpoints.DataTypes.Request;
+using Refresh.Database.Models.Playlists;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
 
 namespace RefreshTests.GameServer;
 
@@ -195,6 +197,16 @@ public class TestContext : IDisposable
         Assert.That(submittedScore, Is.Not.Null);
 
         return submittedScore;
+    }
+
+    public GamePlaylist CreatePlaylist(GameUser author, string? title = null)
+    {
+        ApiPlaylistCreationRequest playlist = new()
+        {
+            Name = title
+        };
+
+        return this.Database.CreatePlaylist(author, playlist);
     }
 
     [Pure]

--- a/RefreshTests.GameServer/Tests/ApiV3/PlaylistApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/PlaylistApiTests.cs
@@ -1,0 +1,238 @@
+using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
+using RefreshTests.GameServer.Extensions;
+using Refresh.Database.Models.Authentication;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Playlists;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
+using Refresh.Database.Models.Playlists;
+using Refresh.Database.Models.Levels;
+using Refresh.Common.Constants;
+
+namespace RefreshTests.GameServer.Tests.ApiV3;
+
+public class PlaylistApiTests : GameServerTest
+{
+    [Test]
+    public void CreateAndUpdatePlaylist()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+        
+        // Create
+        ApiPlaylistCreationRequest request = new()
+        {
+            Name = "Hardest levels",
+            Description = "idk"
+        };
+        ApiResponse<ApiGamePlaylistResponse>? response = client.PostData<ApiGamePlaylistResponse>($"/api/v3/playlists", request);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Name, Is.EqualTo(request.Name));
+        Assert.That(response!.Data!.Description, Is.EqualTo(request.Description));
+        context.Database.Refresh();
+
+        // Ensure the playlist is in the root playlist
+        GamePlaylist? root = context.Database.GetUserRootPlaylist(user);
+        Assert.That(root, Is.Not.Null);
+        Assert.That(context.Database.GetPlaylistsInPlaylist(root!, 0, 100).Items.Any(p => p.PlaylistId == response.Data.PlaylistId), Is.True);
+        context.Database.Refresh();
+
+        // Update
+        ApiPlaylistCreationRequest update = new()
+        {
+            Description = "Read the description smh"
+        };
+        response = client.PatchData<ApiGamePlaylistResponse>($"/api/v3/playlists/id/{response.Data.PlaylistId}", update);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Name, Is.EqualTo(request.Name));
+        Assert.That(response!.Data!.Description, Is.EqualTo(update.Description));
+        Assert.That(response!.Data!.Description, Is.Not.EqualTo(request.Description));
+    }
+
+    [Test]
+    public void TrimPlaylistNameAndDescription()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+        
+        // Create
+        ApiPlaylistCreationRequest request = new()
+        {
+            Name = new string('S', 600),
+            Description = new string('S', 600)
+        };
+        ApiResponse<ApiGamePlaylistResponse>? response = client.PostData<ApiGamePlaylistResponse>($"/api/v3/playlists", request);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Name.Length, Is.EqualTo(UgcLimits.TitleLimit));
+        Assert.That(response!.Data!.Description.Length, Is.EqualTo(UgcLimits.DescriptionLimit));
+        context.Database.Refresh();
+
+        // Update
+        ApiPlaylistCreationRequest update = new()
+        {
+            Name = new string('S', 600),
+            Description = new string('S', 600)
+        };
+        response = client.PatchData<ApiGamePlaylistResponse>($"/api/v3/playlists/id/{response.Data.PlaylistId}", update);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Name.Length, Is.EqualTo(UgcLimits.TitleLimit));
+        Assert.That(response!.Data!.Description.Length, Is.EqualTo(UgcLimits.DescriptionLimit));
+    }
+
+    [Test]
+    public void ClampPlaylistLocation()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+        
+        // Create
+        ApiPlaylistCreationRequest request = new()
+        {
+            Location = new(1234567, -420)
+        };
+        ApiResponse<ApiGamePlaylistResponse>? response = client.PostData<ApiGamePlaylistResponse>($"/api/v3/playlists", request);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Location.X, Is.EqualTo(ushort.MaxValue));
+        Assert.That(response!.Data!.Location.Y, Is.Zero);
+        context.Database.Refresh();
+
+        // Update
+        ApiPlaylistCreationRequest update = new()
+        {
+            Location = new(-420, 510)
+        };
+        response = client.PatchData<ApiGamePlaylistResponse>($"/api/v3/playlists/id/{response.Data.PlaylistId}", update);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Location.X, Is.Zero);
+        Assert.That(response!.Data!.Location.Y, Is.EqualTo(update.Location.Y));
+    }
+
+    [Test]
+    public async Task GetAndDeletePlaylist()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GamePlaylist playlist = context.CreatePlaylist(user);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+
+        // Get (unauthenticated)
+        ApiPlaylistCreationRequest request = new()
+        {
+            Name = "Easiest levels",
+            Description = "for the skill issued"
+        };
+        ApiResponse<ApiGamePlaylistResponse>? response = context.Http.GetData<ApiGamePlaylistResponse>($"/api/v3/playlists/id/{playlist.PlaylistId}");
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.PlaylistId, Is.EqualTo(playlist.PlaylistId));
+
+        // Delete (authenticated)
+        HttpResponseMessage deletionResponse = await client.DeleteAsync($"/api/v3/playlists/id/{playlist.PlaylistId}");
+        Assert.That(deletionResponse, Is.Not.Null);
+        Assert.That(deletionResponse.IsSuccessStatusCode, Is.True);
+
+        GamePlaylist? postDeletionPlaylist = context.Database.GetPlaylistById(playlist.PlaylistId);
+        Assert.That(postDeletionPlaylist, Is.Null);
+    }
+
+    [Test]
+    public async Task AddAndRemoveLevelToPlaylist()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GameLevel level = context.CreateLevel(user);
+        GamePlaylist playlist = context.CreatePlaylist(user);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+
+        // Add
+        HttpResponseMessage response = await client.PostAsync($"/api/v3/playlists/id/{playlist.PlaylistId}/addLevel/id/{level.LevelId}", null);
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTotalLevelsInPlaylist(playlist), Is.EqualTo(1));
+        Assert.That(context.Database.GetTotalPlaylistsContainingLevel(level), Is.EqualTo(1));
+
+        // Remove
+        response = await client.PostAsync($"/api/v3/playlists/id/{playlist.PlaylistId}/removeLevel/id/{level.LevelId}", null);
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTotalLevelsInPlaylist(playlist), Is.Zero);
+        Assert.That(context.Database.GetTotalPlaylistsContainingLevel(level), Is.Zero);
+    }
+
+    [Test]
+    public async Task CantAddAndRemoveLevelToOthersPlaylist()
+    {
+        using TestContext context = this.GetServer();
+        GameUser creator = context.CreateUser();
+        GameUser moron = context.CreateUser();
+        GameLevel level = context.CreateLevel(moron);
+        GamePlaylist playlist = context.CreatePlaylist(creator);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, moron);
+
+        // Add (fail)
+        HttpResponseMessage response = await client.PostAsync($"/api/v3/playlists/id/{playlist.PlaylistId}/addLevel/id/{level.LevelId}", null);
+        Assert.That(response.IsSuccessStatusCode, Is.False);
+        Assert.That(context.Database.GetTotalLevelsInPlaylist(playlist), Is.Zero);
+        Assert.That(context.Database.GetTotalPlaylistsContainingLevel(level), Is.Zero);
+
+        // Add (prepare for removal)
+        context.Database.AddLevelToPlaylist(level, playlist);
+        Assert.That(context.Database.GetTotalLevelsInPlaylist(playlist), Is.EqualTo(1));
+        Assert.That(context.Database.GetTotalPlaylistsContainingLevel(level), Is.EqualTo(1));
+
+        // Remove
+        response = await client.PostAsync($"/api/v3/playlists/id/{playlist.PlaylistId}/removeLevel/id/{level.LevelId}", null);
+        Assert.That(response.IsSuccessStatusCode, Is.False);
+        Assert.That(context.Database.GetTotalLevelsInPlaylist(playlist), Is.EqualTo(1));
+        Assert.That(context.Database.GetTotalPlaylistsContainingLevel(level), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task AddAndRemovePlaylistToPlaylist()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        GamePlaylist parent = context.CreatePlaylist(user);
+        GamePlaylist child = context.CreatePlaylist(user);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+
+        // Add
+        HttpResponseMessage response = await client.PostAsync($"/api/v3/playlists/id/{parent.PlaylistId}/addPlaylist/id/{child.PlaylistId}", null);
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTotalPlaylistsInPlaylist(parent), Is.EqualTo(1));
+        Assert.That(context.Database.GetTotalPlaylistsContainingPlaylist(child), Is.EqualTo(1));
+
+        // Remove
+        response = await client.PostAsync($"/api/v3/playlists/id/{parent.PlaylistId}/removePlaylist/id/{child.PlaylistId}", null);
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+        Assert.That(context.Database.GetTotalPlaylistsInPlaylist(parent), Is.Zero);
+        Assert.That(context.Database.GetTotalPlaylistsContainingPlaylist(child), Is.Zero);
+    }
+
+    [Test]
+    public async Task CantAddAndRemovePlaylistToOthersPlaylist()
+    {
+        using TestContext context = this.GetServer();
+        GameUser creator = context.CreateUser();
+        GameUser moron = context.CreateUser();
+        GamePlaylist parent = context.CreatePlaylist(creator);
+        GamePlaylist child = context.CreatePlaylist(moron);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, moron);
+
+        // Add (fail)
+        HttpResponseMessage response = await client.PostAsync($"/api/v3/playlists/id/{parent.PlaylistId}/addPlaylist/id/{child.PlaylistId}", null);
+        Assert.That(response.IsSuccessStatusCode, Is.False);
+        Assert.That(context.Database.GetTotalPlaylistsInPlaylist(parent), Is.Zero);
+        Assert.That(context.Database.GetTotalPlaylistsContainingPlaylist(child), Is.Zero);
+
+        // Add (prepare for removal)
+        context.Database.AddPlaylistToPlaylist(child, parent);
+        Assert.That(context.Database.GetTotalPlaylistsInPlaylist(parent), Is.EqualTo(1));
+        Assert.That(context.Database.GetTotalPlaylistsContainingPlaylist(child), Is.EqualTo(1));
+
+        // Remove
+        response = await client.PostAsync($"/api/v3/playlists/id/{parent.PlaylistId}/removePlaylist/id/{child.PlaylistId}", null);
+        Assert.That(response.IsSuccessStatusCode, Is.False);
+        Assert.That(context.Database.GetTotalPlaylistsInPlaylist(parent), Is.EqualTo(1));
+        Assert.That(context.Database.GetTotalPlaylistsContainingPlaylist(child), Is.EqualTo(1));
+    }
+}

--- a/RefreshTests.GameServer/Tests/ApiV3/PlaylistApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/PlaylistApiTests.cs
@@ -181,11 +181,6 @@ public class PlaylistApiTests : GameServerTest
         using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
 
         // Get (unauthenticated)
-        ApiPlaylistCreationRequest request = new()
-        {
-            Name = "Easiest levels",
-            Description = "for the skill issued"
-        };
         ApiResponse<ApiGamePlaylistResponse>? response = context.Http.GetData<ApiGamePlaylistResponse>($"/api/v3/playlists/id/{playlist.PlaylistId}");
         Assert.That(response?.Data, Is.Not.Null);
         Assert.That(response!.Data!.PlaylistId, Is.EqualTo(playlist.PlaylistId));


### PR DESCRIPTION
Adds API endpoints for basic playlist stuff (creating, updating, deleting, getting a playlist by ID, aswell as adding/removing levels and playlists). Categories and moderation endpoints will come in separate PRs.

This needs a few tests before merging.