### PR TITLE
Ability to properly backroll migration jobs

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -52,15 +52,11 @@ public partial class GameDatabaseContext // Levels
             EnforceMinMaxPlayers = createInfo.EnforceMinMaxPlayers,
             SameScreenGame = createInfo.SameScreenGame,
             BackgroundGuid = createInfo.BackgroundGuid,
-            Publisher = publisher,
+            PublisherUserId = publisher.UserId,
             GameVersion = game,
             PublishDate = timestamp,
             UpdateDate = timestamp,
         };
-
-        // This prevents EF from trying to INSERT both the user and their stats in unit tests, 
-        // just because of us setting the level.Publisher reference, and throwing a duplicate key exception that way.
-        this.Entry(level.Publisher).State = EntityState.Unchanged;
 
         this.ApplyLevelMetadataFromAttributes(level);
         this.GameLevels.Add(level);
@@ -78,6 +74,8 @@ public partial class GameDatabaseContext // Levels
             publisher.Statistics!.LevelCount++;
         });
 
+        level.Publisher = publisher;
+        this.Entry(level.Publisher).State = EntityState.Unchanged;
         return level;
     }
 

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -58,13 +58,12 @@ public partial class GameDatabaseContext // Levels
             UpdateDate = timestamp,
         };
 
+        // This prevents EF from trying to INSERT both the user and their stats in unit tests, 
+        // just because of us setting the level.Publisher reference, and throwing a duplicate key exception that way.
+        this.Entry(level.Publisher).State = EntityState.Unchanged;
+
         this.ApplyLevelMetadataFromAttributes(level);
         this.GameLevels.Add(level);
-
-        // Seems unnecessary, but prevents EF from trying to INSERT both unconditionally in unit tests
-        this.GameUsers.Update(publisher);
-        if (publisher.Statistics != null)
-            this.GameUserStatistics.Update(publisher.Statistics);
 
         this.SaveChanges();
 

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -52,7 +52,7 @@ public partial class GameDatabaseContext // Levels
             EnforceMinMaxPlayers = createInfo.EnforceMinMaxPlayers,
             SameScreenGame = createInfo.SameScreenGame,
             BackgroundGuid = createInfo.BackgroundGuid,
-            PublisherUserId = publisher.UserId,
+            Publisher = publisher,
             GameVersion = game,
             PublishDate = timestamp,
             UpdateDate = timestamp,
@@ -61,31 +61,24 @@ public partial class GameDatabaseContext // Levels
         this.ApplyLevelMetadataFromAttributes(level);
         this.GameLevels.Add(level);
 
+        // Seems unnecessary, but prevents EF from trying to INSERT both unconditionally in unit tests
+        this.GameUsers.Update(publisher);
+        if (publisher.Statistics != null)
+            this.GameUserStatistics.Update(publisher.Statistics);
+
         this.SaveChanges();
 
-        this.CreateRevisionForLevel(level, level.Publisher);
-        this.GameLevelStatistics.Add(level.Statistics = new GameLevelStatistics
+        this.WriteEnsuringStatistics(publisher, () =>
         {
-            LevelId = level.LevelId,
+            this.GameLevelStatistics.Add(level.Statistics = new GameLevelStatistics
+            {
+                LevelId = level.LevelId,
+            });
+
+            this.CreateRevisionForLevel(level, level.Publisher);
+            publisher.Statistics!.LevelCount++;
         });
 
-        this.SaveChanges();
-
-        if (publisher != null)
-        {
-            this.WriteEnsuringStatistics(publisher, () =>
-            {
-                // even if the level count does get updated, ChangeTracker.HasChanges() will return false anyways
-                // (in unit tests atleast), failing the assert
-                this.GameUsers.Update(publisher);
-                publisher.Statistics!.LevelCount++;
-            });
-        }
-
-        // setting Publisher on an untracked object prevents EF from unconditionally trying to INSERT the publisher into the 
-        // GameUsers table on the next SaveChanges() call in unit tests, causing a duplicate key exception
-        level = level.Clone();
-        level.Publisher = publisher;
         return level;
     }
 

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -52,7 +52,7 @@ public partial class GameDatabaseContext // Levels
             EnforceMinMaxPlayers = createInfo.EnforceMinMaxPlayers,
             SameScreenGame = createInfo.SameScreenGame,
             BackgroundGuid = createInfo.BackgroundGuid,
-            Publisher = publisher,
+            PublisherUserId = publisher.UserId,
             GameVersion = game,
             PublishDate = timestamp,
             UpdateDate = timestamp,
@@ -71,14 +71,21 @@ public partial class GameDatabaseContext // Levels
 
         this.SaveChanges();
 
-        if (level.Publisher != null)
+        if (publisher != null)
         {
-            this.WriteEnsuringStatistics(level.Publisher, () =>
+            this.WriteEnsuringStatistics(publisher, () =>
             {
-                level.Publisher.Statistics!.LevelCount++;
+                // even if the level count does get updated, ChangeTracker.HasChanges() will return false anyways
+                // (in unit tests atleast), failing the assert
+                this.GameUsers.Update(publisher);
+                publisher.Statistics!.LevelCount++;
             });
         }
 
+        // setting Publisher on an untracked object prevents EF from unconditionally trying to INSERT the publisher into the 
+        // GameUsers table on the next SaveChanges() call in unit tests, causing a duplicate key exception
+        level = level.Clone();
+        level.Publisher = publisher;
         return level;
     }
 

--- a/Refresh.Database/GameDatabaseContext.Workers.cs
+++ b/Refresh.Database/GameDatabaseContext.Workers.cs
@@ -50,6 +50,13 @@ public partial class GameDatabaseContext // Workers
         return JsonConvert.DeserializeObject(state.State, type);
     }
 
+    public IQueryable<string> GetAllJobIds(WorkerClass? workerClass)
+    {
+        IQueryable<PersistentJobState> states = this.JobStates;
+        if (workerClass != null) states = states.Where(s => s.Class == workerClass);
+        return states.Select(s => s.JobId);
+    }
+
     public void UpdateOrCreateJobState(string jobId, object state, WorkerClass workerClass)
     {
         PersistentJobState? jobState = this.JobStates.FirstOrDefault(s => s.JobId == jobId && s.Class == workerClass);
@@ -65,5 +72,11 @@ public partial class GameDatabaseContext // Workers
         
         jobState.State = JsonConvert.SerializeObject(state, Formatting.None);
         this.SaveChanges();
+    }
+
+    public void RemoveJobState(string jobId, bool save = true)
+    {
+        this.JobStates.RemoveRange(s => s.JobId == jobId);
+        if (save) this.SaveChanges();
     }
 }

--- a/Refresh.Database/GameDatabaseContext.Workers.cs
+++ b/Refresh.Database/GameDatabaseContext.Workers.cs
@@ -65,6 +65,7 @@ public partial class GameDatabaseContext // Workers
             jobState = new PersistentJobState
             {
                 JobId = jobId,
+                Class = workerClass,
             };
 
             this.JobStates.Add(jobState);

--- a/Refresh.Workers/WorkerManager.cs
+++ b/Refresh.Workers/WorkerManager.cs
@@ -105,6 +105,20 @@ public class WorkerManager
         this._threadShouldRun = true;
         Thread thread = new(() =>
         {
+            GameDatabaseContext database = this._databaseProvider.GetContext();
+            string[] jobsFromWorkerManager = this._jobs.Select(j => j.GetType().Name).ToArray();
+            string[] jobsFromDatabase = database.GetAllJobIds(WorkerClass.Refresh).ToArray();
+            
+            foreach (string jobId in jobsFromDatabase)
+            {
+                if (!jobsFromWorkerManager.Any(j => j == jobId))
+                {
+                    this._logger.LogInfo(RefreshContext.Worker, $"Removing job state for {jobId} because it doesn't exist in RefreshWorkerManager (likely from a newer/different Refresh build).");
+                    database.RemoveJobState(jobId, false);
+                }
+            }
+            database.SaveChanges();
+
             while (this._threadShouldRun)
             {
                 try

--- a/Refresh.Workers/WorkerManager.cs
+++ b/Refresh.Workers/WorkerManager.cs
@@ -42,7 +42,7 @@ public class WorkerManager
         this._jobs.Add(worker);
     }
 
-    private void RunWorkCycle()
+    public void RunWorkCycle()
     {
         WorkContext context = new()
         {
@@ -99,25 +99,30 @@ public class WorkerManager
         }
     }
 
+    public void RemoveUnusedJobStates()
+    {
+        GameDatabaseContext database = this._databaseProvider.GetContext();
+        string[] jobsFromWorkerManager = this._jobs.Select(j => j.GetType().Name).ToArray();
+        string[] jobsFromDatabase = database.GetAllJobIds(WorkerClass.Refresh).ToArray();
+        
+        foreach (string jobId in jobsFromDatabase)
+        {
+            if (!jobsFromWorkerManager.Any(j => j == jobId))
+            {
+                this._logger.LogInfo(RefreshContext.Worker, $"Removing job state for {jobId} because it doesn't exist in RefreshWorkerManager (likely from a newer/different Refresh build).");
+                database.RemoveJobState(jobId, false);
+            }
+        }
+        database.SaveChanges();
+    }
+
     public void Start()
     {
         this._logger.LogDebug(RefreshContext.Startup, "Starting the worker thread");
         this._threadShouldRun = true;
         Thread thread = new(() =>
         {
-            GameDatabaseContext database = this._databaseProvider.GetContext();
-            string[] jobsFromWorkerManager = this._jobs.Select(j => j.GetType().Name).ToArray();
-            string[] jobsFromDatabase = database.GetAllJobIds(WorkerClass.Refresh).ToArray();
-            
-            foreach (string jobId in jobsFromDatabase)
-            {
-                if (!jobsFromWorkerManager.Any(j => j == jobId))
-                {
-                    this._logger.LogInfo(RefreshContext.Worker, $"Removing job state for {jobId} because it doesn't exist in RefreshWorkerManager (likely from a newer/different Refresh build).");
-                    database.RemoveJobState(jobId, false);
-                }
-            }
-            database.SaveChanges();
+            this.RemoveUnusedJobStates();
 
             while (this._threadShouldRun)
             {

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -17,6 +17,7 @@ using Refresh.Interfaces.Game.Endpoints.DataTypes.Request;
 using Refresh.Database.Models.Playlists;
 using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Request;
 using Refresh.Database.Models.Photos;
+using Microsoft.EntityFrameworkCore;
 
 namespace RefreshTests.GameServer;
 
@@ -111,6 +112,7 @@ public class TestContext : IDisposable
         GameUser user = this.Database.CreateUser(username, $"{username}@{username}.local");
         if (role != GameUserRole.User) this.Database.SetUserRole(user, role);
         if (verifyEmail) this.Database.VerifyUserEmail(user);
+        this.Database.Entry(user).State = EntityState.Unchanged;
 
         return user;
     }

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -237,9 +237,14 @@ public class TestContext : IDisposable
         {
             Database = this.Database,
             Logger = this.Server.Value.Logger,
-            DataStore = (IDataStore)this.GetService<StorageService>()
-                .AddParameterToEndpoint(null!, new BunkumParameterInfo(typeof(IDataStore), ""), null!)!,
+            DataStore = this.GetDataStore(),
         };
+    }
+
+    public IDataStore GetDataStore()
+    {
+        return (IDataStore)this.GetService<StorageService>()
+            .AddParameterToEndpoint(null!, new BunkumParameterInfo(typeof(IDataStore), ""), null!)!;
     }
 
     public void Dispose()

--- a/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
@@ -25,6 +25,18 @@ public class UploadTests : GameServerTest
     }
 
     [Test]
+    public void CanCreateTwoLevelsWhileRefreshing()
+    {
+        using TestContext context = this.GetServer(false);
+        GameUser user = context.CreateUser();
+        context.Database.Refresh();
+        GameLevel level1 = context.CreateLevel(user);
+        context.Database.Refresh();
+        GameLevel level2 = context.CreateLevel(user);
+        context.Database.Refresh();
+    }
+
+    [Test]
     public void CanUpdateLevel()
     {
         using TestContext context = this.GetServer(false);

--- a/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
@@ -25,14 +25,17 @@ public class UploadTests : GameServerTest
     }
 
     [Test]
-    public void CanCreateTwoLevelsWhileRefreshing()
+    public void CanCreateMultipleLevelsWhileRefreshing()
     {
         using TestContext context = this.GetServer(false);
         GameUser user = context.CreateUser();
+
         context.Database.Refresh();
         GameLevel level1 = context.CreateLevel(user);
         context.Database.Refresh();
         GameLevel level2 = context.CreateLevel(user);
+        context.Database.Refresh();
+        GameLevel level3 = context.CreateLevel(user);
         context.Database.Refresh();
     }
 

--- a/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
@@ -40,6 +40,18 @@ public class UploadTests : GameServerTest
     }
 
     [Test]
+    public void LevelReferencesAreSetAfterCreation()
+    {
+        using TestContext context = this.GetServer(false);
+        GameUser user = context.CreateUser();
+
+        context.Database.Refresh();
+        GameLevel level = context.CreateLevel(user);
+        Assert.That(level.Publisher, Is.Not.Null);
+        Assert.That(level.Statistics, Is.Not.Null);
+    }
+
+    [Test]
     public void CanUpdateLevel()
     {
         using TestContext context = this.GetServer(false);

--- a/RefreshTests.GameServer/Tests/Workers/JobStateTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/JobStateTests.cs
@@ -135,6 +135,7 @@ public class JobStateTests : GameServerTest
         // Simulate a roll-back, meaning the job wouldn't be in the WorkerManager anymore, so no migrations will happen, and the job state would be
         // auto-removed by WorkerManager.Start() in real cases.
         manager = new(Logger, dataStore, context.DatabaseProvider);
+        context.Database.Refresh();
         GameLevel thirdLevel = context.CreateLevel(user);
 
         manager.RemoveUnusedJobStates();

--- a/RefreshTests.GameServer/Tests/Workers/JobStateTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/JobStateTests.cs
@@ -1,0 +1,168 @@
+using Bunkum.Core.Storage;
+using Refresh.Database.Models.Levels;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Models.Workers;
+using Refresh.Workers;
+using Refresh.Workers.State;
+
+namespace RefreshTests.GameServer.Tests.Workers;
+
+public class JobStateTests : GameServerTest
+{
+    [Test]
+    public void RemovesJobStateIfJobDoesntExist()
+    {
+        using TestContext context = this.GetServer();
+        IDataStore dataStore = context.GetDataStore();
+        WorkerManager manager = new(Logger, dataStore, context.DatabaseProvider);
+
+        context.Database.UpdateOrCreateJobState(typeof(TestMigrationJob).Name, new MigrationJobState(), WorkerClass.Refresh);
+        Assert.That(context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh), Is.Not.Null);
+
+        manager.RemoveUnusedJobStates();
+        manager.RunWorkCycle();
+        context.Database.Refresh();
+
+        object? stateObject = context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Null);
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DoesNotRemoveJobStateIfJobExists(bool uploadLevel)
+    {
+        using TestContext context = this.GetServer();
+        IDataStore dataStore = context.GetDataStore();
+        WorkerManager manager = new(Logger, dataStore, context.DatabaseProvider);
+        TestMigrationJob job = new();
+        manager.AddJob(job);
+
+        context.Database.UpdateOrCreateJobState(typeof(TestMigrationJob).Name, new MigrationJobState()
+        {
+            Total = uploadLevel ? 1 : 0, // Since we're creating the state manually, instead of having WorkerManager do it
+        }, WorkerClass.Refresh);
+        Assert.That(context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh), Is.Not.Null);
+
+        if (uploadLevel)
+        {
+            context.CreateLevel(context.CreateUser());
+            Assert.That(context.Database.GetTotalLevelCount(), Is.EqualTo(1));
+            
+        }
+        manager.RemoveUnusedJobStates();
+        manager.RunWorkCycle();
+        context.Database.Refresh();
+
+        object? stateObject = context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
+        MigrationJobState jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Processed, Is.EqualTo(uploadLevel ? 1 : 0));
+        Assert.That(jobState.Total, Is.EqualTo(uploadLevel ? 1 : 0));
+        Assert.That(jobState.Complete, Is.True);
+    }
+
+    [Test]
+    public void DoesNotRemoveJobStateIfNotRefreshClass()
+    {
+        using TestContext context = this.GetServer();
+        IDataStore dataStore = context.GetDataStore();
+        WorkerManager manager = new(Logger, dataStore, context.DatabaseProvider);
+        
+        context.Database.UpdateOrCreateJobState(typeof(TestMigrationJob).Name, new MigrationJobState(), WorkerClass.Craftworld);
+        Assert.That(context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Craftworld), Is.Not.Null);
+
+        manager.RemoveUnusedJobStates();
+        manager.RunWorkCycle();
+        context.Database.Refresh();
+
+        object? stateObject = context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Craftworld);
+        Assert.That(stateObject, Is.Not.Null);
+
+        MigrationJobState jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Complete, Is.True);
+    }
+
+    [Test]
+    public void ReExecutesMigrationJobAfterRollbackAndReupdate()
+    {
+        using TestContext context = this.GetServer();
+        IDataStore dataStore = context.GetDataStore();
+        WorkerManager manager = new(Logger, dataStore, context.DatabaseProvider);
+        TestMigrationJob job = new();
+        manager.AddJob(job);
+
+        GameUser user = context.CreateUser();
+        GameLevel firstLevel = context.CreateLevel(user);
+        
+        // migrate first level
+        manager.RemoveUnusedJobStates();
+        manager.RunWorkCycle();
+        context.Database.Refresh();
+
+        object? stateObject = context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
+        MigrationJobState jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Complete, Is.True);
+        Assert.That(jobState.Processed, Is.EqualTo(1));
+
+        GameLevel? firstLevelMigrated = context.Database.GetLevelById(firstLevel.LevelId);
+        Assert.That(firstLevelMigrated, Is.Not.Null);
+        Assert.That(firstLevelMigrated!.Title, Does.EndWith(" test"));
+        context.Database.Refresh();
+
+        // While we do automatically apply whatever new change we've migrated existing entities to for real migrations (photo subjects, player limits etc.),
+        // we don't auto-append " test" to new levels here, so we can safely create this level now, which would need migration aswell because of this.
+        GameLevel secondLevel = context.CreateLevel(user);
+        // Should skip job because it's still "complete", so the new level won't be migrated.
+        manager.RunWorkCycle();
+        context.Database.Refresh();
+
+        GameLevel? secondLevelFromDb = context.Database.GetLevelById(secondLevel.LevelId);
+        Assert.That(secondLevelFromDb, Is.Not.Null);
+        Assert.That(secondLevelFromDb!.Title, Does.Not.EndWith(" test"));
+
+        stateObject = context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
+        jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Complete, Is.True);
+        Assert.That(jobState.Processed, Is.EqualTo(1));
+
+        // Simulate a roll-back, meaning the job wouldn't be in the WorkerManager anymore, so no migrations will happen, and the job state would be
+        // auto-removed by WorkerManager.Start() in real cases.
+        manager = new(Logger, dataStore, context.DatabaseProvider);
+        manager.RemoveUnusedJobStates();
+        manager.RunWorkCycle();
+        context.Database.Refresh();
+
+        // Second level was not migrated, and the job state was removed
+        stateObject = context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Null);
+
+        GameLevel? secondLevelMigrated = context.Database.GetLevelById(secondLevel.LevelId);
+        Assert.That(secondLevelMigrated, Is.Not.Null);
+        Assert.That(secondLevelMigrated!.Title, Does.Not.EndWith(" test"));
+
+        // Now simulate a re-update, where the job is in the WorkerManager again
+        manager = new(Logger, dataStore, context.DatabaseProvider);
+        job = new();
+        manager.AddJob(job);
+        manager.RemoveUnusedJobStates();
+        manager.RunWorkCycle();
+        context.Database.Refresh();
+
+        stateObject = context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
+        jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Complete, Is.True);
+        Assert.That(jobState.Processed, Is.EqualTo(2));
+
+        secondLevelMigrated = context.Database.GetLevelById(secondLevel.LevelId);
+        Assert.That(secondLevelMigrated, Is.Not.Null);
+        Assert.That(secondLevelMigrated!.Title, Does.EndWith(" test"));
+    }
+}

--- a/RefreshTests.GameServer/Tests/Workers/JobStateTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/JobStateTests.cs
@@ -111,11 +111,11 @@ public class JobStateTests : GameServerTest
         GameLevel? firstLevelMigrated = context.Database.GetLevelById(firstLevel.LevelId);
         Assert.That(firstLevelMigrated, Is.Not.Null);
         Assert.That(firstLevelMigrated!.Title, Does.EndWith(" test"));
-        context.Database.Refresh();
 
         // We can ignore the fact that this level's title won't end on " test", since when we add a real migration job for a certain entity,
         // we also adjust that entity's creation/update methods in order to apply whatever change we want to new entities aswell.
         // We don't do it here, and it doesn't matter in this test.
+        context.Database.Refresh();
         GameLevel secondLevel = context.CreateLevel(user);
         // Should skip job because it's still "complete", so the new level won't be migrated.
         manager.RunWorkCycle();
@@ -134,8 +134,8 @@ public class JobStateTests : GameServerTest
 
         // Simulate a roll-back, meaning the job wouldn't be in the WorkerManager anymore, so no migrations will happen, and the job state would be
         // auto-removed by WorkerManager.Start() in real cases.
-        manager = new(Logger, dataStore, context.DatabaseProvider);
         context.Database.Refresh();
+        manager = new(Logger, dataStore, context.DatabaseProvider);
         GameLevel thirdLevel = context.CreateLevel(user);
 
         manager.RemoveUnusedJobStates();

--- a/RefreshTests.GameServer/Tests/Workers/JobStateTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/JobStateTests.cs
@@ -113,8 +113,9 @@ public class JobStateTests : GameServerTest
         Assert.That(firstLevelMigrated!.Title, Does.EndWith(" test"));
         context.Database.Refresh();
 
-        // While we do automatically apply whatever new change we've migrated existing entities to for real migrations (photo subjects, player limits etc.),
-        // we don't auto-append " test" to new levels here, so we can safely create this level now, which would need migration aswell because of this.
+        // We can ignore the fact that this level's title won't end on " test", since when we add a real migration job for a certain entity,
+        // we also adjust that entity's creation/update methods in order to apply whatever change we want to new entities aswell.
+        // We don't do it here, and it doesn't matter in this test.
         GameLevel secondLevel = context.CreateLevel(user);
         // Should skip job because it's still "complete", so the new level won't be migrated.
         manager.RunWorkCycle();
@@ -134,17 +135,23 @@ public class JobStateTests : GameServerTest
         // Simulate a roll-back, meaning the job wouldn't be in the WorkerManager anymore, so no migrations will happen, and the job state would be
         // auto-removed by WorkerManager.Start() in real cases.
         manager = new(Logger, dataStore, context.DatabaseProvider);
+        GameLevel thirdLevel = context.CreateLevel(user);
+
         manager.RemoveUnusedJobStates();
         manager.RunWorkCycle();
         context.Database.Refresh();
 
-        // Second level was not migrated, and the job state was removed
+        // No new levels were migrated, and the job state was removed
         stateObject = context.Database.GetJobState(typeof(TestMigrationJob).Name, typeof(MigrationJobState), WorkerClass.Refresh);
         Assert.That(stateObject, Is.Null);
 
         GameLevel? secondLevelMigrated = context.Database.GetLevelById(secondLevel.LevelId);
         Assert.That(secondLevelMigrated, Is.Not.Null);
         Assert.That(secondLevelMigrated!.Title, Does.Not.EndWith(" test"));
+
+        GameLevel? thirdLevelMigrated = context.Database.GetLevelById(thirdLevel.LevelId);
+        Assert.That(thirdLevelMigrated, Is.Not.Null);
+        Assert.That(thirdLevelMigrated!.Title, Does.Not.EndWith(" test"));
 
         // Now simulate a re-update, where the job is in the WorkerManager again
         manager = new(Logger, dataStore, context.DatabaseProvider);
@@ -159,10 +166,14 @@ public class JobStateTests : GameServerTest
 
         jobState = (MigrationJobState)stateObject!;
         Assert.That(jobState.Complete, Is.True);
-        Assert.That(jobState.Processed, Is.EqualTo(2));
+        Assert.That(jobState.Processed, Is.EqualTo(3));
 
         secondLevelMigrated = context.Database.GetLevelById(secondLevel.LevelId);
         Assert.That(secondLevelMigrated, Is.Not.Null);
         Assert.That(secondLevelMigrated!.Title, Does.EndWith(" test"));
+
+        thirdLevelMigrated = context.Database.GetLevelById(thirdLevel.LevelId);
+        Assert.That(thirdLevelMigrated, Is.Not.Null);
+        Assert.That(thirdLevelMigrated!.Title, Does.EndWith(" test"));
     }
 }


### PR DESCRIPTION
Makes the `WorkerManager` automatically remove job states from DB if the manager doesn't have a matching job class, as long as the state belongs to a `Refresh`-class job. This way, if an instance admin wants to backroll their instance to a Refresh version which doesn't have a certain migration job (which was previously already executed due to them running the newer version first), and then they want to update their instance again, the new job will migrate all entities again, which means that it'll also catch all entities uploaded or updated after the rollback, but before the update. 

This does mean that such jobs could try to migrate already migrated entities, however the jobs themselves should have to ensure that no issues will happen because of that, e.g. by simply skipping entities which don't need a migration (TODO until next release).

This also adds a few workarounds to weird test-exclusive issues I've found when writing unit tests for this, where EF would reasonlessly try to also insert the user and their stats when trying to insert a different entity (`GameLevel` or `Event` mostly) into the database, while having their user reference set.