### PR TITLE
Add reason and timestamp to all disallow entities

### DIFF
--- a/Refresh.Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.Database/GameDatabaseContext.Assets.cs
@@ -117,8 +117,6 @@ public partial class GameDatabaseContext // Assets
     /// <returns>
     /// The asset's disallowance info + whether the asset wasn't already disallowed before
     /// </returns
-    // TODO: have the disallowance methods of other similar entities also return the entity itself aswell,
-    // and make their entities also store more info (reason, timestamp etc.)
     public (DisallowedAsset, bool) DisallowAsset(string hash, GameAssetType type, string reason)
     {
         DisallowedAsset? existing = this.GetDisallowedAssetInfo(hash);

--- a/Refresh.Database/GameDatabaseContext.Assets.cs
+++ b/Refresh.Database/GameDatabaseContext.Assets.cs
@@ -150,9 +150,10 @@ public partial class GameDatabaseContext // Assets
             .Where(d => hashes.Contains(d.AssetHash))
             .Select(d => d.AssetHash);
 
-    public DatabaseList<DisallowedAsset> GetDisallowedAssets(int skip, int count)
-        => new(this.DisallowedAssets, skip, count);
-    
-    public DatabaseList<DisallowedAsset> GetDisallowedAssetsByType(GameAssetType type, int skip, int count)
-        => new(this.DisallowedAssets.Where(d => d.AssetType == type), skip, count);
+    public DatabaseList<DisallowedAsset> GetDisallowedAssets(GameAssetType? type, int skip, int count)
+    {
+        IQueryable<DisallowedAsset> disallowedList = this.DisallowedAssets.OrderByDescending(d => d.DisallowedAt);
+        if (type != null) disallowedList = disallowedList.Where(d => d.AssetType == type);
+        return new(disallowedList, skip, count);
+    }
 }

--- a/Refresh.Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.Database/GameDatabaseContext.Registration.cs
@@ -217,95 +217,123 @@ public partial class GameDatabaseContext // Registration
             this.EmailVerificationCodes.Remove(code);
         });
     }
+
+    public bool IsUserDisallowed(string username)
+        => this.DisallowedUsers.Any(u => u.Username == username);
     
-    public bool DisallowUser(string username)
+    public DisallowedUser? GetDisallowedUserInfo(string username)
+        => this.DisallowedUsers.FirstOrDefault(d => d.Username == username);
+    
+    public DatabaseList<DisallowedUser> GetDisallowedUsers(int skip, int count)
+        => new(this.DisallowedUsers, skip, count);
+    
+    public (DisallowedUser, bool) DisallowUser(string username, string reason)
     {
-        if (this.DisallowedUsers.FirstOrDefault(u => u.Username == username) != null) 
-            return false;
+        DisallowedUser? existing = this.GetDisallowedUserInfo(username);
+        if (existing != null) return (existing, false);
         
-        this.Write(() =>
+        DisallowedUser disallowed = new()
         {
-            this.DisallowedUsers.Add(new DisallowedUser
-            {
-                Username = username,
-            });
-        });
+            Username = username,
+            Reason = reason,
+            DisallowedAt = this._time.Now,
+        };
+        this.DisallowedUsers.Add(disallowed);
+        this.SaveChanges();
         
-        return true;
+        return (disallowed, true);
     }
     
     public bool ReallowUser(string username)
     {
-        DisallowedUser? disallowedUser = this.DisallowedUsers.FirstOrDefault(u => u.Username == username);
+        DisallowedUser? disallowedUser = this.GetDisallowedUserInfo(username);
         if (disallowedUser == null) 
             return false;
         
-        this.Write(() =>
-        {
-            this.DisallowedUsers.Remove(disallowedUser);
-        });
-        
-        return true;
-    }
-    
-    public bool IsUserDisallowed(string username)
-    {
-        return this.DisallowedUsers.FirstOrDefault(u => u.Username == username) != null;
-    }
-
-    public bool DisallowEmailAddress(string emailAddress)
-    {
-        if (this.IsEmailAddressDisallowed(emailAddress)) 
-            return false;
-        
-        this.DisallowedEmailAddresses.Add(new()
-        {
-            Address = emailAddress,
-        });
+        this.DisallowedUsers.Remove(disallowedUser);
         this.SaveChanges();
         
         return true;
+    }
+
+    public bool IsEmailAddressDisallowed(string emailAddress)
+        => this.DisallowedEmailAddresses.Any(u => u.Address == emailAddress);
+
+    public DisallowedEmailAddress? GetDisallowedEmailAddressInfo(string emailAddress)
+        => this.DisallowedEmailAddresses.FirstOrDefault(d => d.Address == emailAddress);
+
+    public DatabaseList<DisallowedEmailAddress> GetDisallowedEmailAddresses(int skip, int count)
+        => new(this.DisallowedEmailAddresses, skip, count);
+
+    public (DisallowedEmailAddress, bool) DisallowEmailAddress(string emailAddress, string reason)
+    {
+        DisallowedEmailAddress? existing = this.GetDisallowedEmailAddressInfo(emailAddress);
+        if (existing != null) return (existing, false);
+        
+        DisallowedEmailAddress disallowed = new()
+        {
+            Address = emailAddress,
+            Reason = reason,
+            DisallowedAt = this._time.Now,
+        };
+        this.DisallowedEmailAddresses.Add(disallowed);
+        this.SaveChanges();
+        
+        return (disallowed, true);
     }
     
     public bool ReallowEmailAddress(string emailAddress)
     {
-        DisallowedEmailAddress? DisallowedEmailAddress = this.DisallowedEmailAddresses.FirstOrDefault(u => u.Address == emailAddress);
-        if (DisallowedEmailAddress == null) 
+        DisallowedEmailAddress? disallowed = this.GetDisallowedEmailAddressInfo(emailAddress);
+        if (disallowed == null) 
             return false;
         
-        this.DisallowedEmailAddresses.Remove(DisallowedEmailAddress);
+        this.DisallowedEmailAddresses.Remove(disallowed);
         this.SaveChanges();
         
         return true;
-    }
-    
-    public bool IsEmailAddressDisallowed(string emailAddress)
-    {
-        return this.DisallowedEmailAddresses.Any(u => u.Address == emailAddress);
     }
 
     private string GetEmailDomainFromAddress(string emailAddress)
         => emailAddress.Split('@').Last();
-
-    public bool DisallowEmailDomain(string emailAddress)
+    
+    public bool IsEmailDomainDisallowed(string emailAddress)
     {
         string emailDomain = this.GetEmailDomainFromAddress(emailAddress);
-        if (this.IsEmailDomainDisallowed(emailDomain)) 
-            return false;
+        return this.DisallowedEmailDomains.Any(u => u.Domain == emailDomain);
+    }
+
+    public DisallowedEmailDomain? GetDisallowedEmailDomainInfo(string emailAddress)
+    {
+        string emailDomain = this.GetEmailDomainFromAddress(emailAddress);
+        return this.DisallowedEmailDomains.FirstOrDefault(d => d.Domain == emailDomain);
+    }
+
+    public DatabaseList<DisallowedEmailDomain> GetDisallowedEmailDomains(int skip, int count)
+        => new(this.DisallowedEmailDomains, skip, count);
+
+    public (DisallowedEmailDomain, bool) DisallowEmailDomain(string emailAddress, string reason)
+    {
+        string emailDomain = this.GetEmailDomainFromAddress(emailAddress);
+        DisallowedEmailDomain? existing = this.GetDisallowedEmailDomainInfo(emailDomain);
+        if (existing != null) return (existing, false);
         
-        this.DisallowedEmailDomains.Add(new()
+        DisallowedEmailDomain disallowed = new()
         {
             Domain = emailDomain,
-        });
+            Reason = reason,
+            DisallowedAt = this._time.Now,
+        };
+        this.DisallowedEmailDomains.Add(disallowed);
         this.SaveChanges();
         
-        return true;
+        return (disallowed, true);
     }
 
     public bool ReallowEmailDomain(string emailAddress)
     {
         string emailDomain = this.GetEmailDomainFromAddress(emailAddress);
-        DisallowedEmailDomain? disallowedDomain = this.DisallowedEmailDomains.FirstOrDefault(u => u.Domain == emailDomain);
+        DisallowedEmailDomain? disallowedDomain = this.GetDisallowedEmailDomainInfo(emailDomain);
         if (disallowedDomain == null) 
             return false;
         
@@ -313,11 +341,5 @@ public partial class GameDatabaseContext // Registration
         this.SaveChanges();
         
         return true;
-    }
-
-    public bool IsEmailDomainDisallowed(string emailAddress)
-    {
-        string emailDomain = this.GetEmailDomainFromAddress(emailAddress);
-        return this.DisallowedEmailDomains.Any(u => u.Domain == emailDomain);
     }
 }

--- a/Refresh.Database/GameDatabaseContext.Registration.cs
+++ b/Refresh.Database/GameDatabaseContext.Registration.cs
@@ -225,7 +225,7 @@ public partial class GameDatabaseContext // Registration
         => this.DisallowedUsers.FirstOrDefault(d => d.Username == username);
     
     public DatabaseList<DisallowedUser> GetDisallowedUsers(int skip, int count)
-        => new(this.DisallowedUsers, skip, count);
+        => new(this.DisallowedUsers.OrderByDescending(d => d.DisallowedAt), skip, count);
     
     public (DisallowedUser, bool) DisallowUser(string username, string reason)
     {
@@ -263,7 +263,7 @@ public partial class GameDatabaseContext // Registration
         => this.DisallowedEmailAddresses.FirstOrDefault(d => d.Address == emailAddress);
 
     public DatabaseList<DisallowedEmailAddress> GetDisallowedEmailAddresses(int skip, int count)
-        => new(this.DisallowedEmailAddresses, skip, count);
+        => new(this.DisallowedEmailAddresses.OrderByDescending(d => d.DisallowedAt), skip, count);
 
     public (DisallowedEmailAddress, bool) DisallowEmailAddress(string emailAddress, string reason)
     {
@@ -310,7 +310,7 @@ public partial class GameDatabaseContext // Registration
     }
 
     public DatabaseList<DisallowedEmailDomain> GetDisallowedEmailDomains(int skip, int count)
-        => new(this.DisallowedEmailDomains, skip, count);
+        => new(this.DisallowedEmailDomains.OrderByDescending(d => d.DisallowedAt), skip, count);
 
     public (DisallowedEmailDomain, bool) DisallowEmailDomain(string emailAddress, string reason)
     {

--- a/Refresh.Database/Migrations/20260415112120_AddReasonAndTimestampToDisallowTables.cs
+++ b/Refresh.Database/Migrations/20260415112120_AddReasonAndTimestampToDisallowTables.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Refresh.Database.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(GameDatabaseContext))]
+    [Migration("20260415112120_AddReasonAndTimestampToDisallowTables")]
+    public partial class AddReasonAndTimestampToDisallowTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "DisallowedAt",
+                table: "DisallowedUsers",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            migrationBuilder.AddColumn<string>(
+                name: "Reason",
+                table: "DisallowedUsers",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "DisallowedAt",
+                table: "DisallowedEmailDomains",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            migrationBuilder.AddColumn<string>(
+                name: "Reason",
+                table: "DisallowedEmailDomains",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "DisallowedAt",
+                table: "DisallowedEmailAddresses",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            migrationBuilder.AddColumn<string>(
+                name: "Reason",
+                table: "DisallowedEmailAddresses",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DisallowedAt",
+                table: "DisallowedUsers");
+
+            migrationBuilder.DropColumn(
+                name: "Reason",
+                table: "DisallowedUsers");
+
+            migrationBuilder.DropColumn(
+                name: "DisallowedAt",
+                table: "DisallowedEmailDomains");
+
+            migrationBuilder.DropColumn(
+                name: "Reason",
+                table: "DisallowedEmailDomains");
+
+            migrationBuilder.DropColumn(
+                name: "DisallowedAt",
+                table: "DisallowedEmailAddresses");
+
+            migrationBuilder.DropColumn(
+                name: "Reason",
+                table: "DisallowedEmailAddresses");
+        }
+    }
+}

--- a/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
+++ b/Refresh.Database/Migrations/GameDatabaseContextModelSnapshot.cs
@@ -1535,6 +1535,12 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("Address")
                         .HasColumnType("text");
 
+                    b.Property<DateTimeOffset>("DisallowedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Reason")
+                        .HasColumnType("text");
+
                     b.HasKey("Address");
 
                     b.ToTable("DisallowedEmailAddresses");
@@ -1545,6 +1551,12 @@ namespace Refresh.Database.Migrations
                     b.Property<string>("Domain")
                         .HasColumnType("text");
 
+                    b.Property<DateTimeOffset>("DisallowedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Reason")
+                        .HasColumnType("text");
+
                     b.HasKey("Domain");
 
                     b.ToTable("DisallowedEmailDomains");
@@ -1553,6 +1565,12 @@ namespace Refresh.Database.Migrations
             modelBuilder.Entity("Refresh.Database.Models.Users.DisallowedUser", b =>
                 {
                     b.Property<string>("Username")
+                        .HasColumnType("text");
+
+                    b.Property<DateTimeOffset>("DisallowedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Reason")
                         .HasColumnType("text");
 
                     b.HasKey("Username");

--- a/Refresh.Database/Models/Users/DisallowedEmailAddress.cs
+++ b/Refresh.Database/Models/Users/DisallowedEmailAddress.cs
@@ -6,4 +6,6 @@ public partial class DisallowedEmailAddress
 {
     [Key]
     public string Address { get; set; }
+    public string Reason { get; set; }
+    public DateTimeOffset DisallowedAt { get; set; }
 }

--- a/Refresh.Database/Models/Users/DisallowedEmailDomain.cs
+++ b/Refresh.Database/Models/Users/DisallowedEmailDomain.cs
@@ -6,4 +6,6 @@ public partial class DisallowedEmailDomain
 {
     [Key]
     public string Domain { get; set; }
+    public string Reason { get; set; }
+    public DateTimeOffset DisallowedAt { get; set; }
 }

--- a/Refresh.Database/Models/Users/DisallowedUser.cs
+++ b/Refresh.Database/Models/Users/DisallowedUser.cs
@@ -6,4 +6,6 @@ public partial class DisallowedUser
 {
     [Key]
     public string Username { get; set; }
+    public string Reason { get; set; }
+    public DateTimeOffset DisallowedAt { get; set; }
 }

--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -203,7 +203,7 @@ internal class CommandLineManager
         {
             if (options.Username != null)
             {
-                if (!this._server.DisallowUser(options.Username))
+                if (!this._server.DisallowUser(options.Username, options.Reason))
                     Fail("User is already disallowed");
             }
             else Fail("No username was provided");
@@ -221,7 +221,7 @@ internal class CommandLineManager
         {
             if (options.EmailAddress != null)
             {
-                if (!this._server.DisallowEmailAddress(options.EmailAddress))
+                if (!this._server.DisallowEmailAddress(options.EmailAddress, options.Reason))
                     Fail("Email address is already disallowed");
             }
             else Fail("No email address was provided");
@@ -239,7 +239,7 @@ internal class CommandLineManager
         {
             if (options.EmailAddress != null)
             {
-                if (!this._server.DisallowEmailDomain(options.EmailAddress))
+                if (!this._server.DisallowEmailDomain(options.EmailAddress, options.Reason))
                     Fail("Email domain is already disallowed");
             }
             else Fail("No email domain was provided");

--- a/Refresh.GameServer/CommandLineManager.cs
+++ b/Refresh.GameServer/CommandLineManager.cs
@@ -80,13 +80,13 @@ internal class CommandLineManager
         [Option("reallow-asset", HelpText = "Re-allow an asset by hash. It may be uploaded and used in various UGC again. Asset option is required if this is set.")]
         public bool ReallowAsset { get; set; }
 
-        [Option("asset", HelpText = "The hash of the asset to operate on.")]
+        [Option('h', "asset", HelpText = "The hash of the asset to operate on.")]
         public string? AssetHash { get; set; }
 
-        [Option("type", HelpText = "The type of the asset to use. If this isn't set, we will use the corrensponding GameAsset's type from DB instead, if it exists.")]
+        [Option('t', "type", HelpText = "The type of the asset to use. If this isn't set, we will use the corresponding GameAsset's type from DB instead, if it exists.")]
         public string? AssetType { get; set; }
 
-        [Option("reason", HelpText = "The (usually optional) reason for a moderation action, such as asset disallowance.")]
+        [Option('r', "reason", HelpText = "The (usually optional) reason for a moderation action, such as asset disallowance.")]
         public string? Reason { get; set; }
         
         [Option("rename-user", HelpText = "Changes a user's username. (old) username or Email option is required if this is set.")]

--- a/Refresh.GameServer/RefreshGameServer.cs
+++ b/Refresh.GameServer/RefreshGameServer.cs
@@ -272,11 +272,12 @@ public class RefreshGameServer : RefreshServer
         context.SetUserRole(user, role);
     }
     
-    public bool DisallowUser(string username)
+    public bool DisallowUser(string username, string? reason)
     {
         using GameDatabaseContext context = this.GetContext();
         
-        return context.DisallowUser(username);
+        (DisallowedUser disallowed, bool success) = context.DisallowUser(username, reason ?? "");
+        return success;
     }
     
     public bool ReallowUser(string username)
@@ -286,11 +287,12 @@ public class RefreshGameServer : RefreshServer
         return context.ReallowUser(username);
     }
 
-    public bool DisallowEmailAddress(string address)
+    public bool DisallowEmailAddress(string address, string? reason)
     {
         using GameDatabaseContext context = this.GetContext();
 
-        return context.DisallowEmailAddress(address);
+        (DisallowedEmailAddress disallowed, bool success) = context.DisallowEmailAddress(address, reason ?? "");
+        return success;
     }
     
     public bool ReallowEmailAddress(string address)
@@ -300,11 +302,12 @@ public class RefreshGameServer : RefreshServer
         return context.ReallowEmailAddress(address);
     }
 
-    public bool DisallowEmailDomain(string domain)
+    public bool DisallowEmailDomain(string domain, string? reason)
     {
         using GameDatabaseContext context = this.GetContext();
 
-        return context.DisallowEmailDomain(domain);
+        (DisallowedEmailDomain disallowed, bool success) = context.DisallowEmailDomain(domain, reason ?? "");
+        return success;
     }
     
     public bool ReallowEmailDomain(string domain)

--- a/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
@@ -54,7 +54,7 @@ public class UserApiTests : GameServerTest
         const string email = "guy@lil.com";
         // Not somehow already disallowed
         Assert.That(context.Database.IsEmailAddressDisallowed(email), Is.False);
-        context.Database.DisallowEmailAddress(email);
+        context.Database.DisallowEmailAddress(email, "");
 
         context.Database.Refresh();
         Assert.That(context.Database.IsEmailAddressDisallowed(email), Is.True);
@@ -87,7 +87,7 @@ public class UserApiTests : GameServerTest
 
         // Not somehow already disallowed
         Assert.That(context.Database.IsEmailDomainDisallowed(addressToBlockWith), Is.False);
-        context.Database.DisallowEmailDomain(addressToBlockWith);
+        context.Database.DisallowEmailDomain(addressToBlockWith, "");
 
         context.Database.Refresh();
         Assert.That(context.Database.IsEmailDomainDisallowed(addressToBlockWith), Is.True);
@@ -161,7 +161,7 @@ public class UserApiTests : GameServerTest
 
         const string username = "a_lil_guy";
 
-        context.Database.DisallowUser(username);
+        context.Database.DisallowUser(username, "");
         
         ApiResponse<ApiAuthenticationResponse>? response = context.Http.PostData<ApiAuthenticationResponse>("/api/v3/register", new ApiRegisterRequest
         {

--- a/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
+++ b/RefreshTests.GameServer/Tests/ApiV3/UserApiTests.cs
@@ -52,12 +52,18 @@ public class UserApiTests : GameServerTest
         using TestContext context = this.GetServer();
 
         const string email = "guy@lil.com";
+        const string disallowReason = "being lil";
         // Not somehow already disallowed
         Assert.That(context.Database.IsEmailAddressDisallowed(email), Is.False);
-        context.Database.DisallowEmailAddress(email, "");
+        Assert.That(context.Database.GetDisallowedEmailAddressInfo(email), Is.Null);
+        context.Database.DisallowEmailAddress(email, disallowReason);
 
         context.Database.Refresh();
         Assert.That(context.Database.IsEmailAddressDisallowed(email), Is.True);
+        DisallowedEmailAddress? disallowed = context.Database.GetDisallowedEmailAddressInfo(email);
+        Assert.That(disallowed, Is.Not.Null);
+        Assert.That(disallowed!.Address, Is.EqualTo(email));
+        Assert.That(disallowed!.Reason, Is.EqualTo(disallowReason));
         
         ApiResponse<ApiAuthenticationResponse>? response = context.Http.PostData<ApiAuthenticationResponse>("/api/v3/register", new ApiRegisterRequest
         {
@@ -76,6 +82,7 @@ public class UserApiTests : GameServerTest
         context.Database.ReallowEmailAddress(email);
         context.Database.Refresh();
         Assert.That(context.Database.IsEmailAddressDisallowed(email), Is.False);
+        Assert.That(context.Database.GetDisallowedEmailAddressInfo(email), Is.Null);
     }
 
     [Test]
@@ -84,13 +91,22 @@ public class UserApiTests : GameServerTest
     public void CannotRegisterAccountsWithDisallowedEmailDomain(string addressToBlockWith)
     {
         using TestContext context = this.GetServer();
+        const string disallowReason = "moron email moment";
+        const string domain = "moron.com";
 
         // Not somehow already disallowed
         Assert.That(context.Database.IsEmailDomainDisallowed(addressToBlockWith), Is.False);
-        context.Database.DisallowEmailDomain(addressToBlockWith, "");
+        Assert.That(context.Database.IsEmailDomainDisallowed(domain), Is.False);
+        Assert.That(context.Database.GetDisallowedEmailDomainInfo(addressToBlockWith), Is.Null);
+        context.Database.DisallowEmailDomain(addressToBlockWith, disallowReason);
 
         context.Database.Refresh();
         Assert.That(context.Database.IsEmailDomainDisallowed(addressToBlockWith), Is.True);
+        Assert.That(context.Database.IsEmailDomainDisallowed(domain), Is.True);
+        DisallowedEmailDomain? disallowed = context.Database.GetDisallowedEmailDomainInfo(addressToBlockWith);
+        Assert.That(disallowed, Is.Not.Null);
+        Assert.That(disallowed!.Domain, Is.EqualTo(domain));
+        Assert.That(disallowed!.Reason, Is.EqualTo(disallowReason));
         
         // Attempt 1 (block)
         ApiResponse<ApiAuthenticationResponse>? response = context.Http.PostData<ApiAuthenticationResponse>("/api/v3/register", new ApiRegisterRequest
@@ -152,16 +168,29 @@ public class UserApiTests : GameServerTest
         context.Database.ReallowEmailDomain(addressToBlockWith);
         context.Database.Refresh();
         Assert.That(context.Database.IsEmailDomainDisallowed(addressToBlockWith), Is.False);
+        Assert.That(context.Database.IsEmailDomainDisallowed(domain), Is.False);
+        Assert.That(context.Database.GetDisallowedEmailDomainInfo(addressToBlockWith), Is.Null);
     }
     
     [Test]
     public void CannotRegisterAccountWithDisallowedUsername()
     {
         using TestContext context = this.GetServer();
-
         const string username = "a_lil_guy";
+        const string disallowReason = "writing these is fun lol";
 
-        context.Database.DisallowUser(username, "");
+        // Not somehow already disallowed
+        Assert.That(context.Database.IsUserDisallowed(username), Is.False);
+        Assert.That(context.Database.GetDisallowedUserInfo(username), Is.Null);
+
+        context.Database.DisallowUser(username, disallowReason);
+        context.Database.Refresh();
+
+        Assert.That(context.Database.IsUserDisallowed(username), Is.True);
+        DisallowedUser? disallowed = context.Database.GetDisallowedUserInfo(username);
+        Assert.That(disallowed, Is.Not.Null);
+        Assert.That(disallowed!.Username, Is.EqualTo(username));
+        Assert.That(disallowed!.Reason, Is.EqualTo(disallowReason));
         
         ApiResponse<ApiAuthenticationResponse>? response = context.Http.PostData<ApiAuthenticationResponse>("/api/v3/register", new ApiRegisterRequest
         {
@@ -172,9 +201,15 @@ public class UserApiTests : GameServerTest
         Assert.That(response, Is.Not.Null);
         Assert.That(response!.Error, Is.Not.EqualTo(null));
         Assert.That(response.Error!.Name, Is.EqualTo("ApiAuthenticationError"));
-        
+
         context.Database.Refresh();
-        Assert.That(context.Database.GetUserByUsername(username), Is.EqualTo(null));
+        Assert.That(context.Database.GetUserByUsername(username), Is.Null);
+        
+        // Undo
+        context.Database.ReallowUser(username);
+        context.Database.Refresh();
+        Assert.That(context.Database.IsUserDisallowed(username), Is.False);
+        Assert.That(context.Database.GetDisallowedUserInfo(username), Is.Null);
     }
 
     [Test]

--- a/RefreshTests.GameServer/Tests/Assets/AssetDisallowanceTests.cs
+++ b/RefreshTests.GameServer/Tests/Assets/AssetDisallowanceTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Refresh.Database;
 using Refresh.Database.Models.Assets;
 using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Users;
@@ -157,5 +158,27 @@ public class AssetDisallowanceTests : GameServerTest
         ApiResponse<ApiGameAssetResponse>? response = client.PostData<ApiGameAssetResponse>($"/api/v3/assets/{hash}", new ByteArrayContent(data.ToArray()), false, true);
         Assert.That(response?.Error, Is.Not.Null);
         Assert.That(response!.Error!.Name, Is.EqualTo(nameof(ApiModerationError)));
+    }
+
+    [Test]
+    public void FiltersDisallowedAssetListByType()
+    {
+        using TestContext context = this.GetServer();
+
+        context.Database.DisallowAsset("3", GameAssetType.Texture, "");
+        context.Database.DisallowAsset("7", GameAssetType.Plan, "");
+        context.Database.DisallowAsset("9", GameAssetType.Mesh, "");
+
+        Assert.That(context.Database.GetDisallowedAssetInfo("3"), Is.Not.Null);
+        Assert.That(context.Database.GetDisallowedAssetInfo("7"), Is.Not.Null);
+        Assert.That(context.Database.GetDisallowedAssetInfo("9"), Is.Not.Null);
+
+        DatabaseList<DisallowedAsset> completeList = context.Database.GetDisallowedAssets(null, 0, 10);
+        Assert.That(completeList.TotalItems, Is.EqualTo(3));
+        Assert.That(completeList.Items.Count(), Is.EqualTo(3));
+
+        DatabaseList<DisallowedAsset> filteredList = context.Database.GetDisallowedAssets(GameAssetType.Texture, 0, 10);
+        Assert.That(filteredList.TotalItems, Is.EqualTo(1));
+        Assert.That(filteredList.Items.Count(), Is.EqualTo(1));
     }
 }


### PR DESCRIPTION
Adds `Reason` and `DisallowedAt` to `DisallowedEmailAddress`, `DisallowedEmailDomain` and `DisallowedUser`, and a way to specify these when using the disallowance CLI commands. Also combines `GetDisallowedAssets()` and `GetDisallowedAssetsByType()` into one method, and makes all disallowance methods return the new/existing entity alongside whether it's new or already existing.