### PR TITLE
Implement basics of asset blocking

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.Database/GameDatabaseContext.Assets.cs
@@ -110,4 +110,41 @@ public partial class GameDatabaseContext // Assets
         {
             asset.AsMainlinePhotoHash = hash;
         });
+    
+    public DisallowedAsset? GetAssetDisallowanceInfo(string hash)
+        => this.DisallowedAssets.FirstOrDefault(d => d.AssetHash == hash);
+    
+    /// <returns>
+    /// The asset's disallowance info + whether the asset wasn't already disallowed before
+    /// </returns
+    // TODO: have the disallowance methods of other similar entities also return the entity itself aswell,
+    // and make their entities also store more info (reason, timestamp etc.)
+    public (DisallowedAsset, bool) DisallowAsset(string hash, GameAssetType type, string reason)
+    {
+        DisallowedAsset? existing = this.GetAssetDisallowanceInfo(hash);
+        if (existing != null) return (existing, false);
+
+        DisallowedAsset disallowed = new()
+        {
+            AssetHash = hash,
+            AssetType = type,
+            Reason = reason,
+        };
+        this.DisallowedAssets.Add(disallowed);
+        return (disallowed, true);
+    }
+
+    public bool ReallowAsset(string hash)
+    {
+        DisallowedAsset? existing = this.GetAssetDisallowanceInfo(hash);
+        if (existing == null) return false;
+
+        this.DisallowedAssets.Remove(existing);
+        return true;
+    }
+
+    public IQueryable<string> FilterOutAllowedAssets(List<string> hashes)
+        => this.DisallowedAssets
+            .Where(d => hashes.Contains(d.AssetHash))
+            .Select(d => d.AssetHash);
 }

--- a/Refresh.Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.Database/GameDatabaseContext.Assets.cs
@@ -130,7 +130,9 @@ public partial class GameDatabaseContext // Assets
             AssetType = type,
             Reason = reason,
         };
+
         this.DisallowedAssets.Add(disallowed);
+        this.SaveChanges();
         return (disallowed, true);
     }
 
@@ -140,6 +142,7 @@ public partial class GameDatabaseContext // Assets
         if (existing == null) return false;
 
         this.DisallowedAssets.Remove(existing);
+        this.SaveChanges();
         return true;
     }
 

--- a/Refresh.Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.Database/GameDatabaseContext.Assets.cs
@@ -111,7 +111,7 @@ public partial class GameDatabaseContext // Assets
             asset.AsMainlinePhotoHash = hash;
         });
     
-    public DisallowedAsset? GetAssetDisallowanceInfo(string hash)
+    public DisallowedAsset? GetDisallowedAssetInfo(string hash)
         => this.DisallowedAssets.FirstOrDefault(d => d.AssetHash == hash);
     
     /// <returns>
@@ -121,7 +121,7 @@ public partial class GameDatabaseContext // Assets
     // and make their entities also store more info (reason, timestamp etc.)
     public (DisallowedAsset, bool) DisallowAsset(string hash, GameAssetType type, string reason)
     {
-        DisallowedAsset? existing = this.GetAssetDisallowanceInfo(hash);
+        DisallowedAsset? existing = this.GetDisallowedAssetInfo(hash);
         if (existing != null) return (existing, false);
 
         DisallowedAsset disallowed = new()
@@ -136,7 +136,7 @@ public partial class GameDatabaseContext // Assets
 
     public bool ReallowAsset(string hash)
     {
-        DisallowedAsset? existing = this.GetAssetDisallowanceInfo(hash);
+        DisallowedAsset? existing = this.GetDisallowedAssetInfo(hash);
         if (existing == null) return false;
 
         this.DisallowedAssets.Remove(existing);
@@ -147,4 +147,10 @@ public partial class GameDatabaseContext // Assets
         => this.DisallowedAssets
             .Where(d => hashes.Contains(d.AssetHash))
             .Select(d => d.AssetHash);
+
+    public DatabaseList<DisallowedAsset> GetDisallowedAssets(int skip, int count)
+        => new(this.DisallowedAssets, skip, count);
+    
+    public DatabaseList<DisallowedAsset> GetDisallowedAssetsByType(GameAssetType type, int skip, int count)
+        => new(this.DisallowedAssets.Where(d => d.AssetType == type), skip, count);
 }

--- a/Refresh.Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.Database/GameDatabaseContext.Assets.cs
@@ -129,6 +129,7 @@ public partial class GameDatabaseContext // Assets
             AssetHash = hash,
             AssetType = type,
             Reason = reason,
+            DisallowedAt = this._time.Now,
         };
 
         this.DisallowedAssets.Add(disallowed);

--- a/Refresh.Database/GameDatabaseContext.cs
+++ b/Refresh.Database/GameDatabaseContext.cs
@@ -66,6 +66,7 @@ public partial class GameDatabaseContext : DbContext, IDatabaseContext
     internal DbSet<DisallowedUser> DisallowedUsers { get; set; }
     internal DbSet<DisallowedEmailAddress> DisallowedEmailAddresses { get; set; }
     internal DbSet<DisallowedEmailDomain> DisallowedEmailDomains { get; set; }
+    internal DbSet<DisallowedAsset> DisallowedAssets { get; set; }
     internal DbSet<RateReviewRelation> RateReviewRelations { get; set; }
     internal DbSet<TagLevelRelation> TagLevelRelations { get; set; }
     internal DbSet<GamePlaylist> GamePlaylists { get; set; }

--- a/Refresh.Database/Migrations/20260411153651_AddAbilityToDisallowAssets.cs
+++ b/Refresh.Database/Migrations/20260411153651_AddAbilityToDisallowAssets.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20260411153651_AddAbilityToDisallowAssets")]
+    public partial class AddAbilityToDisallowAssets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DisallowedAssets",
+                columns: table => new
+                {
+                    AssetHash = table.Column<string>(type: "text", nullable: false),
+                    AssetType = table.Column<int>(type: "integer", nullable: false),
+                    Reason = table.Column<string>(type: "text", nullable: false),
+                    DisallowedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DisallowedAssets", x => x.AssetHash);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DisallowedAssets");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -23,6 +23,26 @@ namespace Refresh.Database.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
+            modelBuilder.Entity("DisallowedAsset", b =>
+                {
+                    b.Property<string>("AssetHash")
+                        .HasColumnType("text");
+
+                    b.Property<int>("AssetType")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset>("DisallowedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Reason")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("AssetHash");
+
+                    b.ToTable("DisallowedAssets");
+                });
+
             modelBuilder.Entity("Refresh.Database.Models.Activity.Event", b =>
                 {
                     b.Property<string>("EventId")

--- a/Refresh.Database/Models/Assets/DisallowedAsset.cs
+++ b/Refresh.Database/Models/Assets/DisallowedAsset.cs
@@ -1,0 +1,13 @@
+using Refresh.Database.Models.Assets;
+
+#nullable disable
+
+public partial class DisallowedAsset
+{
+    [Key]
+    public string AssetHash { get; set; }
+    public GameAssetType AssetType { get; set; }
+
+    // Could be a short description of what this asset is (to understand why it's blocked)
+    public string Reason { get; set; } // TODO: maybe also add reasons to the other 3 "DisallowedX" entities, separately from ModerationAction?
+}

--- a/Refresh.Database/Models/Assets/DisallowedAsset.cs
+++ b/Refresh.Database/Models/Assets/DisallowedAsset.cs
@@ -1,13 +1,11 @@
 using Refresh.Database.Models.Assets;
 
-#nullable disable
-
 public partial class DisallowedAsset
 {
-    [Key]
-    public string AssetHash { get; set; }
+    [Key] public string AssetHash { get; set; } = null!;
+
     public GameAssetType AssetType { get; set; }
 
-    // Could be a short description of what this asset is (to understand why it's blocked)
-    public string Reason { get; set; } // TODO: maybe also add reasons to the other 3 "DisallowedX" entities, separately from ModerationAction?
+    public string Reason { get; set; } = "";
+    public DateTimeOffset DisallowedAt { get; set; }
 }

--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using CommandLine;
 using Refresh.Database;
+using Refresh.Database.Models.Assets;
 using Refresh.Database.Models.Users;
 using Refresh.Interfaces.APIv3.Documentation;
 
@@ -71,6 +72,22 @@ internal class CommandLineManager
         
         [Option("reallow-email-domain", HelpText = "Re-allow the email domain to be used by anyone. Email option is required if this is set. If a whole Email address is given, only the substring after the last @ will be used.")]
         public bool ReallowEmailDomain { get; set; }
+
+        [Option("disallow-asset", HelpText = "Disallow an asset by hash. While this won't delete the asset if it already exists on the server, it will prevent it from being uploaded if it doesn't exist yet, and will do various other things (reset icons, instruct the game to censor this asset, prevent publishing levels/photos which use this asset, etc)."
+                                           + "Asset option is required if this is set, and both the Type and Reason options are optional.")]
+        public bool DisallowAsset { get; set; }
+        
+        [Option("reallow-asset", HelpText = "Re-allow an asset by hash. It may be uploaded and used in various UGC again. Asset option is required if this is set.")]
+        public bool ReallowAsset { get; set; }
+
+        [Option("asset", HelpText = "The hash of the asset to operate with.")]
+        public string? AssetHash { get; set; }
+
+        [Option("type", HelpText = "The type of the asset to use. If this isn't set, we will use the corrensponding GameAsset's type from DB instead, if it exists.")]
+        public string? AssetType { get; set; }
+
+        [Option("reason", HelpText = "The (usually optional) reason for a moderation action, such as asset disallowance.")]
+        public string? Reason { get; set; }
         
         [Option("rename-user", HelpText = "Changes a user's username. (old) username or Email option is required if this is set.")]
         public string? RenameUser { get; set; }
@@ -235,6 +252,39 @@ internal class CommandLineManager
                     Fail("Email domain is already allowed");
             }
             else Fail("No email domain was provided");
+        }
+        else if (options.DisallowAsset)
+        {
+            if (options.AssetHash != null)
+            {
+                GameAssetType? type = null;
+                if (options.AssetType != null)
+                {
+                    bool parsed = Enum.TryParse(options.AssetType, true, out GameAssetType assetType);
+                    if (!parsed)
+                    {
+                        Fail($"The asset type '{options.AssetType}' couldn't be parsed. Possible values: "
+                            + string.Join(", ", Enum.GetNames(typeof(GameAssetType))));
+                        
+                        return;
+                    }
+
+                    type = assetType;
+                }
+
+                if (!this._server.DisallowAsset(options.AssetHash, type, options.Reason))
+                    Fail("Asset is already disallowed");
+            }
+            else Fail("No asset hash was provided");
+        }
+        else if (options.ReallowAsset)
+        {
+            if (options.AssetHash != null)
+            {
+                if (!this._server.ReallowAsset(options.AssetHash))
+                    Fail("Asset is already allowed");
+            }
+            else Fail("No asset hash was provided");
         }
         else if (options.RenameUser != null)
         {

--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -73,14 +73,14 @@ internal class CommandLineManager
         [Option("reallow-email-domain", HelpText = "Re-allow the email domain to be used by anyone. Email option is required if this is set. If a whole Email address is given, only the substring after the last @ will be used.")]
         public bool ReallowEmailDomain { get; set; }
 
-        [Option("disallow-asset", HelpText = "Disallow an asset by hash. While this won't delete the asset if it already exists on the server, it will prevent it from being uploaded if it doesn't exist yet, and will do various other things (reset icons, instruct the game to censor this asset, prevent publishing levels/photos which use this asset, etc)."
+        [Option("disallow-asset", HelpText = "Disallow an asset by hash. While this won't delete the asset, it will prevent it from being uploaded in the future, and do other actions, such as instructing the game to censor this asset. "
                                            + "Asset option is required if this is set, and both the Type and Reason options are optional.")]
         public bool DisallowAsset { get; set; }
         
         [Option("reallow-asset", HelpText = "Re-allow an asset by hash. It may be uploaded and used in various UGC again. Asset option is required if this is set.")]
         public bool ReallowAsset { get; set; }
 
-        [Option("asset", HelpText = "The hash of the asset to operate with.")]
+        [Option("asset", HelpText = "The hash of the asset to operate on.")]
         public string? AssetHash { get; set; }
 
         [Option("type", HelpText = "The type of the asset to use. If this isn't set, we will use the corrensponding GameAsset's type from DB instead, if it exists.")]

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -32,6 +32,7 @@ using Refresh.Interfaces.Internal;
 using Refresh.Interfaces.Workers;
 using Refresh.Interfaces.Workers.Repeating;
 using Refresh.Workers;
+using Refresh.Database.Models.Assets;
 
 namespace Refresh.GameServer;
 
@@ -311,6 +312,22 @@ public class RefreshGameServer : RefreshServer
         using GameDatabaseContext context = this.GetContext();
 
         return context.ReallowEmailDomain(domain);
+    }
+
+    public bool DisallowAsset(string hash, GameAssetType? type, string? reason)
+    {
+        using GameDatabaseContext context = this.GetContext();
+        type ??= context.GetAssetFromHash(hash)?.AssetType;
+
+        (DisallowedAsset disallowed, bool success) = context.DisallowAsset(hash, type ?? GameAssetType.Unknown, reason ?? "");
+        return success;
+    }
+    
+    public bool ReallowAsset(string hash)
+    {
+        using GameDatabaseContext context = this.GetContext();
+
+        return context.ReallowAsset(hash);
     }
 
     public void RenameUser(GameUser user, string newUsername, bool force = false)

--- a/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiModerationError.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ApiTypes/Errors/ApiModerationError.cs
@@ -2,9 +2,11 @@ namespace Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
 
 public class ApiModerationError : ApiError
 {
-    public static readonly ApiModerationError Instance = new();
-    
-    public ApiModerationError() : base("This content was flagged as potentially unsafe, and administrators have been alerted. If you believe this is an error, please contact an administrator.", UnprocessableContent)
-    {
-    }
+    public ApiModerationError(string message) : base(message, UnprocessableContent) {}
+
+    public const string AssetAutoFlaggedErrorWhen = "This content was flagged as potentially unsafe, and administrators have been alerted. If you believe this is an error, please contact an administrator.";
+    public static readonly ApiModerationError AssetAutoFlaggedError = new(AssetAutoFlaggedErrorWhen);
+
+    public const string AssetDisallowedErrorWhen = "The asset you tried to upload is disallowed.";
+    public static readonly ApiModerationError AssetDisallowedError = new(AssetDisallowedErrorWhen);
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/ResourceApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/ResourceApiEndpoints.cs
@@ -200,6 +200,12 @@ public class ResourceApiEndpoints : EndpointGroup
             return new ApiValidationError($"You have exceeded your filesize quota.");
         }
 
+        if (database.GetDisallowedAssetInfo(hash) != null)
+        {
+            context.Logger.LogWarning(BunkumCategory.UserContent, "User {0} has tried to upload a disallowed asset, rejecting.", user);
+            return ApiModerationError.AssetDisallowedError;
+        }
+
         GameAsset? gameAsset = importer.ReadAndVerifyAsset(hash, body, TokenPlatform.Website, database);
         if (gameAsset == null)
             return ApiValidationError.CannotReadAssetError;
@@ -214,7 +220,7 @@ public class ResourceApiEndpoints : EndpointGroup
         
         if (aipi != null && aipi.ScanAndHandleAsset(dataContext, gameAsset))
         {
-            return ApiModerationError.Instance;
+            return ApiModerationError.AssetAutoFlaggedError;
         }
         
         database.AddAssetToDatabase(gameAsset);

--- a/Refresh.Interfaces.Game/Endpoints/ModerationEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/ModerationEndpoints.cs
@@ -6,6 +6,7 @@ using Bunkum.Protocols.Http;
 using Refresh.Core.Authentication.Permission;
 using Refresh.Core.Services;
 using Refresh.Core.Types.Commands;
+using Refresh.Core.Types.Data;
 using Refresh.Database;
 using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Users;
@@ -26,11 +27,11 @@ public class ModerationEndpoints : EndpointGroup
     }
 
     [GameEndpoint("showModerated", HttpMethods.Post, ContentType.Xml)]
-    public SerializedModeratedResourceList ModerateResources(RequestContext context, SerializedModeratedResourceList body)
+    public SerializedModeratedResourceList ModerateResources(RequestContext context, SerializedModeratedResourceList body, DataContext dataContext)
     {
         return new SerializedModeratedResourceList
         {
-            Resources = new List<string>(),
+            Resources = dataContext.Database.FilterOutAllowedAssets(body.Resources).ToList(),
         };
     }
 

--- a/Refresh.Interfaces.Game/Endpoints/ResourceEndpoints.cs
+++ b/Refresh.Interfaces.Game/Endpoints/ResourceEndpoints.cs
@@ -61,6 +61,12 @@ public class ResourceEndpoints : EndpointGroup
             context.Logger.LogWarning(BunkumCategory.UserContent, "{0} is above 2MB ({1} bytes), rejecting.", hash, body.Length);
             return RequestEntityTooLarge;
         }
+
+        if (database.GetDisallowedAssetInfo(hash) != null)
+        {
+            context.Logger.LogWarning(BunkumCategory.UserContent, "User {0} has tried to upload a disallowed asset, rejecting.", user);
+            return Unauthorized;
+        }
         
         GameAsset? gameAsset = importer.ReadAndVerifyAsset(hash, body, token.TokenPlatform, database);
         if (gameAsset == null)

--- a/RefreshTests.GameServer/Tests/Assets/AssetDisallowanceTests.cs
+++ b/RefreshTests.GameServer/Tests/Assets/AssetDisallowanceTests.cs
@@ -1,6 +1,10 @@
+using System.Security.Cryptography;
 using Refresh.Database.Models.Assets;
 using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Users;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes;
+using Refresh.Interfaces.APIv3.Endpoints.ApiTypes.Errors;
+using Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response.Data;
 using Refresh.Interfaces.Game.Types.UserData;
 using RefreshTests.GameServer.Extensions;
 
@@ -114,5 +118,44 @@ public class AssetDisallowanceTests : GameServerTest
         Assert.That(response.Resources.Count, Is.EqualTo(2));
         Assert.That(response.Resources.Contains("3"), Is.True);
         Assert.That(response.Resources.Contains("7"), Is.True);
+    }
+
+    [Test]
+    public void CannotUploadDisallowedAssetFromGame()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
+
+        ReadOnlySpan<byte> data = "TEX a"u8;
+        
+        string hash = BitConverter.ToString(SHA1.HashData(data))
+            .Replace("-", "")
+            .ToLower();
+
+        context.Database.DisallowAsset(hash, GameAssetType.Texture, "Weegee");
+
+        HttpResponseMessage message = client.PostAsync($"/lbp/upload/{hash}", new ByteArrayContent(data.ToArray())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(Unauthorized));
+    }
+
+    [Test]
+    public void CannotUploadDisallowedAssetFromApi()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Api, user);
+
+        ReadOnlySpan<byte> data = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        
+        string hash = BitConverter.ToString(SHA1.HashData(data))
+            .Replace("-", "")
+            .ToLower();
+
+        context.Database.DisallowAsset(hash, GameAssetType.Png, "Weegee");
+
+        ApiResponse<ApiGameAssetResponse>? response = client.PostData<ApiGameAssetResponse>($"/api/v3/assets/{hash}", new ByteArrayContent(data.ToArray()), false, true);
+        Assert.That(response?.Error, Is.Not.Null);
+        Assert.That(response!.Error!.Name, Is.EqualTo(nameof(ApiModerationError)));
     }
 }

--- a/RefreshTests.GameServer/Tests/Assets/AssetDisallowanceTests.cs
+++ b/RefreshTests.GameServer/Tests/Assets/AssetDisallowanceTests.cs
@@ -1,0 +1,118 @@
+using Refresh.Database.Models.Assets;
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Users;
+using Refresh.Interfaces.Game.Types.UserData;
+using RefreshTests.GameServer.Extensions;
+
+namespace RefreshTests.GameServer.Tests.Assets;
+
+public class AssetDisallowanceTests : GameServerTest
+{
+    [Test]
+    public void CanDisallowAndReallowAsset()
+    {
+        using TestContext context = this.GetServer();
+        
+        string hash = "trash";
+        GameAssetType type = GameAssetType.Mesh;
+
+        // Ensure that the asset isn't already disallowed
+        Assert.That(context.Database.GetDisallowedAssetInfo(hash), Is.Null);
+
+        // Disallow
+        (DisallowedAsset disallowed, bool success) = context.Database.DisallowAsset(hash, type, "too ugly");
+        Assert.That(success, Is.True);
+        Assert.That(disallowed.AssetHash, Is.EqualTo(hash));
+        Assert.That(disallowed.AssetType, Is.EqualTo(type));
+        Assert.That(disallowed.Reason, Is.EqualTo("too ugly"));
+
+        // Ensure that the same entity is gotten again, and the DB method doesn't try to insert a new one
+        (disallowed, success) = context.Database.DisallowAsset(hash, type, "too ugly");
+        Assert.That(success, Is.False);
+        Assert.That(disallowed.AssetHash, Is.EqualTo(hash));
+        Assert.That(disallowed.AssetType, Is.EqualTo(type));
+        Assert.That(disallowed.Reason, Is.EqualTo("too ugly"));
+
+        // ensure that the separately gotten entity is also the same
+        DisallowedAsset? gottenAgain = context.Database.GetDisallowedAssetInfo(hash);
+        Assert.That(gottenAgain, Is.Not.Null);
+        Assert.That(success, Is.False);
+        Assert.That(disallowed.AssetHash, Is.EqualTo(hash));
+        Assert.That(disallowed.AssetType, Is.EqualTo(type));
+        Assert.That(disallowed.Reason, Is.EqualTo("too ugly"));
+
+        // Ensure it doesn't also return this if the hash is different
+        Assert.That(context.Database.GetDisallowedAssetInfo("bash"), Is.Null);
+
+        // Reallow
+        success = context.Database.ReallowAsset(hash);
+        Assert.That(success, Is.True);
+        Assert.That(context.Database.GetDisallowedAssetInfo(hash), Is.Null);
+
+        // Reallow again
+        success = context.Database.ReallowAsset(hash);
+        Assert.That(success, Is.False);
+        Assert.That(context.Database.GetDisallowedAssetInfo(hash), Is.Null);
+    }
+
+    [Test]
+    public void ShowModeratedReturnsDisallowedAssetHashes()
+    {
+        using TestContext context = this.GetServer();
+        GameAsset one = new()
+        {
+            AssetHash = "1",
+            AssetType = GameAssetType.Texture,
+            AssetFormat = GameAssetFormat.Binary,
+        };
+        GameAsset two = new()
+        {
+            AssetHash = "2",
+            AssetType = GameAssetType.Texture,
+            AssetFormat = GameAssetFormat.Binary,
+        };
+        GameAsset three = new()
+        {
+            AssetHash = "3",
+            AssetType = GameAssetType.Texture,
+            AssetFormat = GameAssetFormat.Binary,
+        };
+        GameAsset four = new()
+        {
+            AssetHash = "4",
+            AssetType = GameAssetType.Texture,
+            AssetFormat = GameAssetFormat.Binary,
+        };
+
+        context.Database.AddAssetsToDatabase([one, two, three, four]);
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, user);
+
+        SerializedModeratedResourceList request = new()
+        {
+            Resources = ["1", "2", "4", "6"] // also test against assets not in DB (in this case "6")
+        };
+        HttpResponseMessage message = client.PostAsync("/lbp/showModerated", new StringContent(request.AsXML())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(OK));
+
+        SerializedModeratedResourceList response = message.Content.ReadAsXML<SerializedModeratedResourceList>();
+        Assert.That(response.Resources, Is.Empty);
+
+        // Now disallow a few assets and try again
+        context.Database.DisallowAsset("3", GameAssetType.Texture, "Cringe drawing");
+        context.Database.DisallowAsset("7", GameAssetType.Plan, "Cringe drawing");
+        context.Database.DisallowAsset("9", GameAssetType.Plan, "Cringe drawing");
+
+        request = new()
+        {
+            Resources = ["1", "3", "4", "6", "7"]
+        };
+        message = client.PostAsync("/lbp/showModerated", new StringContent(request.AsXML())).Result;
+        Assert.That(message.StatusCode, Is.EqualTo(OK));
+
+        response = message.Content.ReadAsXML<SerializedModeratedResourceList>();
+        Assert.That(response.Resources.Count, Is.EqualTo(2));
+        Assert.That(response.Resources.Contains("3"), Is.True);
+        Assert.That(response.Resources.Contains("7"), Is.True);
+    }
+}


### PR DESCRIPTION
Adds the ability to disallow assets by hash via CLI. While this PR doesn't actually implement any enforcement for this (aside from a proper `/showModerated` implementation), it does prepare for future PRs to do so.

Doesn't really close https://github.com/LittleBigRefresh/Refresh/issues/472 yet, because other kinds of enforcements (like icon resetting, preventing uploads of blocked assets, preventing new entities from referencing blocked assets etc.), aswell as a way to add/remove/view blocked assets over API are missing.