### PR TITLE
Print token data in certain cases

### DIFF
--- a/Refresh.Core/Configuration/GameServerConfig.cs
+++ b/Refresh.Core/Configuration/GameServerConfig.cs
@@ -10,7 +10,7 @@ namespace Refresh.Core.Configuration;
 [SuppressMessage("ReSharper", "RedundantDefaultMemberInitializer")]
 public class GameServerConfig : Config
 {
-    public override int CurrentConfigVersion => 25;
+    public override int CurrentConfigVersion => 26;
     public override int Version { get; set; } = 0;
     
     protected override void Migrate(int oldVer, dynamic oldConfig)
@@ -116,6 +116,11 @@ public class GameServerConfig : Config
     /// Whether to print the room state whenever a `FindBestRoom` match returns no results
     /// </summary>
     public bool PrintRoomStateWhenNoFoundRooms { get; set; } = true;
+
+    /// <summary>
+    /// Whether to unconditionally print data like token, token owner, remote IP, request URI etc during authentication outside of exceptions
+    /// </summary>
+    public bool PrintAuthenticationData { get; set; } = false;
 
     public string[] Sha1DigestKeys = ["CustomServerDigest"];
     public string[] HmacDigestKeys = ["CustomServerDigest"];

--- a/Refresh.Database/GameDatabaseContext.Tokens.cs
+++ b/Refresh.Database/GameDatabaseContext.Tokens.cs
@@ -90,7 +90,7 @@ public partial class GameDatabaseContext // Tokens
 #if DEBUG
             if(Debugger.IsAttached) Debugger.Break();
 #endif
-            throw new InvalidDataException($"GetTokenFromTokenData - Token data or type does not match!");
+            throw new InvalidDataException($"GetTokenFromTokenData - Token data or type does not match (expected {tokenData} | {type}, got {token.TokenData} | {token.TokenType} by {token.User})!");
         }
 
         return token;

--- a/Refresh.GameServer/Authentication/GameAuthenticationProvider.cs
+++ b/Refresh.GameServer/Authentication/GameAuthenticationProvider.cs
@@ -76,13 +76,16 @@ public class GameAuthenticationProvider : IAuthenticationProvider<Token>
         if ((this._config?.MaintenanceMode ?? false) && user.Role != GameUserRole.Admin)
             return null;
         
+        if (this._config?.PrintAuthenticationData ?? false)
+            this._logger.LogInfo(BunkumCategory.Authentication, $"Authenticating request from {request.RemoteEndpoint} to {request.Uri.AbsolutePath} by {user} using token {tokenData}");
+        
         // Additional validation of the token gotten from DB. Exceptions will be caught, logged and InternalServerError will be returned automatically.
         if (token.TokenData != tokenData)
         {
 #if DEBUG
             if(Debugger.IsAttached) Debugger.Break();
 #endif
-            throw new InvalidDataException($"{typeof(GameAuthenticationProvider)} - Token from DB does not match token received from client!");
+            throw new InvalidDataException($"{typeof(GameAuthenticationProvider)} - Token from DB ({token.TokenData}) does not match token received from client ({tokenData})!");
         }
 
         if (token.User.UserId != token.UserId)


### PR DESCRIPTION
Makes the exception messages of some of the recently added token validations include token data, and also makes `GameAuthenticationProvider` always print various information about the request and the received token as long as a certain config option is enabled. This is primarily meant to help understand future issues if they ever happen.