### PR TITLE
Revert automatically disallowing email address when deleting user

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Users.cs
+++ b/Refresh.Database/GameDatabaseContext.Users.cs
@@ -402,8 +402,6 @@ public partial class GameDatabaseContext // Users
         this.BanUser(user, deletedReason, DateTimeOffset.MaxValue);
         this.RevokeAllTokensForUser(user);
         this.DeleteNotificationsByUser(user);
-        if (user.EmailAddress != null)
-            this.DisallowEmail(user.EmailAddress);
         
         this.Write(() =>
         {

--- a/RefreshTests.GameServer/Tests/Users/UserActionTests.cs
+++ b/RefreshTests.GameServer/Tests/Users/UserActionTests.cs
@@ -83,7 +83,7 @@ public class UserActionTests : GameServerTest
     }
 
     [Test]
-    public void DeletingUserDisallowsEmail()
+    public void DeletingUserDoesNotDisallowEmail()
     {
         using TestContext context = this.GetServer();
         GameUser publisher = context.CreateUser();
@@ -95,6 +95,6 @@ public class UserActionTests : GameServerTest
         context.Database.DeleteUser(publisher);
         context.Database.Refresh();
         
-        Assert.That(context.Database.IsEmailDisallowed(email), Is.True);
+        Assert.That(context.Database.IsEmailDisallowed(email), Is.False);
     }
 }


### PR DESCRIPTION
Now that I have thought about this again, this is not a good idea. A user should not "be disallowed" by email if they have deleted their own account. Automatic email blocking should only be done if a moderator deletes an account, and even then it should be optional (for example, a user might ask a moderator to delete their account because they cannot do so themselves, instead of account deletion being necessary due to moderation).