### PR TITLE
Rate limit params adjustments

### DIFF
--- a/Refresh.Core/RateLimits/Levels/SingleLevelEndpointLimits.cs
+++ b/Refresh.Core/RateLimits/Levels/SingleLevelEndpointLimits.cs
@@ -4,7 +4,7 @@ public static class SingleLevelEndpointLimits
 {
     public const int TimeoutDuration = 300;
     public const int ApiRequestAmount = 50;
-    public const int GameRequestAmount = 170; // Game likes to request them a lot
+    public const int GameRequestAmount = 280; // Game likes to request them a lot
     public const int BlockDuration = 240;
     public const string ApiRequestBucket = "single-level-api";
     public const string GameRequestBucket = "single-level-game";

--- a/Refresh.Core/RateLimits/Presence/GamePresenceEndpointLimits.cs
+++ b/Refresh.Core/RateLimits/Presence/GamePresenceEndpointLimits.cs
@@ -5,8 +5,8 @@ namespace Refresh.Core.RateLimits.Presence;
 /// </summary>
 public static class GamePresenceEndpointLimits
 {
-    public const int TimeoutDuration = 450;
-    public const int RequestAmount = 30;
-    public const int BlockDuration = 300;
+    public const int TimeoutDuration = 300;
+    public const int RequestAmount = 80;
+    public const int BlockDuration = 240;
     public const string RequestBucket = "game-presence";
 }

--- a/Refresh.Core/RateLimits/Relations/PlayLevelEndpointLimits.cs
+++ b/Refresh.Core/RateLimits/Relations/PlayLevelEndpointLimits.cs
@@ -3,7 +3,7 @@ namespace Refresh.Core.RateLimits.Relations;
 public static class PlayLevelEndpointLimits
 {
     public const int TimeoutDuration = 300;
-    public const int RequestAmount = 20;
+    public const int RequestAmount = 40;
     public const int BlockDuration = 240;
     public const string RequestBucket = "play-level";
 }

--- a/Refresh.Core/RateLimits/Users/NotificationsEndpointLimits.cs
+++ b/Refresh.Core/RateLimits/Users/NotificationsEndpointLimits.cs
@@ -3,7 +3,7 @@ namespace Refresh.Core.RateLimits.Users;
 public static class NotificationsEndpointLimits
 {
     public const int TimeoutDuration = 180;
-    public const int GameRequestAmount = 4;
+    public const int GameRequestAmount = 8;
     public const int ApiRequestAmount = 20;
     public const int BlockDuration = 150;
     public const string GameRequestBucket = "notifications-game";

--- a/Refresh.Interfaces.Game/Endpoints/ResourceEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/ResourceEndpoints.cs
@@ -30,7 +30,7 @@ public class ResourceEndpoints : EndpointGroup
     [GameEndpoint("upload/{hash}", HttpMethods.Post)]
     [RequireEmailVerified]
     [SuppressMessage("ReSharper", "ConvertIfStatementToReturnStatement")]
-    [RateLimitSettings(450, 180, 300, "game-asset-upload")]
+    [RateLimitSettings(300, 200, 240, "game-asset-upload")]
     public Response UploadAsset(RequestContext context, string hash, string type, byte[] body, IDataStore dataStore,
         GameDatabaseContext database, GameUser user, AssetImporter importer, GameServerConfig config, IDateTimeProvider timeProvider, Token token,
         DataContext dataContext)
@@ -106,7 +106,7 @@ public class ResourceEndpoints : EndpointGroup
 
     [GameEndpoint("r/{hash}")]
     [MinimumRole(GameUserRole.Restricted)]
-    [RateLimitSettings(450, 250, 300, "game-asset-download")]
+    [RateLimitSettings(300, 340, 240, "game-asset-download")]
     public Response GetResource(RequestContext context, GameUser user, Token token, string hash, DataContext dataContext, ChallengeGhostRateLimitService ghostService)
     {
         if (!CommonPatterns.Sha1Regex().IsMatch(hash)) return BadRequest;


### PR DESCRIPTION
First round of adjusting some of the recently added endpoint-specific rate limit parameters. This loosens the limits for endpoints which seem to have been rate-limited too quickly on production. More such PRs will likely be needed in the future, since it's not easy to nail these values (not too loose and not too strict) outside of production.