### PR TITLE
Rework API level editing, refactor icon validation

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -212,30 +212,27 @@ public partial class GameDatabaseContext // Levels
         this.SaveChanges();
         return level;
     }
+
+    public GameLevel? UpdateLevel(IApiAdminEditLevelRequest body, GameLevel level, GameUser? updatingUser)
+    {
+        level.Title = body.Title ?? level.Title;
+        level.IconHash = body.IconHash ?? level.IconHash;
+        level.Description = body.Description ?? level.Description;
+        level.GameVersion = body.GameVersion ?? level.GameVersion;
+        level.IsReUpload = body.IsReUpload ?? level.IsReUpload;
+        level.OriginalPublisher = body.OriginalPublisher ?? level.OriginalPublisher;
+
+        this.ApplyLevelMetadataFromAttributes(level);
+        this.CreateRevisionForLevel(level, updatingUser);
+        this.SaveChanges();
+        return level;
+    }
     
     public GameLevel? UpdateLevel(IApiEditLevelRequest body, GameLevel level, GameUser? updatingUser)
     {
-        if (body.Title is { Length: > UgcLimits.TitleLimit })
-            body.Title = body.Title[..UgcLimits.TitleLimit];
-
-        if (body.Description is { Length: > UgcLimits.DescriptionLimit })
-            body.Description = body.Description[..UgcLimits.DescriptionLimit];
-        
-        PropertyInfo[] userProps = body.GetType().GetProperties();
-        foreach (PropertyInfo prop in userProps)
-        {
-            if (!prop.CanWrite || !prop.CanRead) continue;
-                
-            object? propValue = prop.GetValue(body);
-            if(propValue == null) continue;
-
-            PropertyInfo? gameLevelProp = level.GetType().GetProperty(prop.Name);
-            Debug.Assert(gameLevelProp != null, $"Invalid property {prop.Name} on {nameof(IApiEditLevelRequest)}");
-                
-            gameLevelProp.SetValue(level, prop.GetValue(body));
-        }
-            
-        level.UpdateDate = this._time.Now;
+        level.Title = body.Title ?? level.Title;
+        level.IconHash = body.IconHash ?? level.IconHash;
+        level.Description = body.Description ?? level.Description;
 
         this.ApplyLevelMetadataFromAttributes(level);
         this.CreateRevisionForLevel(level, updatingUser);

--- a/Refresh.Database/Models/Levels/GameLevel.cs
+++ b/Refresh.Database/Models/Levels/GameLevel.cs
@@ -26,11 +26,11 @@ public partial class GameLevel : ISequentialId
     public string RootResource { get; set; } = string.Empty;
 
     /// <summary>
-    /// When the level was first published in unix milliseconds
+    /// When the level was first published
     /// </summary>
     public DateTimeOffset PublishDate { get; set; }
     /// <summary>
-    /// When the level was last updated in unix milliseconds
+    /// When the level's root resource was last updated
     /// </summary>
     public DateTimeOffset UpdateDate { get; set; }
     

--- a/Refresh.Database/Query/IApiAdminEditLevelRequest.cs
+++ b/Refresh.Database/Query/IApiAdminEditLevelRequest.cs
@@ -1,0 +1,14 @@
+﻿using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Users;
+
+namespace Refresh.Database.Query;
+
+public interface IApiAdminEditLevelRequest
+{
+    string? Title { get; set; }
+    string? Description { get; set; }
+    string? IconHash { get; set; }
+    public TokenGame? GameVersion { get; set; }
+    public bool? IsReUpload { get; set; }
+    public string? OriginalPublisher { get; set; }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminLevelApiEndpoints.cs
@@ -13,6 +13,7 @@ using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Levels;
+using Refresh.Interfaces.APIv3.Extensions;
 
 namespace Refresh.Interfaces.APIv3.Endpoints.Admin;
 
@@ -54,9 +55,8 @@ public class AdminLevelApiEndpoints : EndpointGroup
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
-        if (body.IconHash != null && body.IconHash.StartsWith('g') &&
-            !dataContext.GuidChecker.IsTextureGuid(level.GameVersion, long.Parse(body.IconHash)))
-            return ApiValidationError.InvalidTextureGuidError;
+        (body.IconHash, ApiError? iconError) = body.IconHash.ValidateIcon(dataContext);
+        if (iconError != null) return iconError;
         
         // Trim title and description
         if (body.Title != null && body.Title.Length > UgcLimits.TitleLimit) 

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminLevelApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminLevelApiEndpoints.cs
@@ -3,6 +3,7 @@ using Bunkum.Core;
 using Bunkum.Core.Endpoints;
 using Bunkum.Protocols.Http;
 using MongoDB.Bson;
+using Refresh.Common.Constants;
 using Refresh.Core.Authentication.Permission;
 using Refresh.Core.Types.Data;
 using Refresh.Database;
@@ -56,6 +57,13 @@ public class AdminLevelApiEndpoints : EndpointGroup
         if (body.IconHash != null && body.IconHash.StartsWith('g') &&
             !dataContext.GuidChecker.IsTextureGuid(level.GameVersion, long.Parse(body.IconHash)))
             return ApiValidationError.InvalidTextureGuidError;
+        
+        // Trim title and description
+        if (body.Title != null && body.Title.Length > UgcLimits.TitleLimit) 
+            body.Title = body.Title[..UgcLimits.TitleLimit];
+
+        if (body.Description != null && body.Description.Length > UgcLimits.DescriptionLimit)
+            body.Description = body.Description[..UgcLimits.DescriptionLimit];
         
         level = database.UpdateLevel(body, level, user);
 

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
@@ -157,29 +157,14 @@ public class AdminUserApiEndpoints : EndpointGroup
                 return ApiValidationError.WrongRoleUpdateMethodError;
         }
 
-        if (body.IconHash != null)
-        {
-            if (body.IconHash.IsBlankHash())
-                body.IconHash = "0";
-            else if (database.GetAssetFromHash(body.IconHash) == null)
-                return ApiNotFoundError.IconMissingError;
-        }
+        (body.IconHash, ApiError? mainIconError) = body.IconHash.ValidateIcon(dataContext);
+        if (mainIconError != null) return mainIconError;
 
-        if (body.VitaIconHash != null)
-        {
-            if (body.VitaIconHash.IsBlankHash())
-                body.VitaIconHash = "0";
-            else if (database.GetAssetFromHash(body.VitaIconHash) == null)
-                return ApiNotFoundError.IconMissingError;
-        }
+        (body.VitaIconHash, ApiError? vitaIconError) = body.VitaIconHash.ValidateIcon(dataContext);
+        if (vitaIconError != null) return vitaIconError;
 
-        if (body.BetaIconHash != null)
-        {
-            if (body.BetaIconHash.IsBlankHash())
-                body.BetaIconHash = "0";
-            else if (database.GetAssetFromHash(body.BetaIconHash) == null)
-                return ApiNotFoundError.IconMissingError;
-        }
+        (body.BetaIconHash, ApiError? betaIconError) = body.BetaIconHash.ValidateIcon(dataContext);
+        if (betaIconError != null) return betaIconError;
 
         // Do nothing if the username entered is actually the same as the one already set
         if (body.Username != null && body.Username != targetUser.Username) 

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Request/ApiAdminEditLevelRequest.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Request/ApiAdminEditLevelRequest.cs
@@ -1,10 +1,14 @@
 using Refresh.Database.Models.Authentication;
+using Refresh.Database.Query;
 
 namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
 
 [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public class ApiAdminEditLevelRequest : ApiEditLevelRequest
+public class ApiAdminEditLevelRequest : IApiAdminEditLevelRequest
 {
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+    public string? IconHash { get; set; }
     public TokenGame? GameVersion { get; set; }
     public bool? IsReUpload { get; set; }
     public string? OriginalPublisher { get; set; }

--- a/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
@@ -17,6 +17,7 @@ using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
 using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Levels;
+using Refresh.Interfaces.APIv3.Extensions;
 
 namespace Refresh.Interfaces.APIv3.Endpoints;
 
@@ -61,9 +62,8 @@ public class LevelApiEndpoints : EndpointGroup
         if (level.Publisher?.UserId != dataContext.User!.UserId) 
             return ApiAuthenticationError.NoPermissionsForObject;
 
-        if (body.IconHash != null && body.IconHash.StartsWith('g') &&
-            !dataContext.GuidChecker.IsTextureGuid(level.GameVersion, long.Parse(body.IconHash)))
-            return ApiValidationError.InvalidTextureGuidError;
+        (body.IconHash, ApiError? iconError) = body.IconHash.ValidateIcon(dataContext);
+        if (iconError != null) return iconError;
         
         // Trim title and description
         if (body.Title != null && body.Title.Length > UgcLimits.TitleLimit) 

--- a/Refresh.Interfaces.APIv3/Extensions/StringExtensions.cs
+++ b/Refresh.Interfaces.APIv3/Extensions/StringExtensions.cs
@@ -1,0 +1,42 @@
+using Refresh.Core.Types.Data;
+using Refresh.Database.Models.Assets;
+using Refresh.Database.Models.Authentication;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
+
+namespace Refresh.Interfaces.APIv3.Extensions;
+
+public static class StringExtensions
+{
+    /// <summary>
+    /// Validates the given icon reference (may be null, blank, a GUID or a hash).
+    /// Returns the icon reference to use, and an ApiError if validation failed.
+    /// </summary>
+    public static (string?, ApiError?) ValidateIcon(this string? iconReference, DataContext dataContext)
+    {
+        if (iconReference == null) 
+            return (null, null);
+
+        else if (iconReference.IsBlankHash())
+            return ("0", null);
+
+        else if (iconReference.StartsWith('g') && iconReference.Length > 1)
+        {
+            bool isGuid = long.TryParse(iconReference[1..], out long guid);
+            if (!isGuid || (isGuid && !dataContext.GuidChecker.IsTextureGuid(TokenGame.LittleBigPlanet1, guid)))
+                return (null, ApiValidationError.InvalidTextureGuidError);
+        }
+        else
+        {
+            GameAsset? asset = dataContext.Database.GetAssetFromHash(iconReference);
+
+            if (asset == null) 
+                return (null, ApiValidationError.IconMissingError);
+
+            if (asset.AssetType is not GameAssetType.Jpeg and not GameAssetType.Png)
+                return (null, ApiValidationError.IconMustBeImageError);
+        }
+
+        return (iconReference, null);
+    }
+}

--- a/RefreshTests.GameServer/Tests/ApiV3/EditApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/EditApiTests.cs
@@ -34,8 +34,7 @@ public class EditApiTests : GameServerTest
         Assert.Multiple(() =>
         {
             Assert.That(level.Title, Is.EqualTo("Updated"));
-            Assert.That(level.UpdateDate, Is.Not.EqualTo(oldUpdate));
-            Assert.That(level.UpdateDate, Is.EqualTo(context.Time.Now));
+            Assert.That(level.UpdateDate, Is.EqualTo(oldUpdate));
         });
     }
     
@@ -93,8 +92,7 @@ public class EditApiTests : GameServerTest
         {
             Assert.That(level.Title, Is.EqualTo("Updated"));
             Assert.That(level.GameVersion, Is.EqualTo(TokenGame.LittleBigPlanetPSP));
-            Assert.That(level.UpdateDate, Is.Not.EqualTo(oldUpdate));
-            Assert.That(level.UpdateDate, Is.EqualTo(context.Time.Now));
+            Assert.That(level.UpdateDate, Is.EqualTo(oldUpdate));
         });
     }
     
@@ -118,67 +116,6 @@ public class EditApiTests : GameServerTest
         Assert.Multiple(() =>
         {
             Assert.That(level.Title, Is.EqualTo("Not updated"));
-        });
-    }
-
-    [Test]
-    public void LevelUpdateChangesUpdateDate()
-    {
-        using TestContext context = this.GetServer(false);
-        GameUser author = context.CreateUser();
-
-        context.Time.TimestampMilliseconds = 1;
-        GameLevel level = context.CreateLevel(author);
-        Assert.Multiple(() =>
-        {
-            Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
-            Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
-        });
-        
-        // When originating from a request, it wouldn't pass down the original PublishDate.
-        // Replicate this here.
-        GameLevelRequest newLevel = new()
-        {
-            RootResource = "g12345",
-        };
-
-        context.Time.TimestampMilliseconds = 2;
-        context.Database.UpdateLevel(newLevel, level);
-        Assert.Multiple(() =>
-        {
-            Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
-            Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(2));
-        });
-    }
-    
-    [Test]
-    public void LevelUpdateDoesNotChangeUpdateDateWhenRootUnchanged()
-    {
-        using TestContext context = this.GetServer(false);
-        GameUser author = context.CreateUser();
-
-        context.Time.TimestampMilliseconds = 1;
-        GameLevel level = context.CreateLevel(author);
-        Assert.Multiple(() =>
-        {
-            Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
-            Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
-        });
-        
-        // When originating from a request, it wouldn't pass down the original PublishDate.
-        // Replicate this here.
-        GameLevelRequest newLevel = new()
-        {
-            Description = "description update",
-            RootResource = level.RootResource,
-        };
-
-        context.Time.TimestampMilliseconds = 2;
-        context.Database.UpdateLevel(newLevel, level);
-        Assert.Multiple(() =>
-        {
-            Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
-            Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
         });
     }
 }

--- a/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
@@ -68,4 +68,61 @@ public class UploadTests : GameServerTest
         context.Database.DeleteLevel(level);
         Assert.That(context.Database.GetLevelById(id), Is.Null);
     }
+
+    [Test]
+    public void LevelRootUpdateChangesUpdateDate()
+    {
+        using TestContext context = this.GetServer(false);
+        GameUser author = context.CreateUser();
+
+        context.Time.TimestampMilliseconds = 1;
+        GameLevel level = context.CreateLevel(author);
+        Assert.Multiple(() =>
+        {
+            Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
+            Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
+        });
+        
+        GameLevelRequest newLevel = new()
+        {
+            RootResource = "g12345",
+        };
+
+        context.Time.TimestampMilliseconds = 2;
+        context.Database.UpdateLevel(newLevel, level);
+        Assert.Multiple(() =>
+        {
+            Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
+            Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(2));
+        });
+    }
+    
+    [Test]
+    public void LevelUpdateDoesNotChangeUpdateDateWhenRootUnchanged()
+    {
+        using TestContext context = this.GetServer(false);
+        GameUser author = context.CreateUser();
+
+        context.Time.TimestampMilliseconds = 1;
+        GameLevel level = context.CreateLevel(author);
+        Assert.Multiple(() =>
+        {
+            Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
+            Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
+        });
+        
+        GameLevelRequest newLevel = new()
+        {
+            Description = "description update",
+            RootResource = level.RootResource,
+        };
+
+        context.Time.TimestampMilliseconds = 2;
+        context.Database.UpdateLevel(newLevel, level);
+        Assert.Multiple(() =>
+        {
+            Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
+            Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
+        });
+    }
 }


### PR DESCRIPTION
- The normal and the admin API endpoint for editing a level now use separate request body classes/interfaces and DB methods
- These DB methods no longer use reflection. They now update levels similarly to how most other similar methods do it now (handle every wanted attribute separately). Closes #579 
- All API endpoints which need to validate icons now use one helper method for this. Removes duplicate code and inconsistent validation processes this way.