### PR TITLE
Block more endpoints if read-only mode is enabled

### DIFF
--- a/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiAuthenticationError.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiAuthenticationError.cs
@@ -9,6 +9,9 @@ public class ApiAuthenticationError : ApiError
     public const string NoPermissionsForCreationWhen = "You lack the permissions to create this type of resource.";
     public static readonly ApiAuthenticationError NoPermissionsForCreation = new(NoPermissionsForCreationWhen);
 
+    public const string ReadOnlyErrorWhen = "The server is currently in read-only mode.";
+    public static readonly ApiAuthenticationError ReadOnlyError = new(ReadOnlyErrorWhen);
+
     public const string NotAuthenticatedWhen = "You are not authenticated.";
     public static readonly ApiAuthenticationError NotAuthenticated = new(NotAuthenticatedWhen);
 

--- a/Refresh.Interfaces.APIv3/Endpoints/CommentApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/CommentApiEndpoints.cs
@@ -4,6 +4,7 @@ using Bunkum.Core.Endpoints;
 using Bunkum.Core.RateLimit;
 using Bunkum.Protocols.Http;
 using Refresh.Common.Constants;
+using Refresh.Core.Configuration;
 using Refresh.Core.RateLimits.Comments;
 using Refresh.Core.RateLimits.Relations;
 using Refresh.Core.Types.Data;
@@ -51,8 +52,11 @@ public class CommentApiEndpoints : EndpointGroup
     public ApiResponse<ApiProfileCommentResponse> PostCommentOnProfile(RequestContext context,
         DataContext dataContext, GameUser user, ApiCommentPostRequest body,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
-        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType)
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+        
         GameUser? profile = dataContext.Database.GetUserByIdAndType(idType, id);
         if (profile == null) return ApiNotFoundError.UserMissingError;
 
@@ -99,8 +103,11 @@ public class CommentApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse RateProfileComment(RequestContext context, DataContext dataContext, GameUser user, int id, 
-        [DocSummary("The user's new rating for the comment. -1 = dislike, 0 = neutral, 1 = like.")] string rawRating)
+        [DocSummary("The user's new rating for the comment. -1 = dislike, 0 = neutral, 1 = like.")] string rawRating, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+        
         GameProfileComment? comment = dataContext.Database.GetProfileCommentById(id);
         if (comment == null) return ApiNotFoundError.CommentMissingError;
 
@@ -138,8 +145,11 @@ public class CommentApiEndpoints : EndpointGroup
     [RateLimitSettings(CommentUploadEndpointLimits.TimeoutDuration, CommentUploadEndpointLimits.RequestAmount, 
                             CommentUploadEndpointLimits.BlockDuration, CommentUploadEndpointLimits.RequestBucket)]
     public ApiResponse<ApiLevelCommentResponse> PostCommentOnLevel(RequestContext context,
-        DataContext dataContext, int id, GameUser user, ApiCommentPostRequest body)
+        DataContext dataContext, int id, GameUser user, ApiCommentPostRequest body, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+        
         GameLevel? level = dataContext.Database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -186,8 +196,11 @@ public class CommentApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse RateLevelComment(RequestContext context, DataContext dataContext, GameUser user, int id, 
-        [DocSummary("The user's new rating for the comment. -1 = dislike, 0 = neutral, 1 = like.")] string rawRating)
+        [DocSummary("The user's new rating for the comment. -1 = dislike, 0 = neutral, 1 = like.")] string rawRating, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+        
         GameLevelComment? comment = dataContext.Database.GetLevelCommentById(id);
         if (comment == null) return ApiNotFoundError.CommentMissingError;
 

--- a/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
@@ -7,6 +7,7 @@ using Bunkum.Protocols.Http;
 using Refresh.Common.Constants;
 using Refresh.Common.Verification;
 using Refresh.Core.Authentication.Permission;
+using Refresh.Core.Configuration;
 using Refresh.Core.RateLimits.Levels;
 using Refresh.Core.RateLimits.Playlists;
 using Refresh.Core.RateLimits.Presence;
@@ -63,9 +64,12 @@ public class LevelApiEndpoints : EndpointGroup
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     [DocError(typeof(ApiAuthenticationError), ApiAuthenticationError.NoPermissionsForObjectWhen)]
     [RateLimitSettings(420, 8, 300, "level-update-api")]
-    public ApiResponse<ApiGameLevelResponse> EditLevelById(RequestContext context,
-        [DocSummary("The ID of the level")] int id, ApiEditLevelRequest body, DataContext dataContext)
+    public ApiResponse<ApiGameLevelResponse> EditLevelById(RequestContext context, GameUser user,
+        [DocSummary("The ID of the level")] int id, ApiEditLevelRequest body, DataContext dataContext, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GameLevel? level = dataContext.Database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
         
@@ -115,8 +119,11 @@ public class LevelApiEndpoints : EndpointGroup
         GameDatabaseContext database, 
         GameUser user, 
         PlayNowService overrideService,
-        [DocSummary("The ID of the level")] int id)
+        [DocSummary("The ID of the level")] int id, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -132,8 +139,11 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(LevelOverrideEndpointLimits.TimeoutDuration, LevelOverrideEndpointLimits.RequestAmount, 
                             LevelOverrideEndpointLimits.BlockDuration, LevelOverrideEndpointLimits.RequestBucket)]
     public ApiOkResponse SetLevelAsOverrideByHash(RequestContext context, GameDatabaseContext database, GameUser user,
-        PlayNowService service, PresenceService presenceService, [DocSummary("The hash of level root resource")] string hash)
+        PlayNowService service, PresenceService presenceService, [DocSummary("The hash of level root resource")] string hash, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         if (!CommonPatterns.Sha1Regex().IsMatch(hash)) 
             return ApiValidationError.HashInvalidError;
 
@@ -163,8 +173,11 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse FavouriteLevel(RequestContext context, GameDatabaseContext database, GameUser user,
-        [DocSummary("The ID of the level")] int id, DataContext dataContext) 
+        [DocSummary("The ID of the level")] int id, DataContext dataContext, GameServerConfig config) 
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -179,8 +192,11 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse UnheartLevel(RequestContext context, GameDatabaseContext database, GameUser user,
-        [DocSummary("The ID of the level")] int id, DataContext dataContext) 
+        [DocSummary("The ID of the level")] int id, DataContext dataContext, GameServerConfig config) 
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+        
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -195,8 +211,11 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse QueueLevel(RequestContext context, GameDatabaseContext database, GameUser user,
-        [DocSummary("The ID of the level")] int id, DataContext dataContext) 
+        [DocSummary("The ID of the level")] int id, DataContext dataContext, GameServerConfig config) 
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+        
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -217,8 +236,11 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse DequeueLevel(RequestContext context, GameDatabaseContext database, GameUser user,
-        [DocSummary("The ID of the level")] int id, DataContext dataContext) 
+        [DocSummary("The ID of the level")] int id, DataContext dataContext, GameServerConfig config) 
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+        
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -232,8 +254,11 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse ClearQueuedLevels(RequestContext context, GameDatabaseContext database,
-        IDataStore dataStore, GameUser user, DataContext dataContext) 
+        IDataStore dataStore, GameUser user, DataContext dataContext, GameServerConfig config) 
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+        
         database.ClearQueue(user);
         dataContext.Cache.ClearQueueByUser(user);
         return new ApiOkResponse();

--- a/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/LevelApiEndpoints.cs
@@ -119,11 +119,8 @@ public class LevelApiEndpoints : EndpointGroup
         GameDatabaseContext database, 
         GameUser user, 
         PlayNowService overrideService,
-        [DocSummary("The ID of the level")] int id, GameServerConfig config)
+        [DocSummary("The ID of the level")] int id)
     {
-        if (user.IsWriteBlocked(config)) 
-            return ApiAuthenticationError.ReadOnlyError;
-
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -139,11 +136,8 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(LevelOverrideEndpointLimits.TimeoutDuration, LevelOverrideEndpointLimits.RequestAmount, 
                             LevelOverrideEndpointLimits.BlockDuration, LevelOverrideEndpointLimits.RequestBucket)]
     public ApiOkResponse SetLevelAsOverrideByHash(RequestContext context, GameDatabaseContext database, GameUser user,
-        PlayNowService service, PresenceService presenceService, [DocSummary("The hash of level root resource")] string hash, GameServerConfig config)
+        PlayNowService service, PresenceService presenceService, [DocSummary("The hash of level root resource")] string hash)
     {
-        if (user.IsWriteBlocked(config)) 
-            return ApiAuthenticationError.ReadOnlyError;
-
         if (!CommonPatterns.Sha1Regex().IsMatch(hash)) 
             return ApiValidationError.HashInvalidError;
 
@@ -172,7 +166,7 @@ public class LevelApiEndpoints : EndpointGroup
     [DocError(typeof(ApiNotFoundError), ApiNotFoundError.LevelMissingErrorWhen)]
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public ApiOkResponse FavouriteLevel(RequestContext context, GameDatabaseContext database, GameUser user,
+    public ApiOkResponse HeartLevel(RequestContext context, GameDatabaseContext database, GameUser user,
         [DocSummary("The ID of the level")] int id, DataContext dataContext, GameServerConfig config) 
     {
         if (user.IsWriteBlocked(config)) 
@@ -211,11 +205,8 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse QueueLevel(RequestContext context, GameDatabaseContext database, GameUser user,
-        [DocSummary("The ID of the level")] int id, DataContext dataContext, GameServerConfig config) 
+        [DocSummary("The ID of the level")] int id, DataContext dataContext) 
     {
-        if (user.IsWriteBlocked(config)) 
-            return ApiAuthenticationError.ReadOnlyError;
-        
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -236,11 +227,8 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse DequeueLevel(RequestContext context, GameDatabaseContext database, GameUser user,
-        [DocSummary("The ID of the level")] int id, DataContext dataContext, GameServerConfig config) 
+        [DocSummary("The ID of the level")] int id, DataContext dataContext) 
     {
-        if (user.IsWriteBlocked(config)) 
-            return ApiAuthenticationError.ReadOnlyError;
-        
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -254,11 +242,8 @@ public class LevelApiEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse ClearQueuedLevels(RequestContext context, GameDatabaseContext database,
-        IDataStore dataStore, GameUser user, DataContext dataContext, GameServerConfig config) 
+        GameUser user, DataContext dataContext) 
     {
-        if (user.IsWriteBlocked(config)) 
-            return ApiAuthenticationError.ReadOnlyError;
-        
         database.ClearQueue(user);
         dataContext.Cache.ClearQueueByUser(user);
         return new ApiOkResponse();

--- a/Refresh.Interfaces.APIv3/Endpoints/PlaylistApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/PlaylistApiEndpoints.cs
@@ -14,6 +14,7 @@ using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Playlists;
 using Refresh.Interfaces.APIv3.Extensions;
 using Refresh.Core.RateLimits.Playlists;
+using Refresh.Core.Configuration;
 
 namespace Refresh.Interfaces.APIv3.Endpoints;
 
@@ -54,8 +55,11 @@ public class PlaylistApiEndpoints : EndpointGroup
     [DocQueryParam("parentId", "If set, the new playlist will be added to the playlist specified by ID here instead of the root playlist. "
         + "If the specified playlist doesn't exist or is not owned by the user calling this endpoint, nothing will happen.")]
     public ApiResponse<ApiGamePlaylistResponse> CreatePlaylist(RequestContext context, DataContext dataContext,
-        GameUser user, ApiPlaylistCreationRequest body)
+        GameUser user, ApiPlaylistCreationRequest body, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         ApiError? error = this.ValidatePlaylist(body, dataContext);
         if (error != null) return error;
 
@@ -96,8 +100,11 @@ public class PlaylistApiEndpoints : EndpointGroup
     [RateLimitSettings(PlaylistCreationEndpointLimits.UploadTimeoutDuration, PlaylistCreationEndpointLimits.MaxCreateAmount, 
                         PlaylistCreationEndpointLimits.UploadBlockDuration, PlaylistCreationEndpointLimits.CreateBucket)]
     public ApiResponse<ApiGamePlaylistResponse> UpdatePlaylist(RequestContext context, DataContext dataContext,
-        GameUser user, ApiPlaylistCreationRequest body, int id)
+        GameUser user, ApiPlaylistCreationRequest body, int id, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GamePlaylist? playlist = dataContext.Database.GetPlaylistById(id);
         if (playlist == null) return ApiNotFoundError.PlaylistMissingError;
 
@@ -149,8 +156,11 @@ public class PlaylistApiEndpoints : EndpointGroup
     [RateLimitSettings(PlaylistModificationEndpointLimits.TimeoutDuration, PlaylistModificationEndpointLimits.RequestAmount, 
                                 PlaylistModificationEndpointLimits.BlockDuration, PlaylistModificationEndpointLimits.RequestBucket)]
     public ApiOkResponse AddLevelToPlaylist(RequestContext context, DataContext dataContext,
-        GameUser user, int playlistId, int levelId)
+        GameUser user, int playlistId, int levelId, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GamePlaylist? playlist = dataContext.Database.GetPlaylistById(playlistId);
         if (playlist == null) return ApiNotFoundError.ParentPlaylistMissingError;
 
@@ -172,8 +182,11 @@ public class PlaylistApiEndpoints : EndpointGroup
     [RateLimitSettings(PlaylistModificationEndpointLimits.TimeoutDuration, PlaylistModificationEndpointLimits.RequestAmount, 
                                 PlaylistModificationEndpointLimits.BlockDuration, PlaylistModificationEndpointLimits.RequestBucket)]
     public ApiOkResponse RemoveLevelFromPlaylist(RequestContext context, DataContext dataContext,
-        GameUser user, int playlistId, int levelId)
+        GameUser user, int playlistId, int levelId, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GamePlaylist? playlist = dataContext.Database.GetPlaylistById(playlistId);
         if (playlist == null) return ApiNotFoundError.ParentPlaylistMissingError;
 
@@ -195,8 +208,11 @@ public class PlaylistApiEndpoints : EndpointGroup
     [RateLimitSettings(PlaylistModificationEndpointLimits.TimeoutDuration, PlaylistModificationEndpointLimits.RequestAmount, 
                                 PlaylistModificationEndpointLimits.BlockDuration, PlaylistModificationEndpointLimits.RequestBucket)]
     public ApiOkResponse AddPlaylistToPlaylist(RequestContext context, DataContext dataContext,
-        GameUser user, int playlistId, int subPlaylistId)
+        GameUser user, int playlistId, int subPlaylistId, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GamePlaylist? parent = dataContext.Database.GetPlaylistById(playlistId);
         if (parent == null) return ApiNotFoundError.ParentPlaylistMissingError;
 
@@ -218,8 +234,11 @@ public class PlaylistApiEndpoints : EndpointGroup
     [RateLimitSettings(PlaylistModificationEndpointLimits.TimeoutDuration, PlaylistModificationEndpointLimits.RequestAmount, 
                                 PlaylistModificationEndpointLimits.BlockDuration, PlaylistModificationEndpointLimits.RequestBucket)]
     public ApiOkResponse RemovePlaylistFromPlaylist(RequestContext context, DataContext dataContext,
-        GameUser user, int playlistId, int subPlaylistId)
+        GameUser user, int playlistId, int subPlaylistId, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GamePlaylist? parent = dataContext.Database.GetPlaylistById(playlistId);
         if (parent == null) return ApiNotFoundError.ParentPlaylistMissingError;
 

--- a/Refresh.Interfaces.APIv3/Endpoints/ResourceApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ResourceApiEndpoints.cs
@@ -161,7 +161,6 @@ public class ResourceApiEndpoints : EndpointGroup
     [DocError(typeof(ApiValidationError), ApiValidationError.BodyTooLongErrorWhen)]
     [DocError(typeof(ApiValidationError), ApiValidationError.CannotReadAssetErrorWhen)]
     [DocError(typeof(ApiValidationError), ApiValidationError.BodyMustBeImageErrorWhen)]
-    [DocError(typeof(ApiAuthenticationError), ApiAuthenticationError.NoPermissionsForCreationWhen)]
     [RateLimitSettings(420, 10, 300, "image-upload-api")]
     public ApiResponse<ApiGameAssetResponse> UploadImageAsset(RequestContext context, GameDatabaseContext database,
         IDataStore dataStore, AssetImporter importer, GameServerConfig config,
@@ -176,7 +175,7 @@ public class ResourceApiEndpoints : EndpointGroup
         // If we're blocking asset uploads, throw unless the user is an admin.
         // We also have the ability to block asset uploads for trusted users (when they would normally bypass this)
         if (user.IsWriteBlocked(config)) 
-            return ApiAuthenticationError.NoPermissionsForCreation;
+            return ApiAuthenticationError.ReadOnlyError;
         
         if (!CommonPatterns.Sha1Regex().IsMatch(hash)) return ApiValidationError.HashInvalidError;
 

--- a/Refresh.Interfaces.APIv3/Endpoints/ReviewApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ReviewApiEndpoints.cs
@@ -5,6 +5,7 @@ using Bunkum.Core.RateLimit;
 using Bunkum.Core.Storage;
 using Bunkum.Protocols.Http;
 using Refresh.Common.Constants;
+using Refresh.Core.Configuration;
 using Refresh.Core.RateLimits.Relations;
 using Refresh.Core.RateLimits.Reviews;
 using Refresh.Core.Types.Data;
@@ -101,8 +102,11 @@ public class ReviewApiEndpoints : EndpointGroup
                             ReviewUploadEndpointLimits.BlockDuration, ReviewUploadEndpointLimits.RequestBucket)]
     public ApiResponse<ApiGameReviewResponse> PostReviewToLevel(RequestContext context,
         GameDatabaseContext database, IDataStore dataStore, GameUser user,
-        [DocSummary("The ID of the level")] int id, ApiSubmitReviewRequest body, DataContext dataContext)
+        [DocSummary("The ID of the level")] int id, ApiSubmitReviewRequest body, DataContext dataContext, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GameLevel? level = database.GetLevelById(id);
         if (level == null) return ApiNotFoundError.LevelMissingError;
 
@@ -147,8 +151,11 @@ public class ReviewApiEndpoints : EndpointGroup
                             ReviewUploadEndpointLimits.BlockDuration, ReviewUploadEndpointLimits.RequestBucket)]
     public ApiResponse<ApiGameReviewResponse> UpdateReviewById(RequestContext context,
         GameDatabaseContext database, IDataStore dataStore, GameUser user,
-        [DocSummary("The ID of the review")] int id, ApiSubmitReviewRequest body, DataContext dataContext)
+        [DocSummary("The ID of the review")] int id, ApiSubmitReviewRequest body, DataContext dataContext, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GameReview? review = database.GetReviewById(id);
         if (review == null) return ApiNotFoundError.ReviewMissingError;
 
@@ -209,8 +216,11 @@ public class ReviewApiEndpoints : EndpointGroup
     public ApiOkResponse RateReviewById(RequestContext context,
         GameDatabaseContext database, IDataStore dataStore, GameUser user,
         [DocSummary("The ID of the review")] int id, DataContext dataContext,
-        [DocSummary("The user's new rating. -1 = dislike, 0 = neutral, 1 = like.")] string rawRating)
+        [DocSummary("The user's new rating. -1 = dislike, 0 = neutral, 1 = like.")] string rawRating, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GameReview? review = database.GetReviewById(id);
         if (review == null) return ApiNotFoundError.ReviewMissingError;
 

--- a/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/UserApiEndpoints.cs
@@ -49,8 +49,11 @@ public class UserApiEndpoints : EndpointGroup
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse HeartUser(RequestContext context, GameDatabaseContext database,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
-        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext, GameUser user)
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext, GameUser user, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GameUser? target = database.GetUserByIdAndType(idType, id);
         if(target == null) return ApiNotFoundError.UserMissingError;
         
@@ -72,8 +75,11 @@ public class UserApiEndpoints : EndpointGroup
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public ApiOkResponse UnheartUser(RequestContext context, GameDatabaseContext database,
         [DocSummary(SharedParamDescriptions.UserIdParam)] string id, 
-        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext, GameUser user)
+        [DocSummary(SharedParamDescriptions.UserIdTypeParam)] string idType, DataContext dataContext, GameUser user, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return ApiAuthenticationError.ReadOnlyError;
+
         GameUser? target = database.GetUserByIdAndType(idType, id);
         if(target == null) return ApiNotFoundError.UserMissingError;
         

--- a/Refresh.Interfaces.Game/Endpoints/CommentEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/CommentEndpoints.cs
@@ -160,8 +160,11 @@ public class CommentEndpoints : EndpointGroup
     [GameEndpoint("rateUserComment/{content}", HttpMethods.Post)] // profile comments
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public Response RateProfileComment(RequestContext context, GameDatabaseContext database, GameUser user, string content)
+    public Response RateProfileComment(RequestContext context, GameDatabaseContext database, GameUser user, string content, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return Unauthorized;
+
         if (!int.TryParse(context.QueryString["commentId"], out int commentId)) return BadRequest;
         if (!Enum.TryParse(context.QueryString["rating"], out RatingType ratingType)) return BadRequest;
 
@@ -176,8 +179,11 @@ public class CommentEndpoints : EndpointGroup
     [GameEndpoint("rateComment/{slotType}/{content}", HttpMethods.Post)]
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public Response RateLevelComment(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, string content)
+    public Response RateLevelComment(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, string content, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return Unauthorized;
+
         if (!int.TryParse(context.QueryString["commentId"], out int commentId)) return BadRequest;
         if (!Enum.TryParse(context.QueryString["rating"], out RatingType ratingType)) return BadRequest;
 

--- a/Refresh.Interfaces.Game/Endpoints/Handshake/MetadataEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Handshake/MetadataEndpoints.cs
@@ -51,7 +51,7 @@ public class MetadataEndpoints : EndpointGroup
     public Response SetFriendData(RequestContext context, GameUser user, GameDatabaseContext database, SerializedFriendData body, DataContext dataContext, GameServerConfig config)
     {
         if (user.IsWriteBlocked(config))
-            return Unauthorized;
+            return OK; // else the game will send a new request for this every minute
 
         IEnumerable<GameUser> friends = body.FriendsList.Names
             .Take(128) // should be way more than enough - we'll see if this becomes a problem

--- a/Refresh.Interfaces.Game/Endpoints/Handshake/MetadataEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Handshake/MetadataEndpoints.cs
@@ -48,8 +48,11 @@ public class MetadataEndpoints : EndpointGroup
 
     [GameEndpoint("npdata", ContentType.Xml, HttpMethods.Post)]
     [RateLimitSettings(480, 8, 420, "game-npdata")]
-    public Response SetFriendData(RequestContext context, GameUser user, GameDatabaseContext database, SerializedFriendData body, DataContext dataContext)
+    public Response SetFriendData(RequestContext context, GameUser user, GameDatabaseContext database, SerializedFriendData body, DataContext dataContext, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config))
+            return Unauthorized;
+
         IEnumerable<GameUser> friends = body.FriendsList.Names
             .Take(128) // should be way more than enough - we'll see if this becomes a problem
             .Select(username => database.GetUserByUsername(username))

--- a/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Levels/PublishEndpoints.cs
@@ -122,7 +122,10 @@ public class PublishEndpoints : EndpointGroup
         IDateTimeProvider dateTimeProvider)
     {
         if (dataContext.User!.IsWriteBlocked(config))
+        {
+            dataContext.Database.AddPublishFailNotification("The server is in read-only mode.", body.Title, dataContext.User!);
             return Unauthorized;
+        }
         
         if (IsTimedLevelLimitReached(dataContext, dataContext.User!, body.Title, config.TimedLevelUploadLimits, dateTimeProvider.Now)) 
             return Unauthorized;

--- a/Refresh.Interfaces.Game/Endpoints/MatchingEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/MatchingEndpoints.cs
@@ -81,9 +81,6 @@ public class MatchingEndpoints : EndpointGroup
         DataContext dataContext,
         GameServerConfig gameServerConfig)
     {
-        if (dataContext.User!.IsWriteBlocked(gameServerConfig))
-            return Unauthorized;
-        
         (string method, string rawJsonBody) = MatchService.ExtractMethodAndBodyFromJson(body);
 
         string jsonBody = FixupLocationData(rawJsonBody);

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
@@ -59,11 +59,12 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
     {
         GameUser user = dataContext.User!;
         
-        if (user.IsWriteBlocked(config))
-            return Unauthorized;
-        
         GamePlaylist? parent = null;
         GamePlaylist? rootPlaylist = dataContext.Database.GetUserRootPlaylist(user);
+
+        // Don't block root playlist creation, as the game will otherwise spam requests and softlock
+        if (user.IsWriteBlocked(config) && rootPlaylist != null)
+            return Unauthorized;
 
         // If the parent ID is specified, try to parse that out
         if (int.TryParse(context.QueryString["parent_id"], out int parentId))

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp1PlaylistEndpoints.cs
@@ -221,11 +221,8 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
 
     [GameEndpoint("deletePlaylist/{id}", HttpMethods.Post)]
     [RequireEmailVerified]
-    public Response DeletePlaylist(RequestContext context, GameServerConfig config, GameDatabaseContext database, GameUser user, int id)
+    public Response DeletePlaylist(RequestContext context, GameDatabaseContext database, GameUser user, int id)
     {
-        if (user.IsWriteBlocked(config))
-            return Unauthorized;
-        
         GamePlaylist? playlist = database.GetPlaylistById(id);
         if (playlist == null)
             return NotFound;
@@ -379,6 +376,9 @@ public class Lbp1PlaylistEndpoints : EndpointGroup
                             PlaylistModificationEndpointLimits.BlockDuration, PlaylistModificationEndpointLimits.RequestBucket)]
     public Response MoveSlotFromPlaylist(RequestContext context, GameServerConfig config, GameDatabaseContext database, GameUser user, int from)     
     {
+        if (user.IsWriteBlocked(config))
+            return Unauthorized;
+
         if (!int.TryParse(context.QueryString["to"], out int to))
             return BadRequest;
 

--- a/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/Playlists/Lbp3PlaylistEndpoints.cs
@@ -81,11 +81,8 @@ public class Lbp3PlaylistEndpoints : EndpointGroup
 
     [GameEndpoint("playlists/{playlistId}/delete", HttpMethods.Post, ContentType.Xml)]
     [RequireEmailVerified]
-    public Response DeletePlaylist(RequestContext context, GameServerConfig config, DataContext dataContext, GameUser user, int playlistId)
+    public Response DeletePlaylist(RequestContext context, DataContext dataContext, GameUser user, int playlistId)
     {
-        if (user.IsWriteBlocked(config))
-            return Unauthorized;
-
         GamePlaylist? playlist = dataContext.Database.GetPlaylistById(playlistId);
         if (playlist == null) 
             return NotFound;

--- a/Refresh.Interfaces.Game/Endpoints/RelationEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/RelationEndpoints.cs
@@ -120,11 +120,8 @@ public class RelationEndpoints : EndpointGroup
     [RequireEmailVerified]
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public Response QueueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, DataContext dataContext, GameServerConfig config)
+    public Response QueueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, DataContext dataContext)
     {
-        if (user.IsWriteBlocked(config)) 
-            return Unauthorized;
-
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
 
@@ -137,11 +134,8 @@ public class RelationEndpoints : EndpointGroup
     [RequireEmailVerified]
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public Response DequeueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, DataContext dataContext, GameServerConfig config)
+    public Response DequeueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, DataContext dataContext)
     {
-        if (user.IsWriteBlocked(config)) 
-            return Unauthorized;
-
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
 
@@ -154,11 +148,8 @@ public class RelationEndpoints : EndpointGroup
     [RequireEmailVerified]
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public Response ClearQueue(RequestContext context, GameDatabaseContext database, GameUser user, DataContext dataContext, GameServerConfig config)
+    public Response ClearQueue(RequestContext context, GameDatabaseContext database, GameUser user, DataContext dataContext)
     {
-        if (user.IsWriteBlocked(config)) 
-            return Unauthorized;
-
         database.ClearQueue(user);
         dataContext.Cache.ClearQueueByUser(user);
         return OK;

--- a/Refresh.Interfaces.Game/Endpoints/RelationEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/RelationEndpoints.cs
@@ -120,8 +120,11 @@ public class RelationEndpoints : EndpointGroup
     [RequireEmailVerified]
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public Response QueueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, DataContext dataContext)
+    public Response QueueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, DataContext dataContext, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return Unauthorized;
+
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
 
@@ -134,8 +137,11 @@ public class RelationEndpoints : EndpointGroup
     [RequireEmailVerified]
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public Response DequeueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, DataContext dataContext)
+    public Response DequeueLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, DataContext dataContext, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return Unauthorized;
+
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
 
@@ -148,8 +154,11 @@ public class RelationEndpoints : EndpointGroup
     [RequireEmailVerified]
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
-    public Response ClearQueue(RequestContext context, GameDatabaseContext database, GameUser user, DataContext dataContext)
+    public Response ClearQueue(RequestContext context, GameDatabaseContext database, GameUser user, DataContext dataContext, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return Unauthorized;
+
         database.ClearQueue(user);
         dataContext.Cache.ClearQueueByUser(user);
         return OK;

--- a/Refresh.Interfaces.Game/Endpoints/ReviewEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/ReviewEndpoints.cs
@@ -58,8 +58,11 @@ public class ReviewEndpoints : EndpointGroup
     [RateLimitSettings(CommonRelationEndpointLimits.TimeoutDuration, CommonRelationEndpointLimits.RequestAmount, 
                             CommonRelationEndpointLimits.BlockDuration, CommonRelationEndpointLimits.RequestBucket)]
     public Response RateUserLevel(RequestContext context, GameDatabaseContext database, GameUser user, string slotType, int id, 
-        DataContext dataContext)
+        DataContext dataContext, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return Unauthorized;
+
         GameLevel? level = database.GetLevelByIdAndType(slotType, id);
         if (level == null) return NotFound;
 

--- a/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
@@ -213,14 +213,14 @@ public class UserEndpoints : EndpointGroup
 
         // Return newly updated pins (LBP2 and 3 update their pin progresses if there are higher progress values
         // in the response, but seemingly ignore the profile pins in the response)
-        return this.GetPins(context, dataContext, user, config);
+        return this.GetPins(context, dataContext, user);
     }
 
     [GameEndpoint("get_my_pins", HttpMethods.Get, ContentType.Json)]
     [MinimumRole(GameUserRole.Restricted)]
     [NullStatusCode(Unauthorized)]
     [RateLimitSettings(PinTimeoutDuration, PinRequestAmount, PinBlockDuration, PinBucket)]
-    public SerializedPins? GetPins(RequestContext context, DataContext dataContext, GameUser user, GameServerConfig config)
+    public SerializedPins? GetPins(RequestContext context, DataContext dataContext, GameUser user)
     {
         return SerializedPins.FromOld
         (

--- a/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
@@ -7,6 +7,7 @@ using Bunkum.Listener.Protocol;
 using Bunkum.Protocols.Http;
 using Refresh.Common.Constants;
 using Refresh.Core.Authentication.Permission;
+using Refresh.Core.Configuration;
 using Refresh.Core.RateLimits.Users;
 using Refresh.Core.Services;
 using Refresh.Core.Types.Data;
@@ -169,8 +170,11 @@ public class UserEndpoints : EndpointGroup
     [RequireEmailVerified]
     [NullStatusCode(BadRequest)]
     [RateLimitSettings(PinTimeoutDuration, PinRequestAmount, PinBlockDuration, PinBucket)]
-    public SerializedPins? UpdatePins(RequestContext context, DataContext dataContext, GameUser user, SerializedPins body)
+    public SerializedPins? UpdatePins(RequestContext context, DataContext dataContext, GameUser user, SerializedPins body, GameServerConfig config)
     {
+        if (user.IsWriteBlocked(config)) 
+            return null;
+
         // Try to convert pin progress
         Dictionary<long, int> pinProgresses = [];
         try
@@ -209,15 +213,22 @@ public class UserEndpoints : EndpointGroup
 
         // Return newly updated pins (LBP2 and 3 update their pin progresses if there are higher progress values
         // in the response, but seemingly ignore the profile pins in the response)
-        return this.GetPins(context, dataContext, user);
+        return this.GetPins(context, dataContext, user, config);
     }
 
     [GameEndpoint("get_my_pins", HttpMethods.Get, ContentType.Json)]
     [MinimumRole(GameUserRole.Restricted)]
+    [NullStatusCode(Unauthorized)]
     [RateLimitSettings(PinTimeoutDuration, PinRequestAmount, PinBlockDuration, PinBucket)]
-    public SerializedPins GetPins(RequestContext context, DataContext dataContext, GameUser user)
-        => SerializedPins.FromOld
+    public SerializedPins? GetPins(RequestContext context, DataContext dataContext, GameUser user, GameServerConfig config)
+    {
+        if (user.IsWriteBlocked(config)) 
+            return null;
+
+        return SerializedPins.FromOld
         (
             dataContext.Database.GetPinProgressesByUser(user, dataContext.Game == TokenGame.BetaBuild, dataContext.Platform, 0, 999).Items
         );
+        
+    }
 }

--- a/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/UserEndpoints.cs
@@ -222,9 +222,6 @@ public class UserEndpoints : EndpointGroup
     [RateLimitSettings(PinTimeoutDuration, PinRequestAmount, PinBlockDuration, PinBucket)]
     public SerializedPins? GetPins(RequestContext context, DataContext dataContext, GameUser user, GameServerConfig config)
     {
-        if (user.IsWriteBlocked(config)) 
-            return null;
-
         return SerializedPins.FromOld
         (
             dataContext.Database.GetPinProgressesByUser(user, dataContext.Game == TokenGame.BetaBuild, dataContext.Platform, 0, 999).Items

--- a/RefreshTests.GameServer/Tests/Playlists/PlaylistUploadTests.cs
+++ b/RefreshTests.GameServer/Tests/Playlists/PlaylistUploadTests.cs
@@ -1,4 +1,5 @@
 using Refresh.Common.Constants;
+using Refresh.Core.Configuration;
 using Refresh.Database;
 using Refresh.Database.Models;
 using Refresh.Database.Models.Authentication;
@@ -82,6 +83,96 @@ public class PlaylistUploadTests : GameServerTest
         GamePlaylist? updated = context.Database.GetPlaylistById(subResponse.Id);
         Assert.That(updated, Is.Not.Null);
         Assert.That(updated!.Name, Is.EqualTo("legit"));
+    }
+
+    [Test]
+    public void CreateSubPlaylist()
+    {
+        using TestContext context = this.GetServer();
+
+        GameUser user = context.CreateUser();
+        GamePlaylist root = context.Database.CreatePlaylist(user, new SerializedLbp1Playlist()
+        {
+            Name = "root",
+            Icon = ValidIconGuid,
+            Description = "d",
+            Location = GameLocation.Zero
+        }, true);
+        Assert.That(context.Database.GetUserRootPlaylist(user), Is.Not.Null);
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, user);
+        
+        // Create sub-playlist of root
+        SerializedLbp1Playlist request = new()
+        {
+            Name = "hi",
+            Icon = ValidIconGuid,
+            Description = "DESCRIPTION",
+            Location = new GameLocation(),
+        };
+
+        HttpResponseMessage message = client.PostAsync($"/lbp/createPlaylist?parent_id={root.PlaylistId}", new StringContent(request.AsXML())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(OK));
+
+        Assert.That(context.Database.GetTotalPlaylistsInPlaylist(root), Is.EqualTo(1));
+        Assert.That(context.Database.GetTotalPlaylistsByAuthor(user), Is.EqualTo(1)); // does not include root
+    }
+
+    [Test]
+    public void CannotCreateSubPlaylistWhileReadOnlyMode()
+    {
+        using TestContext context = this.GetServer();
+        GameServerConfig config = context.Server.Value.GameServerConfig;
+        config.ReadOnlyMode = true;
+        config.ReadonlyModeForTrustedUsers = true;
+
+        GameUser user = context.CreateUser();
+        GamePlaylist root = context.Database.CreatePlaylist(user, new SerializedLbp1Playlist()
+        {
+            Name = "root",
+            Icon = ValidIconGuid,
+            Description = "d",
+            Location = GameLocation.Zero
+        }, true);
+        Assert.That(context.Database.GetUserRootPlaylist(user), Is.Not.Null);
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, user);
+        
+        // Create sub-playlist of root
+        SerializedLbp1Playlist request = new()
+        {
+            Name = "hi",
+            Icon = ValidIconGuid,
+            Description = "DESCRIPTION",
+            Location = new GameLocation(),
+        };
+
+        HttpResponseMessage message = client.PostAsync($"/lbp/createPlaylist?parent_id={root.PlaylistId}", new StringContent(request.AsXML())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(Unauthorized));
+        Assert.That(context.Database.GetTotalPlaylistsByAuthor(user), Is.Zero); // does not include root
+    }
+
+    [Test]
+    public void CanCreateRootPlaylistWhileReadOnlyMode()
+    {
+        using TestContext context = this.GetServer();
+        GameServerConfig config = context.Server.Value.GameServerConfig;
+        config.ReadOnlyMode = true;
+        config.ReadonlyModeForTrustedUsers = true;
+
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, user);
+        
+        // Create root playlist
+        SerializedLbp1Playlist request = new()
+        {
+            Name = "root",
+            Icon = ValidIconGuid,
+            Description = "DESCRIPTION",
+            Location = new GameLocation(),
+        };
+
+        HttpResponseMessage message = client.PostAsync("/lbp/createPlaylist", new StringContent(request.AsXML())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(OK));
+        Assert.That(context.Database.GetUserRootPlaylist(user), Is.Not.Null);
     }
 
     [Test]


### PR DESCRIPTION
This makes a few adjustments to read-only mode:
- Now all upload/modification endpoints for both the game and public API are blocked if the user has no perms due to this mode (still excluding account/profile updating, contest updating and moderation)
- The only 2 deletion endpoints which were previously blocked (playlist deletion) are no longer affected by read-only mode. This is mostly for consistency, and because this mode is primarily intended to block new content.
- The user will now be properly notified if their level publish has failed because of this.