### PR TITLE
Don't flag PSP assets/levels as modded

### DIFF
--- a/Refresh.Core/Extensions/GameDatabaseContextExtensions.cs
+++ b/Refresh.Core/Extensions/GameDatabaseContextExtensions.cs
@@ -1,18 +1,23 @@
 ﻿using Refresh.Database;
 using Refresh.Database.Models.Assets;
+using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Levels;
 
 namespace Refresh.Core.Extensions;
 
 public static class GameDatabaseContextExtensions
 {
-    public static void UpdateLevelModdedStatus(this GameDatabaseContext database, GameLevel level)
+    public static void UpdateLevelModdedStatus(this GameDatabaseContext database, GameLevel level, bool save = true)
     {
-        database.SetLevelModdedStatus(level, database.GetLevelModdedStatus(level));
+        database.SetLevelModdedStatus(level, database.GetLevelModdedStatus(level), save);
     }
     
     public static bool GetLevelModdedStatus(this GameDatabaseContext database, GameLevel level)
     {
+        // Skip this for PSP assets, as we can't read them nor determine their type (yet)
+        if (level.GameVersion == TokenGame.LittleBigPlanetPSP)
+            return false;
+
         bool modded = false;
 
         GameAsset? rootAsset = database.GetAssetFromHash(level.RootResource);

--- a/Refresh.Database/GameDatabaseContext.Levels.cs
+++ b/Refresh.Database/GameDatabaseContext.Levels.cs
@@ -597,12 +597,10 @@ public partial class GameDatabaseContext // Levels
         this.SaveChanges();
     }
     
-    public void SetLevelModdedStatus(GameLevel level, bool modded)
+    public void SetLevelModdedStatus(GameLevel level, bool modded, bool save = true)
     {
-        this.Write(() =>
-        {
-            level.IsModded = modded;
-        });
+        level.IsModded = modded;
+        if (save) this.SaveChanges();
     }
     
     public void SetLevelModdedStatuses(Dictionary<GameLevel, bool> levels)

--- a/Refresh.Database/Models/Assets/GameAsset.cs
+++ b/Refresh.Database/Models/Assets/GameAsset.cs
@@ -25,6 +25,13 @@ public partial class GameAsset
             if (VanillaHashChecker.IsVanillaHash(this.AssetHash))
                 flags &= ~AssetFlags.Modded;
             
+            // If this is a PSP asset, strip both modded and dangerous flags
+            if (this.IsPSP)
+            {
+                flags &= ~AssetFlags.Modded;
+                flags &= ~AssetFlags.Dangerous;
+            }
+            
             return flags;
         }
     }

--- a/Refresh.Interfaces.Workers/Migrations/CorrectLevelModdedStatusMigration.cs
+++ b/Refresh.Interfaces.Workers/Migrations/CorrectLevelModdedStatusMigration.cs
@@ -1,0 +1,29 @@
+using Refresh.Core.Extensions;
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Levels;
+using Refresh.Workers;
+
+namespace Refresh.Interfaces.Workers.Migrations;
+
+public class CorrectLevelModdedStatusMigration : MigrationJob<GameLevel>
+{
+    protected override int BatchCount => 1000;
+
+    protected override IQueryable<GameLevel> SortAndFilter(IQueryable<GameLevel> query)
+    {
+        return query
+            .Where(l => l.GameVersion == TokenGame.LittleBigPlanetPSP) // for now this should only unflag PSP levels
+            .OrderBy(l => l.LevelId);
+    }
+
+    protected override int Migrate(WorkContext context, GameLevel[] batch)
+    {
+        foreach (GameLevel level in batch)
+        {
+            context.Database.UpdateLevelModdedStatus(level, false);
+        }
+
+        context.Database.SaveChanges();
+        return batch.Length;
+    }
+}

--- a/Refresh.Interfaces.Workers/RefreshWorkerManager.cs
+++ b/Refresh.Interfaces.Workers/RefreshWorkerManager.cs
@@ -28,6 +28,7 @@ public static class RefreshWorkerManager
         manager.AddJob<CorrectWebsitePinProgressPlatformMigration>();
         manager.AddJob<CalculateScoreRanksMigration>();
         manager.AddJob<MoveSubjectsOutOfGamePhotosMigration>();
+        manager.AddJob<CorrectLevelModdedStatusMigration>();
 
         return manager;
     }

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -147,6 +147,17 @@ public class TestContext : IDisposable
         return level;
     }
 
+    public GameLevel CreateLevelWithRootResource(GameUser author, string rootResource, TokenGame gameVersion = TokenGame.LittleBigPlanet1)
+    {
+        GameLevelRequest levelRequest = new()
+        {
+            RootResource = rootResource,
+        };
+
+        GameLevel level = this.Database.AddLevel(levelRequest, gameVersion, author);
+        return level;
+    }
+
     public GamePhoto CreatePhotoWithSubject(GameUser author, string imageHash, GameLevel? level = null, List<SerializedPhotoSubject>? subjects = null)
     {
         // TODO: Return newly created GamePhoto

--- a/RefreshTests.GameServer/Tests/Assets/AssetUploadTests.cs
+++ b/RefreshTests.GameServer/Tests/Assets/AssetUploadTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Refresh.Core.Configuration;
 using Refresh.Core.Services;
+using Refresh.Database.Models.Assets;
 using Refresh.Database.Models.Authentication;
 using Refresh.Database.Models.Users;
 using Refresh.Interfaces.Game.Types.Lists;
@@ -257,6 +258,53 @@ public class AssetUploadTests : GameServerTest
 
         HttpResponseMessage response = client.PostAsync("/lbp/upload/" + hash, new ByteArrayContent(data.ToArray())).Result;
         Assert.That(response.StatusCode, Is.EqualTo(OK));
+    }
+
+    [Test]
+    public void UnreadablePspAssetsAreNotMarkedAsModdedDangerous()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanetPSP, TokenPlatform.PSP, user);
+        client.DefaultRequestHeaders.UserAgent.TryParseAdd("LBPPSP CLIENT");
+        
+        ReadOnlySpan<byte> data = "MMMMMMMMMMMMMMMMMMMMM"u8;
+        
+        string hash = BitConverter.ToString(SHA1.HashData(data))
+            .Replace("-", "")
+            .ToLower();
+
+        HttpResponseMessage response = client.PostAsync("/lbp/upload/" + hash, new ByteArrayContent(data.ToArray())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(OK));
+
+        GameAsset? assetInfo = context.Database.GetAssetFromHash(hash);
+        Assert.That(assetInfo, Is.Not.Null);
+        Assert.That(assetInfo!.AssetType, Is.EqualTo(GameAssetType.Unknown));
+        Assert.That(assetInfo!.AssetFormat, Is.EqualTo(GameAssetFormat.Unknown));
+        Assert.That(assetInfo!.IsPSP, Is.True);
+        Assert.That(assetInfo!.AssetFlags, Is.EqualTo(AssetFlags.None));
+    }
+
+    [Test]
+    public void CantUploadUnreadableAssetFromNonPsp()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet2, TokenPlatform.PS3, user);
+        
+        ReadOnlySpan<byte> data = "MMMMMMMMMMMMMMMMMMMMM"u8;
+        
+        string hash = BitConverter.ToString(SHA1.HashData(data))
+            .Replace("-", "")
+            .ToLower();
+
+        HttpResponseMessage response = client.PostAsync("/lbp/upload/" + hash, new ByteArrayContent(data.ToArray())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(Unauthorized));
+
+        GameAsset? assetInfo = context.Database.GetAssetFromHash(hash);
+        Assert.That(assetInfo, Is.Null);
     }
     
     [Test]

--- a/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
+++ b/RefreshTests.GameServer/Tests/Levels/UploadTests.cs
@@ -2,6 +2,9 @@ using Refresh.Database.Models.Users;
 using Refresh.Database.Models.Levels;
 using Refresh.Interfaces.Game.Endpoints.DataTypes.Request;
 using Refresh.Database.Models.Authentication;
+using System.Security.Cryptography;
+using Refresh.Core.Extensions;
+using Refresh.Database.Models.Assets;
 
 namespace RefreshTests.GameServer.Tests.Levels;
 
@@ -151,5 +154,39 @@ public class UploadTests : GameServerTest
             Assert.That(level.PublishDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
             Assert.That(level.UpdateDate.ToUnixTimeMilliseconds(), Is.EqualTo(1));
         });
+    }
+
+    [Test]
+    public void PspLevelWithUnknownRootTypeDoesNotGetMarkedAsModded()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+
+        using HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanetPSP, TokenPlatform.PSP, user);
+        client.DefaultRequestHeaders.UserAgent.TryParseAdd("LBPPSP CLIENT");
+
+        // upload asset from PSP
+        ReadOnlySpan<byte> data = "MMMMMMMMMMMMMMMMMMMMM"u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+        
+        HttpResponseMessage response = client.PostAsync("/lbp/upload/" + hash, new ByteArrayContent(data.ToArray())).Result;
+        Assert.That(response.StatusCode, Is.EqualTo(OK));
+
+        GameAsset? rootAsset = context.Database.GetAssetFromHash(hash);
+        Assert.That(rootAsset, Is.Not.Null);
+        Assert.That(rootAsset!.IsPSP, Is.True);
+        Assert.That(rootAsset!.AssetType, Is.EqualTo(GameAssetType.Unknown));
+        Assert.That(rootAsset!.AssetFormat, Is.EqualTo(GameAssetFormat.Unknown));
+
+        GameLevel level = context.CreateLevelWithRootResource(user, hash, TokenGame.LittleBigPlanetPSP);
+        context.Database.UpdateLevelModdedStatus(level);
+
+        context.Database.Refresh();
+
+        GameLevel? updatedLevel = context.Database.GetLevelById(level.LevelId);
+        Assert.That(updatedLevel, Is.Not.Null);
+        Assert.That(updatedLevel!.LevelId, Is.EqualTo(level.LevelId));
+        Assert.That(updatedLevel!.RootResource, Is.EqualTo(hash));
+        Assert.That(updatedLevel!.IsModded, Is.False);
     }
 }


### PR DESCRIPTION
Fixes an issue where PSP assets would be flagged as modded/dangerous because they don't have any magic/can't be read by the server yet, and also fixes PSP levels always being flagged as modded because of that. Also unflags already existing PSP levels.

Needs unit tests for level flagging.