### PR TITLE
Require password when deleting account

### DIFF
--- a/Refresh.Interfaces.APIv3/Endpoints/AuthenticationApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/AuthenticationApiEndpoints.cs
@@ -425,7 +425,7 @@ public class AuthenticationApiEndpoints : EndpointGroup
     }
 
     [ApiV3Endpoint("users/me", HttpMethods.Delete), MinimumRole(GameUserRole.Restricted)]
-    [DocSummary("Deletes your own account. This action is non-reversible. This endpoint now requires you to enter your password, regardless of previous authentication.")]
+    [DocSummary("Deletes your own account. This action is non-reversible. This endpoint now requires you to include your own password while being authenticated.")]
     public ApiOkResponse DeleteMyAccount(RequestContext context, GameUser user, ApiOwnUserDeletionRequest body, GameDatabaseContext database)
     {
         if (string.IsNullOrWhiteSpace(body.PasswordSha512))

--- a/Refresh.Interfaces.APIv3/Endpoints/AuthenticationApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/AuthenticationApiEndpoints.cs
@@ -402,9 +402,15 @@ public class AuthenticationApiEndpoints : EndpointGroup
     }
 
     [ApiV3Endpoint("users/me", HttpMethods.Delete), MinimumRole(GameUserRole.Restricted)]
-    [DocSummary("Deletes your own account. This action is non-reversible.")]
-    public ApiOkResponse DeleteMyAccount(RequestContext context, GameUser user, GameDatabaseContext database)
+    [DocSummary("Deletes your own account. This action is non-reversible. This endpoint now requires you to enter your password, regardless of previous authentication.")]
+    public ApiOkResponse DeleteMyAccount(RequestContext context, GameUser user, ApiOwnUserDeletionRequest body, GameDatabaseContext database)
     {
+        if (string.IsNullOrWhiteSpace(body.PasswordSha512))
+            return new ApiValidationError("You must enter your password to delete your account.");
+
+        if (!BC.Verify(body.PasswordSha512, user.PasswordBcrypt))
+            return new ApiValidationError("The password was incorrect.");
+
         database.DeleteUser(user);
         return new ApiOkResponse();
     }

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Request/Authentication/ApiOwnUserDeletionRequest.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Request/Authentication/ApiOwnUserDeletionRequest.cs
@@ -1,0 +1,8 @@
+#nullable disable
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request.Authentication;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiOwnUserDeletionRequest
+{
+    public string PasswordSha512 { get; set; }
+}

--- a/RefreshTests.GameServer/Extensions/HttpClientExtensions.cs
+++ b/RefreshTests.GameServer/Extensions/HttpClientExtensions.cs
@@ -58,4 +58,20 @@ public static class HttpClientExtensions
             Assert.That(response.StatusCode, Is.Not.EqualTo(OK));
         return ReadData<TData>(response.Content);
     }
+
+    public static ApiResponse<TData>? DeleteData<TData>(this HttpClient client, string endpoint, object data, bool ensureSuccessful = true, bool ensureFailure = false) where TData : class, IApiResponse
+    {
+        // HttpClient's DeleteAsync method does not allow us to include a body
+        HttpRequestMessage request = new(HttpMethod.Delete, endpoint)
+        {
+            Content = new StringContent(data.AsJson())
+        };
+        HttpResponseMessage response = client.SendAsync(request).Result;
+
+        if (ensureSuccessful)
+            Assert.That(response.StatusCode, Is.EqualTo(OK));
+        else if (ensureFailure)
+            Assert.That(response.StatusCode, Is.Not.EqualTo(OK));
+        return ReadData<TData>(response.Content);
+    }
 }

--- a/RefreshTests.GameServer/Tests/ApiV3/UserDeletionApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/UserDeletionApiTests.cs
@@ -1,0 +1,95 @@
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request.Authentication;
+using RefreshTests.GameServer.Extensions;
+
+namespace RefreshTests.GameServer.Tests.ApiV3;
+
+public class UserDeletionApiTests : GameServerTest
+{
+    [Test]
+    public void CanDeleteOwnUserWithPassword()
+    {
+        using TestContext context = this.GetServer();
+        const string password = "password";
+
+        GameUser user = context.CreateUser();
+        string passwordBcrypt = BCrypt.Net.BCrypt.HashPassword(password, 4);
+        context.Database.SetUserPassword(user, passwordBcrypt);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+
+        Assert.That(context.Database.GetUserByObjectId(user.UserId), Is.Not.Null);
+
+        // Try to delete
+        ApiOwnUserDeletionRequest request = new()
+        {
+            PasswordSha512 = password
+        };
+        ApiResponse<ApiEmptyResponse>? response = client.DeleteData<ApiEmptyResponse>($"/api/v3/users/me", request);
+        Assert.That(response?.Data, Is.Not.Null);
+        Assert.That(response!.Success, Is.True);
+
+        context.Database.Refresh();
+        GameUser? fakeDeletedUser = context.Database.GetUserByObjectId(user.UserId);
+        Assert.That(fakeDeletedUser, Is.Not.Null);
+        Assert.That(fakeDeletedUser!.Role, Is.EqualTo(GameUserRole.Banned));
+        Assert.That(fakeDeletedUser!.PasswordBcrypt, Is.EqualTo("deleted"));
+    }
+
+    [Test]
+    public async Task CannotDeleteOwnUserWithoutPassword()
+    {
+        using TestContext context = this.GetServer();
+        const string password = "password";
+
+        GameUser user = context.CreateUser();
+        string passwordBcrypt = BCrypt.Net.BCrypt.HashPassword(password, 4);
+        context.Database.SetUserPassword(user, passwordBcrypt);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+
+        Assert.That(context.Database.GetUserByObjectId(user.UserId), Is.Not.Null);
+
+        // Try to delete
+        HttpResponseMessage? response = await client.DeleteAsync($"/api/v3/users/me");
+        Assert.That(response, Is.Not.Null);
+        Assert.That(response!.IsSuccessStatusCode, Is.False);
+
+        context.Database.Refresh();
+        GameUser? fakeDeletedUser = context.Database.GetUserByObjectId(user.UserId);
+        Assert.That(fakeDeletedUser, Is.Not.Null);
+        Assert.That(fakeDeletedUser!.Role, Is.EqualTo(GameUserRole.User));
+        Assert.That(fakeDeletedUser!.PasswordBcrypt, Is.Not.EqualTo("deleted"));
+    }
+
+    [Test]
+    public void CannotDeleteOwnUserWithWrongPassword()
+    {
+        using TestContext context = this.GetServer();
+        const string correctPassword = "password";
+        const string wrongPassword = "assword";
+
+        GameUser user = context.CreateUser();
+        string correctPasswordBcrypt = BCrypt.Net.BCrypt.HashPassword(correctPassword, 4);
+        string wrongPasswordBcrypt = BCrypt.Net.BCrypt.HashPassword(wrongPassword, 4);
+        context.Database.SetUserPassword(user, correctPasswordBcrypt);
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+
+        Assert.That(context.Database.GetUserByObjectId(user.UserId), Is.Not.Null);
+
+        // Try to delete
+        ApiOwnUserDeletionRequest request = new()
+        {
+            PasswordSha512 = wrongPassword
+        };
+        ApiResponse<ApiEmptyResponse>? response = client.DeleteData<ApiEmptyResponse>($"/api/v3/users/me", request, false, true);
+        Assert.That(response?.Error, Is.Not.Null);
+        Assert.That(response!.Success, Is.False);
+
+        context.Database.Refresh();
+        GameUser? fakeDeletedUser = context.Database.GetUserByObjectId(user.UserId);
+        Assert.That(fakeDeletedUser, Is.Not.Null);
+        Assert.That(fakeDeletedUser!.Role, Is.EqualTo(GameUserRole.User));
+        Assert.That(fakeDeletedUser!.PasswordBcrypt, Is.Not.EqualTo("deleted"));
+    }
+} 


### PR DESCRIPTION
For security reasons, this PR makes requests to the user's own account deletion endpoint require a body with a SHA512 hash of the user's password, regardless of whether they are already authenticated. This does alter APIv3 spec, but it's likely not a widely used endpoint. A complementary PR for the refresh-web legacy branch will be opened alongside this one.