### PR TITLE
Expose more information over /instance

### DIFF
--- a/Refresh.Core/Configuration/IntegrationConfig.cs
+++ b/Refresh.Core/Configuration/IntegrationConfig.cs
@@ -7,7 +7,7 @@ namespace Refresh.Core.Configuration;
 /// </summary>
 public class IntegrationConfig : Config
 {
-    public override int CurrentConfigVersion => 8;
+    public override int CurrentConfigVersion => 9;
     public override int Version { get; set; }
     protected override void Migrate(int oldVer, dynamic oldConfig)
     {
@@ -69,6 +69,7 @@ public class IntegrationConfig : Config
     #endregion
     
     public string? GrafanaDashboardUrl { get; set; }
+    public string? ServerStatusUrl { get; set; }
     
     /// <summary>
     /// A link to a .SVG or .PNG containing the logo to use for branding.

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/ApiInstanceResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/ApiInstanceResponse.cs
@@ -47,6 +47,7 @@ public class ApiInstanceResponse : IApiResponse
     
     public required bool MaintenanceModeEnabled { get; set; }
     public required string? GrafanaDashboardUrl { get; set; }
+    public required string? ServerStatusUrl { get; set; }
     
     public required string WebsiteLogoUrl { get; set; }
     public required string? WebsiteDefaultTheme { get; set; }
@@ -54,4 +55,10 @@ public class ApiInstanceResponse : IApiResponse
     public required ApiContactInfoResponse ContactInfo { get; set; }
     
     public required ApiContestResponse? ActiveContest { get; set; }
+
+    public required ApiRolePermissionsResponse NormalUserPermissions { get; set; }
+    public required ApiRolePermissionsResponse TrustedUserPermissions { get; set; }
+
+    public required bool IsPresenceServerEnabled { get; set; }
+    // TODO: similar attribute for CWLib integration
 }

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/ApiRolePermissionsResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/ApiRolePermissionsResponse.cs
@@ -1,0 +1,27 @@
+using Refresh.Core.Configuration;
+
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiRolePermissionsResponse : IApiResponse
+{
+    public required ConfigAssetFlags BlockedAssetFlags { get; set; }
+    public required bool ReadOnlyMode { get; set; }
+    public required ApiTimedLevelLimitResponse? TimedLevelUploadLimits { get; set; }
+    public required int UserFilesizeQuota { get; set; }
+
+    public static ApiRolePermissionsResponse FromOld(RolePermissions old)
+    {
+        return new()
+        {
+            BlockedAssetFlags = old.BlockedAssetFlags,
+            ReadOnlyMode = old.ReadOnlyMode,
+            TimedLevelUploadLimits = old.TimedLevelUploadLimits.Enabled ? new ApiTimedLevelLimitResponse()
+            {
+                TimeSpanHours = old.TimedLevelUploadLimits.TimeSpanHours,
+                LevelQuota = old.TimedLevelUploadLimits.LevelQuota,
+            } : null,
+            UserFilesizeQuota = old.UserFilesizeQuota,
+        };
+    }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/ApiTimedLevelLimitResponse.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/DataTypes/Response/ApiTimedLevelLimitResponse.cs
@@ -1,0 +1,8 @@
+namespace Refresh.Interfaces.APIv3.Endpoints.DataTypes.Response;
+
+[JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+public class ApiTimedLevelLimitResponse : IApiResponse
+{
+    public required int TimeSpanHours { get; set; }
+    public required int LevelQuota { get; set; }
+}

--- a/Refresh.Interfaces.APIv3/Endpoints/InstanceApiEndpoints.cs
+++ b/Refresh.Interfaces.APIv3/Endpoints/InstanceApiEndpoints.cs
@@ -72,6 +72,11 @@ public class InstanceApiEndpoints : EndpointGroup
             GrafanaDashboardUrl = integrationConfig.GrafanaDashboardUrl,
             WebsiteLogoUrl = integrationConfig.WebsiteLogoUrl,
             WebsiteDefaultTheme = integrationConfig.WebsiteDefaultTheme,
+            IsPresenceServerEnabled = integrationConfig.PresenceEnabled,
+            ServerStatusUrl = integrationConfig.ServerStatusUrl,
+
+            NormalUserPermissions = ApiRolePermissionsResponse.FromOld(gameConfig.NormalUserPermissions),
+            TrustedUserPermissions = ApiRolePermissionsResponse.FromOld(gameConfig.TrustedUserPermissions),
             
             ContactInfo = new ApiContactInfoResponse
             {


### PR DESCRIPTION
Allows instance owners to optionally set a URL leading to a status page for their instance (in bonsai's case, https://status.lbpbonsai.com) in their `integrations.json` config, and adds this URL to the `/instance` API endpoint's response , aswell as some other attributes, like role-specific perms (read-only etc), and whether the instance's presence server is enabled.