### PR TITLE
Track previously used usernames

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.Database/GameDatabaseContext.Registration.cs
@@ -96,12 +96,20 @@ public partial class GameDatabaseContext // Registration
         return this.QueuedRegistrations.Any(r => r.EmailAddress == emailAddress);
     }
 
-    public bool IsUsernameTaken(string username)
+    public bool IsUsernameTaken(string username, GameUser? userToName = null)
     {
-        return this.GameUsers.Any(u => u.Username == username) ||
-               this.QueuedRegistrations.Any(r => r.Username == username);
+        if (this.GameUsers.Any(u => u.Username == username)) return true;
+        if (this.QueuedRegistrations.Any(r => r.Username == username)) return true;
+        
+        PreviousUsername? previous = this.PreviousUsernames.FirstOrDefault(p => p.Username == username);
+        // no one has ever had this name before
+        if (previous == null) return false;
+        // this is not the initial owner of the name (only previous owners may be renamed back)
+        if (userToName == null || userToName.UserId != previous.UserId) return true;
+
+        return false;
     }
-    
+
     public bool IsEmailTaken(string emailAddress)
     {
         return this.GameUsers.Any(u => u.EmailAddress == emailAddress) ||

--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -356,7 +356,7 @@ public partial class GameDatabaseContext // Users
                 throw new ArgumentException("Username is invalid!", nameof(newUsername));
             }
 
-            if (this.IsUsernameTaken(newUsername))
+            if (this.IsUsernameTaken(newUsername, user))
             {
                 throw new ArgumentException("Username is already taken!", nameof(newUsername));
             }
@@ -364,6 +364,13 @@ public partial class GameDatabaseContext // Users
 
         string oldUsername = user.Username;
         user.Username = newUsername;
+
+        this.PreviousUsernames.Add(new()
+        {
+            Username = oldUsername,
+            User = user,
+            ReplacedAt = this._time.Now,
+        });
         this.GameUsers.Update(user);
         this.SaveChanges();
         

--- a/Refresh.Database/GameDatabaseContext.cs
+++ b/Refresh.Database/GameDatabaseContext.cs
@@ -34,6 +34,7 @@ public partial class GameDatabaseContext : DbContext, IDatabaseContext
     private readonly Logger _logger;
 
     internal DbSet<GameUser> GameUsers { get; set; }
+    internal DbSet<PreviousUsername> PreviousUsernames { get; set; }
     internal DbSet<GameUserStatistics> GameUserStatistics { get; set; }
     internal DbSet<Token> Tokens { get; set; }
     internal DbSet<GameLevel> GameLevels { get; set; }

--- a/Refresh.Database/Migrations/20260312104531_TrackUsernameChanges.cs
+++ b/Refresh.Database/Migrations/20260312104531_TrackUsernameChanges.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20260312104531_TrackUsernameChanges")]
+    public partial class TrackUsernameChanges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PreviousUsernames",
+                columns: table => new
+                {
+                    Username = table.Column<string>(type: "text", nullable: false),
+                    ReplacedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UserId = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PreviousUsernames", x => new { x.Username, x.ReplacedAt });
+                    table.ForeignKey(
+                        name: "FK_PreviousUsernames_GameUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "GameUsers",
+                        principalColumn: "UserId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PreviousUsernames_UserId",
+                table: "PreviousUsernames",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PreviousUsernames");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -1715,6 +1715,25 @@ namespace Refresh.Database.Migrations
                     b.ToTable("GameUsers");
                 });
 
+            modelBuilder.Entity("Refresh.Database.Models.Users.PreviousUsername", b =>
+                {
+                    b.Property<string>("Username")
+                        .HasColumnType("text");
+
+                    b.Property<DateTimeOffset>("ReplacedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Username", "ReplacedAt");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("PreviousUsernames");
+                });
+
             modelBuilder.Entity("Refresh.Database.Models.Users.QueuedRegistration", b =>
                 {
                     b.Property<string>("RegistrationId")
@@ -2080,7 +2099,7 @@ namespace Refresh.Database.Migrations
             modelBuilder.Entity("Refresh.Database.Models.Photos.GamePhotoSubject", b =>
                 {
                     b.HasOne("Refresh.Database.Models.Photos.GamePhoto", "Photo")
-                        .WithMany()
+                        .WithMany("Subjects")
                         .HasForeignKey("PhotoId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -2462,6 +2481,22 @@ namespace Refresh.Database.Migrations
                         .HasForeignKey("StatisticsUserId");
 
                     b.Navigation("Statistics");
+                });
+
+            modelBuilder.Entity("Refresh.Database.Models.Users.PreviousUsername", b =>
+                {
+                    b.HasOne("Refresh.Database.Models.Users.GameUser", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("User");
+                });
+
+            modelBuilder.Entity("Refresh.Database.Models.Photos.GamePhoto", b =>
+                {
+                    b.Navigation("Subjects");
                 });
 
             modelBuilder.Entity("Refresh.Database.Models.Reports.GriefReport", b =>

--- a/Refresh.Database/Models/Users/PreviousUsername.cs
+++ b/Refresh.Database/Models/Users/PreviousUsername.cs
@@ -1,0 +1,22 @@
+using MongoDB.Bson;
+
+namespace Refresh.Database.Models.Users;
+
+#nullable disable
+
+[PrimaryKey(nameof(Username), nameof(ReplacedAt))]
+public partial class PreviousUsername
+{
+    public string Username { get; set; }
+
+    [Required]
+    public ObjectId UserId { get; set; }
+
+    [Required, ForeignKey(nameof(UserId))]
+    public GameUser User { get; set; }
+
+    /// <summary>
+    /// When the user's name was changed to no longer use this username
+    /// </summary>
+    public DateTimeOffset ReplacedAt { get; set; }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/Admin/AdminUserApiEndpoints.cs
@@ -173,7 +173,7 @@ public class AdminUserApiEndpoints : EndpointGroup
                 return new ApiValidationError(ApiValidationError.InvalidUsernameErrorWhen
                     + " Are you sure you used a PSN/RPCN username, or prepended it with ! if it's a fake user?");
             
-            if (database.IsUsernameTaken(body.Username))
+            if (database.IsUsernameTaken(body.Username, targetUser))
                 return ApiValidationError.UsernameTakenError;
             
             database.RenameUser(targetUser, body.Username);

--- a/Refresh.Interfaces.APIv3/Endpoints/ContestApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ContestApiEndpoints.cs
@@ -27,7 +27,7 @@ public class ContestApiEndpoints : EndpointGroup
     public ApiListResponse<ApiContestResponse> GetAllContests(RequestContext context, GameDatabaseContext database,
         DataContext dataContext)
     {
-        return new ApiListResponse<ApiContestResponse>(ApiContestResponse.FromOldList(database.GetAllContests(), dataContext));
+        return new ApiListResponse<ApiContestResponse>(ApiContestResponse.FromOldList(database.GetAllContests().ToArray(), dataContext));
     }
     
     [ApiV3Endpoint("contests/{id}"), Authentication(false)]

--- a/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
@@ -342,15 +342,21 @@ public class AdminUserEditApiTests : GameServerTest
         Assert.That(modifiedOwner, Is.Not.Null);
         Assert.That(modifiedOwner!.Username, Is.EqualTo("original_2"));
 
+        context.Time.TimestampMilliseconds += 1000;
+
         context.Database.RenameUser(owner, "original");
         modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
         Assert.That(modifiedOwner, Is.Not.Null);
         Assert.That(modifiedOwner!.Username, Is.EqualTo("original"));
 
+        context.Time.TimestampMilliseconds += 1000;
+
         context.Database.RenameUser(owner, "original_2");
         modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
         Assert.That(modifiedOwner, Is.Not.Null);
         Assert.That(modifiedOwner!.Username, Is.EqualTo("original_2"));
+
+        context.Time.TimestampMilliseconds += 1000;
 
         context.Database.RenameUser(owner, "original");
         modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);

--- a/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/AdminUserEditApiTests.cs
@@ -269,6 +269,96 @@ public class AdminUserEditApiTests : GameServerTest
     }
 
     [Test]
+    public void CannotRenameToOtherUsersPreviousName()
+    {
+        using TestContext context = this.GetServer();
+
+        GameUser mod = context.CreateUser(null, GameUserRole.Moderator);
+        GameUser owner = context.CreateUser("original", GameUserRole.User);
+        GameUser target = context.CreateUser("stinker", GameUserRole.User);
+
+        context.Database.RenameUser(owner, "original_2");
+        GameUser? modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
+        Assert.That(modifiedOwner, Is.Not.Null);
+        Assert.That(modifiedOwner!.Username, Is.EqualTo("original_2"));
+
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
+        ApiAdminUpdateUserRequest request = new()
+        {
+            Username = "original"
+        };
+
+        ApiResponse<ApiExtendedGameUserResponse>? response = client.PatchData<ApiExtendedGameUserResponse>($"/api/v3/admin/users/uuid/{target.UserId}", request, false, true);
+        Assert.That(response?.Error, Is.Not.Null);
+        Assert.That(response!.Error!.StatusCode, Is.EqualTo(BadRequest));
+
+        context.Database.Refresh();
+
+        GameUser? modifiedTarget = context.Database.GetUserByObjectId(target.UserId);
+        Assert.That(modifiedTarget, Is.Not.Null);
+        Assert.That(modifiedTarget!.Username, Is.EqualTo("stinker"));
+    }
+
+    [Test]
+    public void CanRenameUserBackToTheirPreviousName()
+    {
+        using TestContext context = this.GetServer();
+
+        GameUser mod = context.CreateUser(null, GameUserRole.Moderator);
+        GameUser owner = context.CreateUser("original", GameUserRole.User);
+
+        context.Database.RenameUser(owner, "original_2");
+        GameUser? modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
+        Assert.That(modifiedOwner, Is.Not.Null);
+        Assert.That(modifiedOwner!.Username, Is.EqualTo("original_2"));
+
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Api, mod);
+        ApiAdminUpdateUserRequest request = new()
+        {
+            Username = "original"
+        };
+
+        ApiResponse<ApiExtendedGameUserResponse>? response = client.PatchData<ApiExtendedGameUserResponse>($"/api/v3/admin/users/uuid/{owner.UserId}", request);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Data!.Username == "original");
+
+        context.Database.Refresh();
+
+        GameUser? modifiedOwner2 = context.Database.GetUserByObjectId(owner.UserId);
+        Assert.That(modifiedOwner2, Is.Not.Null);
+        Assert.That(modifiedOwner2!.Username, Is.EqualTo("original"));
+    }
+
+    [Test]
+    public void CanRenameUserBackAndForth()
+    {
+        using TestContext context = this.GetServer();
+
+        GameUser mod = context.CreateUser(null, GameUserRole.Moderator);
+        GameUser owner = context.CreateUser("original", GameUserRole.User);
+
+        context.Database.RenameUser(owner, "original_2");
+        GameUser? modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
+        Assert.That(modifiedOwner, Is.Not.Null);
+        Assert.That(modifiedOwner!.Username, Is.EqualTo("original_2"));
+
+        context.Database.RenameUser(owner, "original");
+        modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
+        Assert.That(modifiedOwner, Is.Not.Null);
+        Assert.That(modifiedOwner!.Username, Is.EqualTo("original"));
+
+        context.Database.RenameUser(owner, "original_2");
+        modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
+        Assert.That(modifiedOwner, Is.Not.Null);
+        Assert.That(modifiedOwner!.Username, Is.EqualTo("original_2"));
+
+        context.Database.RenameUser(owner, "original");
+        modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
+        Assert.That(modifiedOwner, Is.Not.Null);
+        Assert.That(modifiedOwner!.Username, Is.EqualTo("original"));
+    }
+
+    [Test]
     [TestCase("!jeff", true)]
     [TestCase("dddd", true)]
     [TestCase("dd", false)]

--- a/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
@@ -68,6 +68,31 @@ public class UserApiTests : GameServerTest
         context.Database.Refresh();
         Assert.That(context.Database.GetUserByUsername(username), Is.EqualTo(null));
     }
+
+    [Test]
+    public void CannotRegisterAccountWithPreviouslyTakenUsername()
+    {
+        using TestContext context = this.GetServer();
+        GameUser owner = context.CreateUser("original", GameUserRole.User);
+
+        context.Database.RenameUser(owner, "original_2");
+        GameUser? modifiedOwner = context.Database.GetUserByObjectId(owner.UserId);
+        Assert.That(modifiedOwner, Is.Not.Null);
+        Assert.That(modifiedOwner!.Username, Is.EqualTo("original_2"));
+        
+        ApiResponse<ApiAuthenticationResponse>? response = context.Http.PostData<ApiAuthenticationResponse>("/api/v3/register", new ApiRegisterRequest
+        {
+            Username = "original",
+            EmailAddress = "guy@lil.com",
+            PasswordSha512 = "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff",
+        }, false, true);
+        Assert.That(response, Is.Not.Null);
+        Assert.That(response!.Error, Is.Not.EqualTo(null));
+        Assert.That(response.Error!.Name, Is.EqualTo("ApiAuthenticationError"));
+        
+        context.Database.Refresh();
+        Assert.That(context.Database.GetTotalUserCount(), Is.EqualTo(1));
+    }
     
     [TestCase("4")]
     [TestCase("44444444444444444444444444444444444444")]


### PR DESCRIPTION
When renaming a user, their old username will now be tracked using a DB table. New users won't be able to register with that name, and only the user who initially owned that name may be renamed back to it.