### PR TITLE
Fix pin and photo subject migration jobs

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Photos.cs
+++ b/Refresh.Database/GameDatabaseContext.Photos.cs
@@ -119,67 +119,20 @@ public partial class GameDatabaseContext // Photos
         return newPhoto;
     }
 
-    /// <remarks>
-    /// Migration only!!
-    /// </remarks>
-    public void MigratePhotoSubjects(GamePhoto photo, bool saveChanges)
+    public GamePhotoSubject AddSubjectForPhoto(GamePhoto photo, int playerId, string displayName, GameUser? user, List<float> bounds, bool save = true)
     {
-        List<GamePhotoSubject> subjects = [];
-
-#pragma warning disable CS0618 // obsoletion
-        
-        // If DisplayName is not null, there is a subject in that spot
-        if (photo.Subject1DisplayName != null)
+        GamePhotoSubject subject = new()
         {
-            subjects.Add(new()
-            {
-                Photo = photo,
-                PlayerId = 1,
-                DisplayName = photo.Subject1DisplayName,
-                User = photo.Subject1User,
-                Bounds = photo.Subject1Bounds,
-            });
-        }
+            Photo = photo,
+            PlayerId = playerId,
+            DisplayName = displayName,
+            User = user,
+            Bounds = bounds,
+        };
 
-        if (photo.Subject2DisplayName != null)
-        {
-            subjects.Add(new()
-            {
-                Photo = photo,
-                PlayerId = 2,
-                DisplayName = photo.Subject2DisplayName,
-                User = photo.Subject2User,
-                Bounds = photo.Subject2Bounds,
-            });
-        }
-
-        if (photo.Subject3DisplayName != null)
-        {
-            subjects.Add(new()
-            {
-                Photo = photo,
-                PlayerId = 3,
-                DisplayName = photo.Subject3DisplayName,
-                User = photo.Subject3User,
-                Bounds = photo.Subject3Bounds,
-            });
-        }
-
-        if (photo.Subject4DisplayName != null)
-        {
-            subjects.Add(new()
-            {
-                Photo = photo,
-                PlayerId = 4,
-                DisplayName = photo.Subject4DisplayName,
-                User = photo.Subject4User,
-                Bounds = photo.Subject4Bounds,
-            });
-        }
-#pragma warning restore CS0618
-
-        this.GamePhotoSubjects.AddRange(subjects);
-        if (saveChanges) this.SaveChanges();
+        this.GamePhotoSubjects.Add(subject);
+        if (save) this.SaveChanges();
+        return subject;
     }
 
     public void RemovePhoto(GamePhoto photo)
@@ -226,6 +179,9 @@ public partial class GameDatabaseContext // Photos
         => this.GamePhotoSubjectsIncluded
             .Where(s => s.PhotoId == photo.PhotoId)
             .OrderBy(s => s.PlayerId);
+    
+    public int GetTotalSubjectsInPhoto(GamePhoto photo)
+        => this.GamePhotoSubjects.Count(s => s.PhotoId == photo.PhotoId);
     
     public IQueryable<GameUser> GetUsersInPhoto(GamePhoto photo)
         => this.GetSubjectsInPhoto(photo)

--- a/Refresh.Database/GameDatabaseContext.Pins.cs
+++ b/Refresh.Database/GameDatabaseContext.Pins.cs
@@ -180,8 +180,6 @@ public partial class GameDatabaseContext // Pins
 
     public DatabaseList<ProfilePinRelation> GetProfilePinsByUser(GameUser user, TokenGame game, TokenPlatform platform, int skip, int count)
         => new(this.GetProfilePinsByUser(user, game, platform), skip, count);
-
-    #region Migration Methods
     
     public void AddPinProgress(PinProgressRelation relation, bool save)
     {
@@ -189,11 +187,12 @@ public partial class GameDatabaseContext // Pins
         if (save) this.SaveChanges();
     }
 
-    public void RemoveAllPinProgressesByIdAndUser(long pinId, ObjectId userId, bool save)
+    public void RemovePinProgress(PinProgressRelation relation, bool save)
     {
-        this.PinProgressRelations.RemoveRange(p => p.PinId == pinId && p.PublisherId == userId);
+        this.PinProgressRelations.Remove(relation);
         if (save) this.SaveChanges();
     }
 
-    #endregion
+    public int GetTotalPinProgresses()
+        => this.PinProgressRelations.Count();
 }

--- a/Refresh.Database/GameDatabaseContext.Relations.cs
+++ b/Refresh.Database/GameDatabaseContext.Relations.cs
@@ -477,20 +477,6 @@ public partial class GameDatabaseContext // Relations
         this.SaveChanges();
         return review;
     }
-
-    public void MigrateReviewLabels(IEnumerable<GameReview> reviews)
-    {
-        foreach (GameReview review in reviews)
-        {
-#pragma warning disable CS0618 // LabelsString is obsolete          
-            if (string.IsNullOrWhiteSpace(review.LabelsString)) continue;
-
-            review.Labels = LabelExtensions.FromLbpCommaList(review.LabelsString).ToList();
-#pragma warning restore CS0618
-        }
-
-        this.SaveChanges();
-    }
     
     public void DeleteReviewsPostedByUser(GameUser user)
     {

--- a/Refresh.Interfaces.Workers/Migrations/BackfillLevelAttributesMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/BackfillLevelAttributesMigration.cs
@@ -12,7 +12,7 @@ public class BackfillLevelAttributesMigration : MigrationJob<GameLevel>
             .OrderBy(l => l.LevelId);
     }
 
-    protected override void Migrate(WorkContext context, GameLevel[] batch)
+    protected override int Migrate(WorkContext context, GameLevel[] batch)
     {
         foreach (GameLevel level in batch)
         {
@@ -20,5 +20,6 @@ public class BackfillLevelAttributesMigration : MigrationJob<GameLevel>
         }
 
         context.Database.SaveChanges();
+        return batch.Length;
     }
 }

--- a/Refresh.Interfaces.Workers/Migrations/BackfillModdedPlanetFlagsMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/BackfillModdedPlanetFlagsMigration.cs
@@ -16,7 +16,7 @@ public class BackfillModdedPlanetFlagsMigration : MigrationJob<GameUser>
             || u.BetaPlanetsHash != "0");
     }
 
-    protected override void Migrate(WorkContext context, GameUser[] batch)
+    protected override int Migrate(WorkContext context, GameUser[] batch)
     {
         foreach (GameUser user in batch)
         {
@@ -24,5 +24,6 @@ public class BackfillModdedPlanetFlagsMigration : MigrationJob<GameUser>
         }
 
         context.Database.SaveChanges();
+        return batch.Length;
     }
 }

--- a/Refresh.Interfaces.Workers/Migrations/BackfillReviewLabelsMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/BackfillReviewLabelsMigration.cs
@@ -1,4 +1,5 @@
-﻿using Refresh.Database.Models.Comments; 
+﻿using Refresh.Database.Models.Comments;
+using Refresh.Database.Models.Levels;
 using Refresh.Workers;
 
 namespace Refresh.Interfaces.Workers.Migrations;
@@ -7,7 +8,17 @@ public class BackfillReviewLabelsMigration : MigrationJob<GameReview>
 {
     protected override void Migrate(WorkContext context, GameReview[] batch)
     {
-        context.Database.MigrateReviewLabels(batch);
+        foreach (GameReview review in batch)
+        {
+#pragma warning disable CS0618 // LabelsString is obsolete          
+            if (string.IsNullOrWhiteSpace(review.LabelsString)) continue;
+
+            context.Database.Update(review);
+            review.Labels = LabelExtensions.FromLbpCommaList(review.LabelsString).ToList();
+#pragma warning restore CS0618
+        }
+
+        context.Database.SaveChanges();
     }
 
     protected override IQueryable<GameReview> SortAndFilter(IQueryable<GameReview> query)

--- a/Refresh.Interfaces.Workers/Migrations/BackfillReviewLabelsMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/BackfillReviewLabelsMigration.cs
@@ -6,7 +6,7 @@ namespace Refresh.Interfaces.Workers.Migrations;
 
 public class BackfillReviewLabelsMigration : MigrationJob<GameReview>
 {
-    protected override void Migrate(WorkContext context, GameReview[] batch)
+    protected override int Migrate(WorkContext context, GameReview[] batch)
     {
         foreach (GameReview review in batch)
         {
@@ -19,6 +19,7 @@ public class BackfillReviewLabelsMigration : MigrationJob<GameReview>
         }
 
         context.Database.SaveChanges();
+        return batch.Length;
     }
 
     protected override IQueryable<GameReview> SortAndFilter(IQueryable<GameReview> query)

--- a/Refresh.Interfaces.Workers/Migrations/BackfillRevisionMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/BackfillRevisionMigration.cs
@@ -5,12 +5,13 @@ namespace Refresh.Interfaces.Workers.Migrations;
 
 public class BackfillRevisionMigration : MigrationJob<GameLevel>
 {
-    protected override void Migrate(WorkContext context, GameLevel[] batch)
+    protected override int Migrate(WorkContext context, GameLevel[] batch)
     {
         foreach (GameLevel level in batch)
         {
             context.Database.CreateRevisionForLevel(level, null);
         }
+        return batch.Length;
     }
 
     protected override IQueryable<GameLevel> SortAndFilter(IQueryable<GameLevel> query)

--- a/Refresh.Interfaces.Workers/Migrations/CalculateScoreRanksMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/CalculateScoreRanksMigration.cs
@@ -12,12 +12,13 @@ public class CalculateScoreRanksMigration : MigrationJob<GameLevel>
         return query.OrderBy(l => l.LevelId);
     }
 
-    protected override void Migrate(WorkContext context, GameLevel[] batch)
+    protected override int Migrate(WorkContext context, GameLevel[] batch)
     {
         foreach (GameLevel level in batch)
         {
             context.Database.RecalculateScoreStatistics(level);
         }
         context.Database.SaveChanges();
+        return batch.Length;
     }
 }

--- a/Refresh.Interfaces.Workers/Migrations/ClampPlayerLimitsMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/ClampPlayerLimitsMigration.cs
@@ -13,7 +13,7 @@ public class ClampPlayerLimitsMigration : MigrationJob<GameLevel>
         return query.OrderBy(l => l.LevelId);
     }
 
-    protected override void Migrate(WorkContext context, GameLevel[] batch)
+    protected override int Migrate(WorkContext context, GameLevel[] batch)
     {
         foreach (GameLevel level in batch)
         {
@@ -26,5 +26,7 @@ public class ClampPlayerLimitsMigration : MigrationJob<GameLevel>
             level.MinPlayers = Math.Clamp(level.MinPlayers, 1, 4);
             level.MaxPlayers = Math.Clamp(level.MaxPlayers, 1, 4);
         }
+
+        return batch.Length;
     }
 }

--- a/Refresh.Interfaces.Workers/Migrations/CorrectWebsitePinProgressPlatformMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/CorrectWebsitePinProgressPlatformMigration.cs
@@ -7,9 +7,9 @@ using Refresh.Workers;
 
 namespace Refresh.Interfaces.Workers.Migrations;
 
-public class CorrectWebsitePinProgressPlatform : MigrationJob<PinProgressRelation>
+public class CorrectWebsitePinProgressPlatformMigration : MigrationJob<PinProgressRelation>
 {
-    private List<long> websitePinIds =
+    private readonly List<long> WebsitePinIds =
     [
         (long)ServerPins.HeartPlayerOnWebsite,
         (long)ServerPins.QueueLevelOnWebsite,
@@ -19,13 +19,15 @@ public class CorrectWebsitePinProgressPlatform : MigrationJob<PinProgressRelatio
     protected override IQueryable<PinProgressRelation> SortAndFilter(IQueryable<PinProgressRelation> query)
     {
         return query
-            .Where(p => this.websitePinIds.Contains(p.PinId))
+            .Where(p => this.WebsitePinIds.Contains(p.PinId))
             .OrderBy(p => p.PinId);
     }
 
-    protected override void Migrate(WorkContext context, PinProgressRelation[] batch)
+    protected override int Migrate(WorkContext context, PinProgressRelation[] batch)
     {
-        foreach (long pinId in this.websitePinIds)
+        int pinsLeft = batch.Length;
+
+        foreach (long pinId in this.WebsitePinIds)
         {
             IEnumerable<IGrouping<ObjectId, PinProgressRelation>> pinsByUser = batch
                 .Where(r => r.PinId == pinId)
@@ -38,12 +40,16 @@ public class CorrectWebsitePinProgressPlatform : MigrationJob<PinProgressRelatio
 
                 // Find best one by the current user
                 PinProgressRelation relationToMigrate = group.MaxBy(r => r.Progress)!;
+                List<PinProgressRelation> relationsToRemove = group.ToList();
 
-                // Remove all already existing progresses to remove duplicates
-                context.Database.RemoveAllPinProgressesByIdAndUser(pinId, relationToMigrate.PublisherId, false);
+                foreach (PinProgressRelation relation in group)
+                {
+                    context.Database.RemovePinProgress(relation, false);
+                    pinsLeft--;
+                }
 
                 // Now take the best progress we've just got and add it as a website pin, preserving other old metadata
-                context.Database.AddPinProgress(new()
+                PinProgressRelation newRelation = new()
                 {
                     PinId = relationToMigrate.PinId,
                     Progress = relationToMigrate.Progress,
@@ -52,10 +58,14 @@ public class CorrectWebsitePinProgressPlatform : MigrationJob<PinProgressRelatio
                     LastUpdated = relationToMigrate.LastUpdated,
                     IsBeta = false, // doesn't matter here
                     Platform = TokenPlatform.Website,
-                }, false);
+                };
+
+                context.Database.AddPinProgress(newRelation, false);
+                pinsLeft++;
             }
         }
 
         context.Database.SaveChanges();
+        return pinsLeft;
     }
 }

--- a/Refresh.Interfaces.Workers/Migrations/EnsureDeletedUsersDeletedMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/EnsureDeletedUsersDeletedMigration.cs
@@ -15,12 +15,13 @@ public class EnsureDeletedUsersDeletedMigration : MigrationJob<GameUser>
             .OrderBy(u => u.UserId); // can't use join date here as we're changing the join date when we delete data
     }
 
-    protected override void Migrate(WorkContext context, GameUser[] batch)
+    protected override int Migrate(WorkContext context, GameUser[] batch)
     {
         foreach (GameUser user in batch)
         {
             context.Logger.LogWarning(RefreshContext.Worker, $"Deleting {user.Username}'s account again to ensure data has been wiped...");
             context.Database.DeleteUser(user);
         }
+        return batch.Length;
     }
 }

--- a/Refresh.Interfaces.Workers/Migrations/MoveSubjectsOutOfGamePhotosMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/MoveSubjectsOutOfGamePhotosMigration.cs
@@ -12,7 +12,7 @@ public class MoveSubjectsOutOfGamePhotosMigration : MigrationJob<GamePhoto>
             .OrderBy(p => p.PhotoId);
     }
 
-    protected override void Migrate(WorkContext context, GamePhoto[] batch)
+    protected override int Migrate(WorkContext context, GamePhoto[] batch)
     {
         foreach (GamePhoto photo in batch)
         {
@@ -47,5 +47,6 @@ public class MoveSubjectsOutOfGamePhotosMigration : MigrationJob<GamePhoto>
         }
 
         context.Database.SaveChanges();
+        return batch.Length;
     }
 }

--- a/Refresh.Interfaces.Workers/Migrations/MoveSubjectsOutOfGamePhotosMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/MoveSubjectsOutOfGamePhotosMigration.cs
@@ -7,14 +7,43 @@ public class MoveSubjectsOutOfGamePhotosMigration : MigrationJob<GamePhoto>
 {
     protected override IQueryable<GamePhoto> SortAndFilter(IQueryable<GamePhoto> query)
     {
-        return query.OrderBy(p => p.PhotoId);
+        return query
+            .Where(p => p.Subjects.Count == 0)
+            .OrderBy(p => p.PhotoId);
     }
 
     protected override void Migrate(WorkContext context, GamePhoto[] batch)
     {
         foreach (GamePhoto photo in batch)
         {
-            context.Database.MigratePhotoSubjects(photo, false);
+            // Extra check to be sure
+            if (context.Database.GetTotalSubjectsInPhoto(photo) > 0)
+                continue;
+
+            #pragma warning disable CS0618 // obsoletion
+
+            // If DisplayName is not null, there is a subject in that spot
+            if (photo.Subject1DisplayName != null)
+            {
+                context.Database.AddSubjectForPhoto(photo, 1, photo.Subject1DisplayName, photo.Subject1User, photo.Subject1Bounds, false);
+            }
+
+            if (photo.Subject2DisplayName != null)
+            {
+                context.Database.AddSubjectForPhoto(photo, 2, photo.Subject2DisplayName, photo.Subject2User, photo.Subject2Bounds, false);
+            }
+
+            if (photo.Subject3DisplayName != null)
+            {
+                context.Database.AddSubjectForPhoto(photo, 3, photo.Subject3DisplayName, photo.Subject3User, photo.Subject3Bounds, false);
+            }
+
+            if (photo.Subject4DisplayName != null)
+            {
+                context.Database.AddSubjectForPhoto(photo, 4, photo.Subject4DisplayName, photo.Subject4User, photo.Subject4Bounds, false);
+            }
+
+            #pragma warning restore CS0618
         }
 
         context.Database.SaveChanges();

--- a/Refresh.Interfaces.Workers/RefreshWorkerManager.cs
+++ b/Refresh.Interfaces.Workers/RefreshWorkerManager.cs
@@ -25,7 +25,7 @@ public static class RefreshWorkerManager
         manager.AddJob<BackfillReviewLabelsMigration>();
         manager.AddJob<ClampPlayerLimitsMigration>();
         manager.AddJob<BackfillModdedPlanetFlagsMigration>();
-        manager.AddJob<CorrectWebsitePinProgressPlatform>();
+        manager.AddJob<CorrectWebsitePinProgressPlatformMigration>();
         manager.AddJob<CalculateScoreRanksMigration>();
         manager.AddJob<MoveSubjectsOutOfGamePhotosMigration>();
 

--- a/Refresh.Workers/MigrationJob.cs
+++ b/Refresh.Workers/MigrationJob.cs
@@ -40,15 +40,21 @@ public abstract class MigrationJob<TEntity> : WorkerJob, IJobStoresState where T
 
         TEntity[] batch = query.ToArray();
         
-        Migrate(context, batch);
+        int entitiesLeftCount = Migrate(context, batch);
         context.Database.SaveChanges();
         transaction.Commit();
 
-        state.Processed += batch.Length;
+        state.Processed += entitiesLeftCount;
+        state.Total = state.Total - batch.Length + entitiesLeftCount;
         context.Logger.LogInfo(RefreshContext.Database, $"{this.JobId} migrated {batch.Length} objects ({state.Processed}/{state.Total}, complete: {state.Complete})");
     }
     
     protected abstract IQueryable<TEntity> SortAndFilter(IQueryable<TEntity> query);
 
-    protected abstract void Migrate(WorkContext context, TEntity[] batch);
+    /// <returns>
+    /// The number of entities in the batch, minus the number of entities removed from DB during this migration.
+    /// E.g. if 1000 items are in the given batch, and 5 got removed from DB during migration, 
+    /// the returned number will be 1000 - 5 = 995
+    /// </returns>
+    protected abstract int Migrate(WorkContext context, TEntity[] batch);
 }

--- a/Refresh.Workers/MigrationJob.cs
+++ b/Refresh.Workers/MigrationJob.cs
@@ -47,6 +47,8 @@ public abstract class MigrationJob<TEntity> : WorkerJob, IJobStoresState where T
         state.Processed += entitiesLeftCount;
         state.Total = state.Total - batch.Length + entitiesLeftCount;
         context.Logger.LogInfo(RefreshContext.Database, $"{this.JobId} migrated {batch.Length} objects ({state.Processed}/{state.Total}, complete: {state.Complete})");
+
+        context.Database.UpdateOrCreateJobState(this.GetType().Name, state, this.JobClass);
     }
     
     protected abstract IQueryable<TEntity> SortAndFilter(IQueryable<TEntity> query);

--- a/RefreshTests.GameServer/GameServer/TestMigrationJob.cs
+++ b/RefreshTests.GameServer/GameServer/TestMigrationJob.cs
@@ -5,12 +5,14 @@ namespace RefreshTests.GameServer.GameServer;
 
 public class TestMigrationJob : MigrationJob<GameLevel>
 {
-    protected override void Migrate(WorkContext context, GameLevel[] batch)
+    protected override int Migrate(WorkContext context, GameLevel[] batch)
     {
         foreach (GameLevel level in batch)
         {
             level.Title += " test";
         }
+
+        return batch.Length;
     }
 
     protected override IQueryable<GameLevel> SortAndFilter(IQueryable<GameLevel> query)

--- a/RefreshTests.GameServer/GameServer/TestMigrationJobDeletingLevels.cs
+++ b/RefreshTests.GameServer/GameServer/TestMigrationJobDeletingLevels.cs
@@ -1,0 +1,37 @@
+﻿using Refresh.Database.Models.Levels;
+using Refresh.Workers;
+
+namespace RefreshTests.GameServer.GameServer;
+
+public class TestMigrationJobDeletingLevels : MigrationJob<GameLevel>
+{
+    protected override int BatchCount => 6;
+
+    // Deletes every second level
+    protected override int Migrate(WorkContext context, GameLevel[] batch)
+    {
+        int entitiesLeft = batch.Length;
+        int index = 0;
+        foreach (GameLevel level in batch)
+        {
+            if (index % 2 == 1)
+            {
+                context.Database.DeleteLevel(level);
+                entitiesLeft--;
+            }
+            else
+            {
+                level.Title += " test";
+            }
+
+            index++;
+        }
+
+        return entitiesLeft;
+    }
+
+    protected override IQueryable<GameLevel> SortAndFilter(IQueryable<GameLevel> query)
+    {
+        return query.OrderBy(l => l.LevelId);
+    }
+}

--- a/RefreshTests.GameServer/Tests/Workers/MigrationTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/MigrationTests.cs
@@ -1,9 +1,7 @@
 ﻿using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Levels;
-using Refresh.Database.Models.Pins;
 using Refresh.Database.Models.Users;
 using Refresh.Database.Models.Workers;
-using Refresh.Interfaces.Workers.Migrations;
 using Refresh.Workers.State;
 
 namespace RefreshTests.GameServer.Tests.Workers;
@@ -30,68 +28,6 @@ public class MigrationTests : GameServerTest
         
         allLevels = context.Database.GetNewestLevels(100, 0, null, new(TokenGame.Website)).Items;
         Assert.That(allLevels.All(l => l.Title == "Level test"), Is.True);
-    }
-
-    [Test]
-    public void WebsitePinMigrationDoesNotBreakPagination()
-    {
-        using TestContext context = this.GetServer();
-
-        for (int i = 0; i < 50; i++)
-        {
-            GameUser user = context.CreateUser();
-            context.Database.AddPinProgress(new()
-            {
-                PinId = (long)ServerPins.SignIntoWebsite,
-                Progress = i + 1,
-                Publisher = user,
-                FirstPublished = new(),
-                LastUpdated = new(),
-                IsBeta = false,
-                Platform = TokenPlatform.RPCS3,
-            }, false);
-
-            context.Database.AddPinProgress(new()
-            {
-                PinId = (long)ServerPins.SignIntoWebsite,
-                Progress = i + 1,
-                Publisher = user,
-                FirstPublished = new(),
-                LastUpdated = new(),
-                IsBeta = true,
-                Platform = TokenPlatform.RPCS3,
-            }, false);
-        }
-        context.Database.SaveChanges();
-        Assert.That(context.Database.GetTotalPinProgresses(), Is.EqualTo(100));
-
-        // Prepare migration
-        CorrectWebsitePinProgressPlatformMigration job = new();
-        context.Database.UpdateOrCreateJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, new MigrationJobState()
-        {
-            Total = 100 // Since we already have to manually create the state
-        }, WorkerClass.Refresh);
-        context.Database.Refresh();
-
-        object? stateObject = context.Database.GetJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
-        Assert.That(stateObject, Is.Not.Null);
-        job.JobState = stateObject!;
-        
-        // Migrate
-        job.ExecuteJob(context.GetWorkContext());
-        context.Database.Refresh();
-
-        stateObject = context.Database.GetJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
-        Assert.That(stateObject, Is.Not.Null);
-
-        // While we're not actually testing pagination here (batch count can't be edited + don't want to create over 1000 users here, would take too long),
-        // it should be enough to simply ensure that both the total and processed counts are adjusted to be less than 100 (as 50 pins were deleted)
-        MigrationJobState jobState = (MigrationJobState)stateObject!;
-        Assert.That(jobState.Processed, Is.EqualTo(50));
-        Assert.That(jobState.Total, Is.EqualTo(50));
-        Assert.That(jobState.Complete, Is.True);
-
-        Assert.That(context.Database.GetTotalPinProgresses(), Is.EqualTo(50));
     }
 
     [Test]
@@ -128,6 +64,9 @@ public class MigrationTests : GameServerTest
         Assert.That(context.Database.GetTotalLevelCount(), Is.EqualTo(15));
         Assert.That(context.Database.GetNewestLevels(20, 0, null, new(TokenGame.Website)).Items.Count(l => l.Title.EndsWith(" test")), Is.EqualTo(3));
 
+        stateObject = context.Database.GetJobState(typeof(TestMigrationJobDeletingLevels).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
         MigrationJobState jobState = (MigrationJobState)stateObject!;
         Assert.That(jobState.Processed, Is.EqualTo(3));
         Assert.That(jobState.Total, Is.EqualTo(15));
@@ -141,6 +80,9 @@ public class MigrationTests : GameServerTest
         Assert.That(context.Database.GetTotalLevelCount(), Is.EqualTo(12));
         Assert.That(context.Database.GetNewestLevels(20, 0, null, new(TokenGame.Website)).Items.Count(l => l.Title.EndsWith(" test")), Is.EqualTo(6));
 
+        stateObject = context.Database.GetJobState(typeof(TestMigrationJobDeletingLevels).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
         jobState = (MigrationJobState)stateObject!;
         Assert.That(jobState.Processed, Is.EqualTo(6));
         Assert.That(jobState.Total, Is.EqualTo(12));
@@ -153,6 +95,9 @@ public class MigrationTests : GameServerTest
         // Ensure 3 more levels were deleted, and 3 more levels were migrated
         Assert.That(context.Database.GetTotalLevelCount(), Is.EqualTo(9));
         Assert.That(context.Database.GetNewestLevels(20, 0, null, new(TokenGame.Website)).Items.Count(l => l.Title.EndsWith(" test")), Is.EqualTo(9));
+
+        stateObject = context.Database.GetJobState(typeof(TestMigrationJobDeletingLevels).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
 
         jobState = (MigrationJobState)stateObject!;
         Assert.That(jobState.Processed, Is.EqualTo(9));

--- a/RefreshTests.GameServer/Tests/Workers/MigrationTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/MigrationTests.cs
@@ -1,7 +1,9 @@
 ﻿using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Levels;
+using Refresh.Database.Models.Pins;
 using Refresh.Database.Models.Users;
-using Refresh.Database.Query;
+using Refresh.Database.Models.Workers;
+using Refresh.Interfaces.Workers.Migrations;
 using Refresh.Workers.State;
 
 namespace RefreshTests.GameServer.Tests.Workers;
@@ -28,5 +30,133 @@ public class MigrationTests : GameServerTest
         
         allLevels = context.Database.GetNewestLevels(100, 0, null, new(TokenGame.Website)).Items;
         Assert.That(allLevels.All(l => l.Title == "Level test"), Is.True);
+    }
+
+    [Test]
+    public void WebsitePinMigrationDoesNotBreakPagination()
+    {
+        using TestContext context = this.GetServer();
+
+        for (int i = 0; i < 50; i++)
+        {
+            GameUser user = context.CreateUser();
+            context.Database.AddPinProgress(new()
+            {
+                PinId = (long)ServerPins.SignIntoWebsite,
+                Progress = i + 1,
+                Publisher = user,
+                FirstPublished = new(),
+                LastUpdated = new(),
+                IsBeta = false,
+                Platform = TokenPlatform.RPCS3,
+            }, false);
+
+            context.Database.AddPinProgress(new()
+            {
+                PinId = (long)ServerPins.SignIntoWebsite,
+                Progress = i + 1,
+                Publisher = user,
+                FirstPublished = new(),
+                LastUpdated = new(),
+                IsBeta = true,
+                Platform = TokenPlatform.RPCS3,
+            }, false);
+        }
+        context.Database.SaveChanges();
+        Assert.That(context.Database.GetTotalPinProgresses(), Is.EqualTo(100));
+
+        // Prepare migration
+        CorrectWebsitePinProgressPlatformMigration job = new();
+        context.Database.UpdateOrCreateJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, new MigrationJobState()
+        {
+            Total = 100 // Since we already have to manually create the state
+        }, WorkerClass.Refresh);
+        context.Database.Refresh();
+
+        object? stateObject = context.Database.GetJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+        job.JobState = stateObject!;
+        
+        // Migrate
+        job.ExecuteJob(context.GetWorkContext());
+        context.Database.Refresh();
+
+        stateObject = context.Database.GetJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
+        // While we're not actually testing pagination here (batch count can't be edited + don't want to create over 1000 users here, would take too long),
+        // it should be enough to simply ensure that both the total and processed counts are adjusted to be less than 100 (as 50 pins were deleted)
+        MigrationJobState jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Processed, Is.EqualTo(50));
+        Assert.That(jobState.Total, Is.EqualTo(50));
+        Assert.That(jobState.Complete, Is.True);
+
+        Assert.That(context.Database.GetTotalPinProgresses(), Is.EqualTo(50));
+    }
+
+    [Test]
+    public void DeletingEntitiesDuringMigrationJobDoesNotBreakPagination()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+
+        // 3 cycles (6 levels per cycle)
+        for (int i = 0; i < 18; i++)
+        {
+            context.CreateLevel(user);
+        }
+        context.Database.Refresh();
+        Assert.That(context.Database.GetTotalLevelCount(), Is.EqualTo(18));
+
+        // Prepare migration
+        TestMigrationJobDeletingLevels job = new();
+        context.Database.UpdateOrCreateJobState(typeof(TestMigrationJobDeletingLevels).Name, new MigrationJobState()
+        {
+            Total = 18
+        }, WorkerClass.Refresh);
+        context.Database.Refresh();
+
+        object? stateObject = context.Database.GetJobState(typeof(TestMigrationJobDeletingLevels).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+        job.JobState = stateObject!;
+        
+        // Migrate - First cycle
+        job.ExecuteJob(context.GetWorkContext());
+        context.Database.Refresh();
+
+        // Ensure only 3 levels were actually migrated, and 3 levels were deleted
+        Assert.That(context.Database.GetTotalLevelCount(), Is.EqualTo(15));
+        Assert.That(context.Database.GetNewestLevels(20, 0, null, new(TokenGame.Website)).Items.Count(l => l.Title.EndsWith(" test")), Is.EqualTo(3));
+
+        MigrationJobState jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Processed, Is.EqualTo(3));
+        Assert.That(jobState.Total, Is.EqualTo(15));
+        Assert.That(jobState.Complete, Is.False);
+
+        // Migrate - Second cycle
+        job.ExecuteJob(context.GetWorkContext());
+        context.Database.Refresh();
+
+        // Ensure 3 more levels were deleted, and 3 more levels were migrated
+        Assert.That(context.Database.GetTotalLevelCount(), Is.EqualTo(12));
+        Assert.That(context.Database.GetNewestLevels(20, 0, null, new(TokenGame.Website)).Items.Count(l => l.Title.EndsWith(" test")), Is.EqualTo(6));
+
+        jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Processed, Is.EqualTo(6));
+        Assert.That(jobState.Total, Is.EqualTo(12));
+        Assert.That(jobState.Complete, Is.False);
+
+        // Migrate - Last cycle
+        job.ExecuteJob(context.GetWorkContext());
+        context.Database.Refresh();
+
+        // Ensure 3 more levels were deleted, and 3 more levels were migrated
+        Assert.That(context.Database.GetTotalLevelCount(), Is.EqualTo(9));
+        Assert.That(context.Database.GetNewestLevels(20, 0, null, new(TokenGame.Website)).Items.Count(l => l.Title.EndsWith(" test")), Is.EqualTo(9));
+
+        jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Processed, Is.EqualTo(9));
+        Assert.That(jobState.Total, Is.EqualTo(9));
+        Assert.That(jobState.Complete, Is.True);
     }
 }

--- a/RefreshTests.GameServer/Tests/Workers/PhotoMigrationTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/PhotoMigrationTests.cs
@@ -1,0 +1,173 @@
+using Refresh.Database.Models.Assets;
+using Refresh.Database.Models.Photos;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Models.Workers;
+using Refresh.Interfaces.Workers.Migrations;
+using Refresh.Workers.State;
+
+namespace RefreshTests.GameServer.Tests.Workers;
+
+public class PhotoMigrationTests : GameServerTest
+{
+    private const string TEST_ASSET_HASH = "0ec63b140374ba704a58fa0c743cb357683313dd";
+
+    [Test]
+    public void MigratesPhotoSubjectsButNotMultipleTimes()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        context.Database.AddAssetToDatabase(new()
+        {
+            AssetHash = TEST_ASSET_HASH,
+            AssetType = GameAssetType.Png,
+            AssetFormat = GameAssetFormat.Unknown,
+            OriginalUploader = user,
+            UploadDate = new(new DateTime(2026, 3, 11), TimeSpan.Zero),
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            context.Database.Add(new GamePhoto()
+            {
+                TakenAt = new(new DateTime(2026, 3, 18), TimeSpan.Zero),
+                PublishedAt = new(new DateTime(2026, 3, 18), TimeSpan.Zero),
+                PublisherId = user.UserId,
+                SmallAssetHash = TEST_ASSET_HASH,
+                MediumAssetHash = TEST_ASSET_HASH,
+                LargeAssetHash = TEST_ASSET_HASH,
+                PlanHash = "plan",
+                LevelType = "pod",
+                OriginalLevelId = 0,
+                OriginalLevelName = "",
+
+                #pragma warning disable CS0618 // obsoletion
+                Subject1DisplayName = "p",
+                Subject1Bounds = [3,1,4,1],
+                Subject2DisplayName = "i",
+                Subject2Bounds = [5,9,2,7],
+                #pragma warning restore CS0618
+            });
+        }
+
+        context.Database.SaveChanges();
+        Assert.That(context.Database.GetTotalPhotoCount(), Is.EqualTo(10));
+
+        MoveSubjectsOutOfGamePhotosMigration job = new();
+        context.Database.UpdateOrCreateJobState(typeof(MoveSubjectsOutOfGamePhotosMigration).Name, new MigrationJobState()
+        {
+            Total = 10
+        }, WorkerClass.Refresh);
+        context.Database.Refresh();
+
+        object? stateObject = context.Database.GetJobState(typeof(MoveSubjectsOutOfGamePhotosMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+        job.JobState = stateObject!;
+        
+        // Migrate - First cycle
+        job.ExecuteJob(context.GetWorkContext());
+        context.Database.Refresh();
+
+        Assert.That(context.Database.GetTotalPhotoCount(), Is.EqualTo(10));
+        foreach(GamePhoto photo in context.Database.GetRecentPhotos(10, 0).Items.ToArray())
+        {
+            Assert.That(photo.Subjects.Count, Is.EqualTo(2));
+            Assert.That(context.Database.GetTotalSubjectsInPhoto(photo), Is.EqualTo(2));
+
+            Assert.That(photo.Subjects.Count(s => s.DisplayName == "p"), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.DisplayName == "i"), Is.EqualTo(1));
+
+            Assert.That(photo.Subjects.Count(s => s.PlayerId == 1), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.PlayerId == 2), Is.EqualTo(1));
+        }
+
+        stateObject = context.Database.GetJobState(typeof(MoveSubjectsOutOfGamePhotosMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
+        MigrationJobState jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Processed, Is.EqualTo(10));
+        Assert.That(jobState.Total, Is.EqualTo(10));
+        Assert.That(jobState.Complete, Is.True);
+
+        // Add new, unmigrated photos
+        for (int i = 0; i < 5; i++)
+        {
+            context.Database.Add(new GamePhoto()
+            {
+                TakenAt = new(new DateTime(2026, 3, 27), TimeSpan.Zero),
+                PublishedAt = new(new DateTime(2026, 3, 27), TimeSpan.Zero),
+                PublisherId = user.UserId,
+                SmallAssetHash = TEST_ASSET_HASH,
+                MediumAssetHash = TEST_ASSET_HASH,
+                LargeAssetHash = TEST_ASSET_HASH,
+                PlanHash = "plan",
+                LevelType = "pod",
+                OriginalLevelId = 0,
+                OriginalLevelName = "",
+
+                #pragma warning disable CS0618 // obsoletion
+                Subject1DisplayName = "d",
+                Subject1Bounds = [1,2,3,4],
+                Subject2DisplayName = "a",
+                Subject2Bounds = [1,2,3,4],
+                Subject3DisplayName = "n",
+                Subject3Bounds = [1,2,3,4],
+                Subject4DisplayName = "k",
+                Subject4Bounds = [1,2,3,4],
+                #pragma warning restore CS0618
+            });
+        }
+        context.Database.SaveChanges();
+        Assert.That(context.Database.GetTotalPhotoCount(), Is.EqualTo(15));
+        context.Database.Refresh();
+
+        // Reset state, to test both the migrated photos not having their subjects re-migrated (should be skipped entirely due to SortAndFilter()),
+        // and to also test the new photos being migrated
+        jobState.Total = 5;
+        jobState.Processed = 0;
+        job.JobState = jobState;
+        context.Database.UpdateOrCreateJobState(typeof(MoveSubjectsOutOfGamePhotosMigration).Name, jobState, WorkerClass.Refresh);
+        context.Database.Refresh();
+
+        // Migrate - Second cycle
+        job.ExecuteJob(context.GetWorkContext());
+        context.Database.Refresh();
+
+        Assert.That(context.Database.GetTotalPhotoCount(), Is.EqualTo(15));
+        foreach(GamePhoto photo in context.Database.GetRecentPhotos(10, 5).Items.ToArray())
+        {
+            // The photos from the first cycle still only have 2 subjects each
+            Assert.That(photo.Subjects.Count, Is.EqualTo(2));
+            Assert.That(context.Database.GetTotalSubjectsInPhoto(photo), Is.EqualTo(2));
+
+            Assert.That(photo.Subjects.Count(s => s.DisplayName == "p"), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.DisplayName == "i"), Is.EqualTo(1));
+
+            Assert.That(photo.Subjects.Count(s => s.PlayerId == 1), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.PlayerId == 2), Is.EqualTo(1));
+        }
+
+        foreach(GamePhoto photo in context.Database.GetRecentPhotos(5, 0).Items.ToArray())
+        {
+            Assert.That(photo.Subjects.Count, Is.EqualTo(4));
+            Assert.That(context.Database.GetTotalSubjectsInPhoto(photo), Is.EqualTo(4));
+
+            Assert.That(photo.Subjects.Count(s => s.DisplayName == "d"), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.DisplayName == "a"), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.DisplayName == "n"), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.DisplayName == "k"), Is.EqualTo(1));
+
+            Assert.That(photo.Subjects.Count(s => s.PlayerId == 1), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.PlayerId == 2), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.PlayerId == 3), Is.EqualTo(1));
+            Assert.That(photo.Subjects.Count(s => s.PlayerId == 4), Is.EqualTo(1));
+        }
+
+        stateObject = context.Database.GetJobState(typeof(MoveSubjectsOutOfGamePhotosMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
+        jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Processed, Is.EqualTo(5));
+        Assert.That(jobState.Total, Is.EqualTo(5));
+        Assert.That(jobState.Complete, Is.True);
+    }
+}

--- a/RefreshTests.GameServer/Tests/Workers/PinMigrationTests.cs
+++ b/RefreshTests.GameServer/Tests/Workers/PinMigrationTests.cs
@@ -1,0 +1,73 @@
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Pins;
+using Refresh.Database.Models.Users;
+using Refresh.Database.Models.Workers;
+using Refresh.Interfaces.Workers.Migrations;
+using Refresh.Workers.State;
+
+namespace RefreshTests.GameServer.Tests.Workers;
+
+public class PinMigrationTests : GameServerTest
+{
+    [Test]
+    public void WebsitePinMigrationDoesNotBreakPagination()
+    {
+        using TestContext context = this.GetServer();
+
+        for (int i = 0; i < 50; i++)
+        {
+            GameUser user = context.CreateUser();
+            context.Database.AddPinProgress(new()
+            {
+                PinId = (long)ServerPins.SignIntoWebsite,
+                Progress = i + 1,
+                Publisher = user,
+                FirstPublished = new(),
+                LastUpdated = new(),
+                IsBeta = false,
+                Platform = TokenPlatform.RPCS3,
+            }, false);
+
+            context.Database.AddPinProgress(new()
+            {
+                PinId = (long)ServerPins.SignIntoWebsite,
+                Progress = i + 1,
+                Publisher = user,
+                FirstPublished = new(),
+                LastUpdated = new(),
+                IsBeta = true,
+                Platform = TokenPlatform.RPCS3,
+            }, false);
+        }
+        context.Database.SaveChanges();
+        Assert.That(context.Database.GetTotalPinProgresses(), Is.EqualTo(100));
+
+        // Prepare migration
+        CorrectWebsitePinProgressPlatformMigration job = new();
+        context.Database.UpdateOrCreateJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, new MigrationJobState()
+        {
+            Total = 100 // Since we already have to manually create the state
+        }, WorkerClass.Refresh);
+        context.Database.Refresh();
+
+        object? stateObject = context.Database.GetJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+        job.JobState = stateObject!;
+        
+        // Migrate
+        job.ExecuteJob(context.GetWorkContext());
+        context.Database.Refresh();
+
+        stateObject = context.Database.GetJobState(typeof(CorrectWebsitePinProgressPlatformMigration).Name, typeof(MigrationJobState), WorkerClass.Refresh);
+        Assert.That(stateObject, Is.Not.Null);
+
+        // While we're not actually testing pagination here (batch count can't be edited + don't want to create over 1000 users here, would take too long),
+        // it should be enough to simply ensure that both the total and processed counts are adjusted to be less than 100 (as 50 pins were deleted)
+        MigrationJobState jobState = (MigrationJobState)stateObject!;
+        Assert.That(jobState.Processed, Is.EqualTo(50));
+        Assert.That(jobState.Total, Is.EqualTo(50));
+        Assert.That(jobState.Complete, Is.True);
+
+        Assert.That(context.Database.GetTotalPinProgresses(), Is.EqualTo(50));
+    }
+}


### PR DESCRIPTION
This does a few fixes/adjustments for existing migration jobs:
- Deleting entities during a migration job will now cause the job state to be adjusted, fixing an issue where `CorrectWebsitePinProgressPlatformMigration` would never be marked as complete (and possibly also unintentionally skip pins) if there were more than 1000 pins to migrate (the job was also renamed for consistency + to allow it to fully retry on instances where it has already been executed), and to allow similar jobs in the future to also run properly
- `MoveSubjectsOutOfGamePhotosMigration` will not try to migrate photos again if they already have associated `GamePhotoSubject`s, avoiding duplicate key insertions
- Some migration job-exclusive code was moved from `Refresh.Database` to the jobs' `Migrate()` method, to not keep methods only used by one specific job there