### PR TITLE
Implement helper method for asset reference validation

### DIFF
--- a/Refresh.Core/Helpers/ResourceValidationHelper.cs
+++ b/Refresh.Core/Helpers/ResourceValidationHelper.cs
@@ -1,0 +1,116 @@
+using System.Diagnostics;
+using Bunkum.Core;
+using NotEnoughLogs;
+using Refresh.Common.Verification;
+using Refresh.Core.Types.Assets.Validation;
+using Refresh.Database.Models.Assets;
+using Refresh.Database.Models.Authentication;
+
+namespace Refresh.Core.Helpers;
+
+public abstract class ResourceValidationHelper
+{
+    public static ValidatedAssetResult Validate(AssetValidationParameters parameters, Logger logger)
+    {
+        string assetTypeStr = parameters.AssetContextTypeStr ?? (parameters.MustBeTexture ? "image asset" : "asset");
+        GameAsset? asset = null;
+        bool existsInDataStore = false;
+        bool isPSP = parameters.GameToUseIn == TokenGame.LittleBigPlanetPSP;
+        Action<string>? onNewAssetKeyCallback = parameters.OnNewAssetKeyCallback;
+
+        if (parameters.AssetKey.IsBlankHash())
+        {
+            if (!parameters.MayBeBlank) return new(BadRequest, "0", $"The {assetTypeStr} must be set.", onNewAssetKeyCallback);
+            else return new(OK, "0", null, onNewAssetKeyCallback);
+        }
+
+        else if (parameters.AssetKey.StartsWith('g'))
+        {
+            if (!parameters.MayBeGuid) return new(BadRequest, null, $"The {assetTypeStr} may not be an in-game asset.", onNewAssetKeyCallback);
+            if (parameters.AssetKey.Length < 2) return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (empty GUID).", onNewAssetKeyCallback);
+
+            // This should only happen if the user is messing with mods/the API/beta builds, so give them a more detailed response
+            bool canParseGuid = long.TryParse(parameters.AssetKey[1..], out long guid);
+            if (!canParseGuid)
+                return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (badly formatted GUID).", onNewAssetKeyCallback);
+
+            if (parameters.MustBeTexture && !parameters.GuidChecker.IsTextureGuid(parameters.GameToUseIn, guid))
+                return new(BadRequest, null, $"The used in-game {assetTypeStr} was not a valid image (unknown GUID).", onNewAssetKeyCallback);
+        }
+
+        // At this point the reference is a hash
+        else if (!parameters.MayBeHash)
+        {
+            return new(BadRequest, null, $"The {assetTypeStr} may not be a custom asset.", onNewAssetKeyCallback);
+        }
+
+        else if (!CommonPatterns.Sha1Regex().IsMatch(parameters.AssetKey))
+        {
+            // This should only happen if a player is messing with mods/the API, so give them a more detailed response
+            return new(BadRequest, null, $"The used {assetTypeStr} had an invalid hash.", onNewAssetKeyCallback);
+        }
+
+        else
+        {
+            DisallowedAsset? disallowed = parameters.Database.GetDisallowedAssetInfo(parameters.AssetKey);
+            if (disallowed != null)
+            {
+                logger.LogWarning(BunkumCategory.UserContent, $"{parameters.User} tried to use a manually disallowed {assetTypeStr}.");
+                return new(Unauthorized, disallowanceInfo: disallowed, onNewAssetKeyCallback: onNewAssetKeyCallback);
+            }
+
+            string filename = isPSP ? $"psp/{parameters.AssetKey}" : parameters.AssetKey;
+            existsInDataStore = parameters.DataStore.ExistsInStore(filename);
+
+            if (!existsInDataStore)
+            {
+                logger.LogDebug(BunkumCategory.UserContent, $"Referenced asset '{filename}' could not be found in data store.");
+
+                if (parameters.MustBeInDataStoreIfHash)
+                    return new(NotFound, null, $"The used {assetTypeStr} did not exist on the server.", onNewAssetKeyCallback);
+            }
+
+            asset = parameters.Cache.GetAssetInfo(parameters.AssetKey, parameters.Database);
+
+            // Only try to import if the asset exists in the data store
+            if (existsInDataStore && asset == null)
+            {
+                logger.LogInfo(BunkumCategory.UserContent, $"Referenced asset '{filename}' exists in data store but not in database, attempting to import automatically...");
+                Stopwatch sw = new();
+                sw.Start();
+
+                if (!parameters.DataStore.TryGetDataFromStore(filename, out byte[]? assetData) || assetData == null)
+                {
+                    sw.Stop();
+                    logger.LogError(BunkumCategory.UserContent, $"Failed to read '{filename}' from data store!");
+                    logger.LogDebug(BunkumCategory.UserContent, $"Failed to get '{filename}' after {sw.ElapsedMilliseconds}ms.");
+                    return new(InternalServerError, null, $"Failed to read {assetTypeStr} internally. Please report this to the server owner.", onNewAssetKeyCallback, existsInDataStore: existsInDataStore);
+                }
+
+                asset = parameters.AssetImporter.ReadAndVerifyAsset(parameters.AssetKey, assetData, parameters.PlatformToUseIn, parameters.Database);
+                if (asset == null) 
+                {
+                    sw.Stop();
+                    logger.LogDebug(BunkumCategory.UserContent, $"Failed to get '{filename}' after {sw.ElapsedMilliseconds}ms.");
+                    return new(BadRequest, null, $"The used {assetTypeStr} was invalid or corrupt.", onNewAssetKeyCallback, existsInDataStore: existsInDataStore);
+                }
+
+                sw.Stop();
+                logger.LogInfo(BunkumCategory.UserContent, $"Successfully imported '{filename}' in {sw.ElapsedMilliseconds}ms.");
+            }
+
+            // FIXME: for some reason, PSP texture detection/conversion broke so we can no longer tell if a PSP texture is actually a texture, so skip this for PSP
+            if (asset != null && !isPSP)
+            {
+                bool isHashedTexture = (asset.AssetFlags & AssetFlags.Imagery) != 0;
+
+                if (parameters.MustBeTexture && !isHashedTexture)
+                    return new(BadRequest, null, $"The used {assetTypeStr} was not a valid custom image.", onNewAssetKeyCallback, assetInfo: asset, existsInDataStore: existsInDataStore);
+                
+                // TODO: actually use AIPI to scan image if not null
+            }
+        }
+
+        return new(OK, parameters.AssetKey, null, onNewAssetKeyCallback, assetInfo: asset, existsInDataStore: existsInDataStore);
+    }
+}

--- a/Refresh.Core/Helpers/ResourceValidationHelper.cs
+++ b/Refresh.Core/Helpers/ResourceValidationHelper.cs
@@ -10,56 +10,60 @@ namespace Refresh.Core.Helpers;
 
 public abstract class ResourceValidationHelper
 {
-    public static ValidatedAssetResult Validate(AssetValidationParameters parameters, Logger logger)
+    /// <summary>
+    /// Validates the given asset reference (hash/guid/blank) using the given parameters, if necessary also by reading the referenced asset
+    /// or getting data about it from database (see <see cref="GameAsset"/> and <see cref="DisallowedAsset"/>).
+    /// </summary>
+    public static ValidatedAssetResult ValidateReference(AssetValidationParameters parameters, Logger logger)
     {
         string assetTypeStr = parameters.AssetContextTypeStr ?? (parameters.MustBeTexture ? "image asset" : "asset");
         GameAsset? asset = null;
         bool existsInDataStore = false;
         bool isPSP = parameters.GameToUseIn == TokenGame.LittleBigPlanetPSP;
-        Action<string>? onNewAssetKeyCallback = parameters.OnNewAssetKeyCallback;
+        Action<string>? onNewAssetRefCallback = parameters.OnNewAssetRefCallback;
 
-        if (parameters.AssetKey.IsBlankHash())
+        if (parameters.AssetRef.IsBlankHash())
         {
-            if (!parameters.MayBeBlank) return new(BadRequest, "0", $"The {assetTypeStr} must be set.", onNewAssetKeyCallback);
-            else return new(OK, "0", null, onNewAssetKeyCallback);
+            if (!parameters.MayBeBlank) return new(BadRequest, "0", $"The {assetTypeStr} must be set.", onNewAssetRefCallback);
+            else return new(OK, "0", null, onNewAssetRefCallback);
         }
 
-        else if (parameters.AssetKey.StartsWith('g'))
+        else if (parameters.AssetRef.StartsWith('g'))
         {
-            if (!parameters.MayBeGuid) return new(BadRequest, null, $"The {assetTypeStr} may not be an in-game asset.", onNewAssetKeyCallback);
-            if (parameters.AssetKey.Length < 2) return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (empty GUID).", onNewAssetKeyCallback);
+            if (!parameters.MayBeGuid) return new(BadRequest, null, $"The {assetTypeStr} may not be an in-game asset.", onNewAssetRefCallback);
+            if (parameters.AssetRef.Length < 2) return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (empty GUID).", onNewAssetRefCallback);
 
             // This should only happen if the user is messing with mods/the API/beta builds, so give them a more detailed response
-            bool canParseGuid = long.TryParse(parameters.AssetKey[1..], out long guid);
+            bool canParseGuid = long.TryParse(parameters.AssetRef[1..], out long guid);
             if (!canParseGuid)
-                return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (badly formatted GUID).", onNewAssetKeyCallback);
+                return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (badly formatted GUID).", onNewAssetRefCallback);
 
             if (parameters.MustBeTexture && !parameters.GuidChecker.IsTextureGuid(parameters.GameToUseIn, guid))
-                return new(BadRequest, null, $"The used in-game {assetTypeStr} was not a valid image (unknown GUID).", onNewAssetKeyCallback);
+                return new(BadRequest, null, $"The used in-game {assetTypeStr} was not a valid image (unknown GUID).", onNewAssetRefCallback);
         }
 
         // At this point the reference is a hash
         else if (!parameters.MayBeHash)
         {
-            return new(BadRequest, null, $"The {assetTypeStr} may not be a custom asset.", onNewAssetKeyCallback);
+            return new(BadRequest, null, $"The {assetTypeStr} may not be a custom asset.", onNewAssetRefCallback);
         }
 
-        else if (!CommonPatterns.Sha1Regex().IsMatch(parameters.AssetKey))
+        else if (!CommonPatterns.Sha1Regex().IsMatch(parameters.AssetRef))
         {
             // This should only happen if a player is messing with mods/the API, so give them a more detailed response
-            return new(BadRequest, null, $"The used {assetTypeStr} had an invalid hash.", onNewAssetKeyCallback);
+            return new(BadRequest, null, $"The used {assetTypeStr} had an invalid hash.", onNewAssetRefCallback);
         }
 
         else
         {
-            DisallowedAsset? disallowed = parameters.Database.GetDisallowedAssetInfo(parameters.AssetKey);
+            DisallowedAsset? disallowed = parameters.Database.GetDisallowedAssetInfo(parameters.AssetRef);
             if (disallowed != null)
             {
                 logger.LogWarning(BunkumCategory.UserContent, $"{parameters.User} tried to use a manually disallowed {assetTypeStr}.");
-                return new(Unauthorized, disallowanceInfo: disallowed, onNewAssetKeyCallback: onNewAssetKeyCallback);
+                return new(Unauthorized, disallowanceInfo: disallowed, onNewAssetRefCallback: onNewAssetRefCallback);
             }
 
-            string filename = isPSP ? $"psp/{parameters.AssetKey}" : parameters.AssetKey;
+            string filename = isPSP ? $"psp/{parameters.AssetRef}" : parameters.AssetRef;
             existsInDataStore = parameters.DataStore.ExistsInStore(filename);
 
             if (!existsInDataStore)
@@ -67,10 +71,10 @@ public abstract class ResourceValidationHelper
                 logger.LogDebug(BunkumCategory.UserContent, $"Referenced asset '{filename}' could not be found in data store.");
 
                 if (parameters.MustBeInDataStoreIfHash)
-                    return new(NotFound, null, $"The used {assetTypeStr} did not exist on the server.", onNewAssetKeyCallback);
+                    return new(NotFound, null, $"The used {assetTypeStr} did not exist on the server.", onNewAssetRefCallback);
             }
 
-            asset = parameters.Cache.GetAssetInfo(parameters.AssetKey, parameters.Database);
+            asset = parameters.Cache.GetAssetInfo(parameters.AssetRef, parameters.Database);
 
             // Only try to import if the asset exists in the data store
             if (existsInDataStore && asset == null)
@@ -84,15 +88,15 @@ public abstract class ResourceValidationHelper
                     sw.Stop();
                     logger.LogError(BunkumCategory.UserContent, $"Failed to read '{filename}' from data store!");
                     logger.LogDebug(BunkumCategory.UserContent, $"Failed to get '{filename}' after {sw.ElapsedMilliseconds}ms.");
-                    return new(InternalServerError, null, $"Failed to read {assetTypeStr} internally. Please report this to the server owner.", onNewAssetKeyCallback, existsInDataStore: existsInDataStore);
+                    return new(InternalServerError, null, $"Failed to read {assetTypeStr} internally. Please report this to the server owner.", onNewAssetRefCallback, existsInDataStore: existsInDataStore);
                 }
 
-                asset = parameters.AssetImporter.ReadAndVerifyAsset(parameters.AssetKey, assetData, parameters.PlatformToUseIn, parameters.Database);
+                asset = parameters.AssetImporter.ReadAndVerifyAsset(parameters.AssetRef, assetData, parameters.PlatformToUseIn, parameters.Database);
                 if (asset == null) 
                 {
                     sw.Stop();
                     logger.LogDebug(BunkumCategory.UserContent, $"Failed to get '{filename}' after {sw.ElapsedMilliseconds}ms.");
-                    return new(BadRequest, null, $"The used {assetTypeStr} was invalid or corrupt.", onNewAssetKeyCallback, existsInDataStore: existsInDataStore);
+                    return new(BadRequest, null, $"The used {assetTypeStr} was invalid or corrupt.", onNewAssetRefCallback, existsInDataStore: existsInDataStore);
                 }
 
                 sw.Stop();
@@ -105,12 +109,12 @@ public abstract class ResourceValidationHelper
                 bool isHashedTexture = (asset.AssetFlags & AssetFlags.Imagery) != 0;
 
                 if (parameters.MustBeTexture && !isHashedTexture)
-                    return new(BadRequest, null, $"The used {assetTypeStr} was not a valid custom image.", onNewAssetKeyCallback, assetInfo: asset, existsInDataStore: existsInDataStore);
+                    return new(BadRequest, null, $"The used {assetTypeStr} was not a valid custom image.", onNewAssetRefCallback, assetInfo: asset, existsInDataStore: existsInDataStore);
                 
                 // TODO: actually use AIPI to scan image if not null
             }
         }
 
-        return new(OK, parameters.AssetKey, null, onNewAssetKeyCallback, assetInfo: asset, existsInDataStore: existsInDataStore);
+        return new(OK, parameters.AssetRef, null, onNewAssetRefCallback, assetInfo: asset, existsInDataStore: existsInDataStore);
     }
 }

--- a/Refresh.Core/Importing/Importer.cs
+++ b/Refresh.Core/Importing/Importer.cs
@@ -107,32 +107,40 @@ public abstract class Importer
     /// <returns>Whether the file is likely of TGA format</returns>
     private static bool IsPspTga(ReadOnlySpan<byte> data)
     {
-        byte imageIdLength = data[0];
-        byte colorMapType = data[1];
-        byte imageType = data[2];
-        ReadOnlySpan<byte> colorMapSpecification = data[3..8];
-        ReadOnlySpan<byte> imageSpecification = data[8..18];
-        short xOrigin = BinaryPrimitives.ReadInt16LittleEndian(imageSpecification[..2]);
-        short yOrigin = BinaryPrimitives.ReadInt16LittleEndian(imageSpecification[2..4]);
-        ushort width = BinaryPrimitives.ReadUInt16LittleEndian(imageSpecification[4..6]);
-        ushort height = BinaryPrimitives.ReadUInt16LittleEndian(imageSpecification[6..8]);
-        byte depth = imageSpecification[8];
-        byte descriptor = imageSpecification[9];
+        try
+        {
+            byte imageIdLength = data[0];
+            byte colorMapType = data[1];
+            byte imageType = data[2];
+            ReadOnlySpan<byte> colorMapSpecification = data[3..8];
+            ReadOnlySpan<byte> imageSpecification = data[8..18];
+            short xOrigin = BinaryPrimitives.ReadInt16LittleEndian(imageSpecification[..2]);
+            short yOrigin = BinaryPrimitives.ReadInt16LittleEndian(imageSpecification[2..4]);
+            ushort width = BinaryPrimitives.ReadUInt16LittleEndian(imageSpecification[4..6]);
+            ushort height = BinaryPrimitives.ReadUInt16LittleEndian(imageSpecification[6..8]);
+            byte depth = imageSpecification[8];
+            byte descriptor = imageSpecification[9];
 
-        //PSP does not seem to fill out this information
-        if (imageIdLength != 0) return false;
-        if (xOrigin != 0) return false;
-        if (yOrigin != 0) return false;
-        //These are the fields set by PSP, that shouldn't change from image to image
-        if (colorMapType != 1) return false;
-        if (descriptor != 0) return false;
-        if (imageType != 1) return false;
-        if (depth != 8) return false;
-        //Reasonable validation checks (PSP seems to only send images of max size 480x272)
-        if (width > 500) return false;
-        if (height > 300) return false;
-        
-        return true;
+            //PSP does not seem to fill out this information
+            if (imageIdLength != 0) return false;
+            if (xOrigin != 0) return false;
+            if (yOrigin != 0) return false;
+            //These are the fields set by PSP, that shouldn't change from image to image
+            if (colorMapType != 1) return false;
+            if (descriptor != 0) return false;
+            if (imageType != 1) return false;
+            if (depth != 8) return false;
+            //Reasonable validation checks (PSP seems to only send images of max size 480x272)
+            if (width > 500) return false;
+            if (height > 300) return false;
+            
+            return true;
+        }
+        catch
+        {
+            //If the data couldn't be read, it's not a TGA
+            return false;
+        }
     }
 
     private bool IsMip(Span<byte> rawData)

--- a/Refresh.Core/Types/Assets/Validation/AssetValidationParameters.cs
+++ b/Refresh.Core/Types/Assets/Validation/AssetValidationParameters.cs
@@ -1,0 +1,65 @@
+using Bunkum.Core.Storage;
+using Refresh.Core.Importing;
+using Refresh.Core.Services;
+using Refresh.Core.Types.Data;
+using Refresh.Database;
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Users;
+
+namespace Refresh.Core.Types.Assets.Validation;
+
+public struct AssetValidationParameters
+{
+    /// <summary>
+    /// The hash/guid/blank to validate
+    /// </summary>
+    public string AssetKey { get; set; } = "0";
+    public GameUser? User { get; set; }
+    public TokenGame GameToUseIn { get; set; }
+    public TokenPlatform PlatformToUseIn { get; set; }
+    public GameDatabaseContext Database { get; set; } = null!;
+    public IDataStore DataStore { get; set; } = null!;
+    public CacheService Cache { get; set; } = null!;
+    public GuidCheckerService GuidChecker { get; set; } = null!;
+    public AssetImporter AssetImporter { get; set; } = null!;
+    public AipiService? Aipi { get; set; }
+
+    public bool MayBeBlank { get; set; } = true;
+    public bool MayBeGuid { get; set; } = true;
+    public bool MayBeHash { get; set; } = true;
+    public bool MustBeInDataStoreIfHash { get; set; } = true;
+    public bool MustBeTexture { get; set; } = false;
+
+    /// <summary>
+    /// What the asset should be referred as in user-faced error messages and in logs, e.g. "planet asset" or "icon".
+    /// If null, we will default to calling it "asset" or "image" depending on MustBeTexture.
+    /// </summary>
+    public string? AssetContextTypeStr { get; set; }
+
+    /// <summary>
+    /// Callback which is called with the new asset reference/key as parameter when constructing <see cref="ValidatedAssetResult"/>;
+    /// useful to update asset references of entities during validation without requiring the caller to manually reassign them after validation;
+    /// this way similar attributes like photo images or face icons can simply be iterated.
+    /// If null, this will be skipped.
+    /// </summary>
+    public Action<string>? OnNewAssetKeyCallback { get; set; }
+
+    public AssetValidationParameters(string assetKey, DataContext dataContext, AssetImporter assetImporter, AipiService? aipi = null)
+    {
+        this.AssetKey = assetKey;
+        this.User = dataContext.User;
+        this.GameToUseIn = dataContext.Game;
+        this.PlatformToUseIn = dataContext.Platform;
+        this.Database = dataContext.Database;
+        this.DataStore = dataContext.DataStore;
+        this.Cache = dataContext.Cache;
+        this.GuidChecker = dataContext.GuidChecker;
+        this.AssetImporter = assetImporter;
+        this.Aipi = aipi;
+    }
+
+    public AssetValidationParameters()
+    {
+
+    }
+}

--- a/Refresh.Core/Types/Assets/Validation/AssetValidationParameters.cs
+++ b/Refresh.Core/Types/Assets/Validation/AssetValidationParameters.cs
@@ -11,9 +11,9 @@ namespace Refresh.Core.Types.Assets.Validation;
 public struct AssetValidationParameters
 {
     /// <summary>
-    /// The hash/guid/blank to validate
+    /// The reference (hash/guid/blank) to validate
     /// </summary>
-    public string AssetKey { get; set; } = "0";
+    public string AssetRef { get; set; } = "0";
     public GameUser? User { get; set; }
     public TokenGame GameToUseIn { get; set; }
     public TokenPlatform PlatformToUseIn { get; set; }
@@ -37,16 +37,16 @@ public struct AssetValidationParameters
     public string? AssetContextTypeStr { get; set; }
 
     /// <summary>
-    /// Callback which is called with the new asset reference/key as parameter when constructing <see cref="ValidatedAssetResult"/>;
+    /// Callback which is called with the new asset reference as parameter when constructing <see cref="ValidatedAssetResult"/>;
     /// useful to update asset references of entities during validation without requiring the caller to manually reassign them after validation;
     /// this way similar attributes like photo images or face icons can simply be iterated.
     /// If null, this will be skipped.
     /// </summary>
-    public Action<string>? OnNewAssetKeyCallback { get; set; }
+    public Action<string>? OnNewAssetRefCallback { get; set; }
 
     public AssetValidationParameters(string assetKey, DataContext dataContext, AssetImporter assetImporter, AipiService? aipi = null)
     {
-        this.AssetKey = assetKey;
+        this.AssetRef = assetKey;
         this.User = dataContext.User;
         this.GameToUseIn = dataContext.Game;
         this.PlatformToUseIn = dataContext.Platform;

--- a/Refresh.Core/Types/Assets/Validation/ValidatedAssetResult.cs
+++ b/Refresh.Core/Types/Assets/Validation/ValidatedAssetResult.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using Refresh.Database.Models.Assets;
+
+namespace Refresh.Core.Types.Assets.Validation;
+
+// key = blank/guid/hash, whatever is used to identify the asset
+public struct ValidatedAssetResult
+{
+    /// <summary>
+    /// HTTP code to return if validation failed.
+    /// OK: don't cancel request and proceed.
+    /// </summary>
+    public HttpStatusCode Status { get; set; }
+
+    /// <summary>
+    /// new hash/guid/blank to use
+    /// </summary>
+    public string NewKey { get; set; }
+
+    /// <summary>
+    /// message to show to the user.
+    /// null: don't show anything.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    public GameAsset? AssetInfo { get; set; }
+    public DisallowedAsset? DisallowanceInfo { get; set; }
+    public bool ExistsInDataStore { get; set; }
+
+    public ValidatedAssetResult(HttpStatusCode status, string? newKey = null, string? errorMessage = null, Action<string>? onNewAssetKeyCallback = null,
+        GameAsset? assetInfo = null, DisallowedAsset? disallowanceInfo = null, bool existsInDataStore = false)
+    {
+        this.Status = status;
+        this.NewKey = newKey ?? "0";
+        this.ErrorMessage = errorMessage;
+        this.AssetInfo = assetInfo;
+        this.DisallowanceInfo = disallowanceInfo;
+        this.ExistsInDataStore = existsInDataStore;
+
+        if (onNewAssetKeyCallback != null)
+            onNewAssetKeyCallback(this.NewKey);
+    }
+}

--- a/Refresh.Core/Types/Assets/Validation/ValidatedAssetResult.cs
+++ b/Refresh.Core/Types/Assets/Validation/ValidatedAssetResult.cs
@@ -3,7 +3,6 @@ using Refresh.Database.Models.Assets;
 
 namespace Refresh.Core.Types.Assets.Validation;
 
-// key = blank/guid/hash, whatever is used to identify the asset
 public struct ValidatedAssetResult
 {
     /// <summary>
@@ -37,7 +36,6 @@ public struct ValidatedAssetResult
         this.DisallowanceInfo = disallowanceInfo;
         this.ExistsInDataStore = existsInDataStore;
 
-        if (onNewAssetRefCallback != null)
-            onNewAssetRefCallback(this.NewAssetRef);
+        onNewAssetRefCallback?.Invoke(this.NewAssetRef);
     }
 }

--- a/Refresh.Core/Types/Assets/Validation/ValidatedAssetResult.cs
+++ b/Refresh.Core/Types/Assets/Validation/ValidatedAssetResult.cs
@@ -13,9 +13,9 @@ public struct ValidatedAssetResult
     public HttpStatusCode Status { get; set; }
 
     /// <summary>
-    /// new hash/guid/blank to use
+    /// new reference (hash/guid/blank) to use
     /// </summary>
-    public string NewKey { get; set; }
+    public string NewAssetRef { get; set; }
 
     /// <summary>
     /// message to show to the user.
@@ -27,17 +27,17 @@ public struct ValidatedAssetResult
     public DisallowedAsset? DisallowanceInfo { get; set; }
     public bool ExistsInDataStore { get; set; }
 
-    public ValidatedAssetResult(HttpStatusCode status, string? newKey = null, string? errorMessage = null, Action<string>? onNewAssetKeyCallback = null,
+    public ValidatedAssetResult(HttpStatusCode status, string? newAssetRef = null, string? errorMessage = null, Action<string>? onNewAssetRefCallback = null,
         GameAsset? assetInfo = null, DisallowedAsset? disallowanceInfo = null, bool existsInDataStore = false)
     {
         this.Status = status;
-        this.NewKey = newKey ?? "0";
+        this.NewAssetRef = newAssetRef ?? "0";
         this.ErrorMessage = errorMessage;
         this.AssetInfo = assetInfo;
         this.DisallowanceInfo = disallowanceInfo;
         this.ExistsInDataStore = existsInDataStore;
 
-        if (onNewAssetKeyCallback != null)
-            onNewAssetKeyCallback(this.NewKey);
+        if (onNewAssetRefCallback != null)
+            onNewAssetRefCallback(this.NewAssetRef);
     }
 }

--- a/Refresh.Database/Models/Assets/AssetFlags.cs
+++ b/Refresh.Database/Models/Assets/AssetFlags.cs
@@ -20,6 +20,10 @@ public enum AssetFlags
     /// A planet is considered modded if it depends on this asset, or if the asset already has the Modded flag above.
     /// </summary>
     ModdedOnPlanets = 1 << 3,
+    /// <summary>
+    /// This asset is a texture or contains imagery, for now only given to asset types handled by image conversion.
+    /// </summary>
+    Imagery = 1 << 4,
 }
 
 public static class AssetSafetyLevelExtensions
@@ -30,33 +34,33 @@ public static class AssetSafetyLevelExtensions
         {
             // Common asset types created by the game
             GameAssetType.Level => AssetFlags.None,
-            GameAssetType.StreamingLevelChunk => AssetFlags.None | AssetFlags.ModdedOnPlanets,
+            GameAssetType.StreamingLevelChunk => AssetFlags.ModdedOnPlanets,
             GameAssetType.Plan => AssetFlags.None,
-            GameAssetType.ThingRecording => AssetFlags.None | AssetFlags.ModdedOnPlanets,
-            GameAssetType.SyncedProfile => AssetFlags.None | AssetFlags.ModdedOnPlanets,
-            GameAssetType.GriefSongState => AssetFlags.None | AssetFlags.ModdedOnPlanets,
-            GameAssetType.Quest => AssetFlags.None | AssetFlags.ModdedOnPlanets,
-            GameAssetType.AdventureSharedData => AssetFlags.None | AssetFlags.ModdedOnPlanets,
-            GameAssetType.AdventureCreateProfile => AssetFlags.None | AssetFlags.ModdedOnPlanets,
-            GameAssetType.ChallengeGhost => AssetFlags.None | AssetFlags.ModdedOnPlanets,
+            GameAssetType.ThingRecording => AssetFlags.ModdedOnPlanets,
+            GameAssetType.SyncedProfile => AssetFlags.ModdedOnPlanets,
+            GameAssetType.GriefSongState => AssetFlags.ModdedOnPlanets,
+            GameAssetType.Quest => AssetFlags.ModdedOnPlanets,
+            GameAssetType.AdventureSharedData => AssetFlags.ModdedOnPlanets,
+            GameAssetType.AdventureCreateProfile => AssetFlags.ModdedOnPlanets,
+            GameAssetType.ChallengeGhost => AssetFlags.ModdedOnPlanets,
             
             // Common media types created by the game
             GameAssetType.VoiceRecording => AssetFlags.Media | AssetFlags.ModdedOnPlanets,
             GameAssetType.Painting => AssetFlags.Media,
-            GameAssetType.Texture => AssetFlags.Media,
-            GameAssetType.Jpeg => AssetFlags.Media,
-            GameAssetType.Png => AssetFlags.Media,
-            GameAssetType.Tga => AssetFlags.Media | AssetFlags.ModdedOnPlanets,
-            GameAssetType.Mip => AssetFlags.Media | AssetFlags.ModdedOnPlanets,
+            GameAssetType.Texture => AssetFlags.Media | AssetFlags.Imagery,
+            GameAssetType.Jpeg => AssetFlags.Media | AssetFlags.Imagery,
+            GameAssetType.Png => AssetFlags.Media | AssetFlags.Imagery,
+            GameAssetType.Tga => AssetFlags.Media | AssetFlags.Imagery | AssetFlags.ModdedOnPlanets,
+            GameAssetType.Mip => AssetFlags.Media | AssetFlags.Imagery | AssetFlags.ModdedOnPlanets,
             
             // Uncommon, but still vanilla assets created by the game in niche scenarios.
             // While not image/audio data like the other media types, GfxMaterial is marked as media because this file can contain full PS3 shaders.
             GameAssetType.GfxMaterial => AssetFlags.Media | AssetFlags.ModdedOnPlanets, 
-            GameAssetType.Material => AssetFlags.None | AssetFlags.ModdedOnPlanets,
-            GameAssetType.Bevel => AssetFlags.None | AssetFlags.ModdedOnPlanets,
+            GameAssetType.Material => AssetFlags.ModdedOnPlanets,
+            GameAssetType.Bevel => AssetFlags.ModdedOnPlanets,
             
             // Modded media types
-            GameAssetType.GameDataTexture => AssetFlags.Media | AssetFlags.Modded,
+            GameAssetType.GameDataTexture => AssetFlags.Media | AssetFlags.Modded | AssetFlags.Imagery,
             GameAssetType.AnimatedTexture => AssetFlags.Media | AssetFlags.Modded,
             
             // Normal modded assets

--- a/RefreshTests.GameServer/TestContext.cs
+++ b/RefreshTests.GameServer/TestContext.cs
@@ -56,7 +56,7 @@ public class TestContext : IDisposable
         int tokenExpirySeconds = GameDatabaseContext.DefaultTokenExpirySeconds,
         string? ipAddress = null)
     {
-        return this.GetAuthenticatedClient(type, game, platform, out _, user, tokenExpirySeconds, ipAddress);
+        return this.GetAuthenticatedClient(type, game, platform, out string _, user, tokenExpirySeconds, ipAddress);
     }
 
     public HttpClient GetAuthenticatedClient(TokenType type, out string tokenData,
@@ -86,23 +86,39 @@ public class TestContext : IDisposable
         int tokenExpirySeconds = GameDatabaseContext.DefaultTokenExpirySeconds, 
         string? ipAddress = null)
     {
-        user ??= this.CreateUser();
-
-        Token token = this.Database.GenerateTokenForUser(user, type, game, platform, ipAddress ?? "0.0.0.0", tokenExpirySeconds);
+        Token token = this.GenerateToken(user, type, game, platform, ipAddress, tokenExpirySeconds);
         tokenData = token.TokenData;
-        
+        return this.GetAuthenticatedClient(token.TokenData, type);
+    }
+
+    public HttpClient GetAuthenticatedClient(TokenType type, TokenGame game, TokenPlatform platform, out Token token,
+        GameUser? user = null,
+        int tokenExpirySeconds = GameDatabaseContext.DefaultTokenExpirySeconds, 
+        string? ipAddress = null)
+    {
+        token = this.GenerateToken(user, type, game, platform, ipAddress, tokenExpirySeconds);
+        return this.GetAuthenticatedClient(token.TokenData, type);
+    }
+
+    public HttpClient GetAuthenticatedClient(string tokenData, TokenType type)
+    {
         HttpClient client = this.Listener.GetClient();
 
         if (type == TokenType.Game)
         {
-            client.DefaultRequestHeaders.Add("Cookie", "MM_AUTH=" + token.TokenData);
+            client.DefaultRequestHeaders.Add("Cookie", "MM_AUTH=" + tokenData);
         }
         else
         {
-            client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", token.TokenData);
+            client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", tokenData);
         }
 
         return client;
+    }
+
+    public Token GenerateToken(GameUser? user, TokenType type, TokenGame game, TokenPlatform platform, string? ipAddress, int tokenExpirySeconds)
+    {
+        return this.Database.GenerateTokenForUser(user ?? this.CreateUser(), type, game, platform, ipAddress ?? "0.0.0.0", tokenExpirySeconds);
     }
 
     public GameUser CreateUser(string? username = null, GameUserRole role = GameUserRole.User, bool verifyEmail = true)
@@ -218,13 +234,13 @@ public class TestContext : IDisposable
     [Pure]
     public TService GetService<TService>() where TService : Service => this.Server.Value.GetService<TService>();
 
-    public DataContext GetDataContext(Token? token = null)
+    public DataContext GetDataContext(Token? token = null, IDataStore? dataStore = null)
     {
         return new DataContext
         {
             Database = this.Database,
             Logger = this.Server.Value.Logger,
-            DataStore = (IDataStore)this.GetService<StorageService>()
+            DataStore = dataStore ?? (IDataStore)this.GetService<StorageService>()
                 .AddParameterToEndpoint(null!, new BunkumParameterInfo(typeof(IDataStore), ""), null!)!,
             Match = this.GetService<MatchService>(),
             Token = token,

--- a/RefreshTests.GameServer/Tests/Assets/AssetReferenceValidationTests.cs
+++ b/RefreshTests.GameServer/Tests/Assets/AssetReferenceValidationTests.cs
@@ -27,14 +27,14 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(blankHashVariation, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(blankHashVariation, dataContext, importer)
         {
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
         Assert.That(result.Status, Is.EqualTo(OK));
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
         Assert.That(result.AssetInfo, Is.Null);
     }
 
@@ -51,16 +51,16 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(blankHashVariation, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(blankHashVariation, dataContext, importer)
         {
             MayBeBlank = false,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -74,14 +74,14 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
         {
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
         Assert.That(result.Status, Is.EqualTo(OK));
-        Assert.That(result.NewKey, Is.EqualTo(guid));
-        Assert.That(newKeySetByCallback, Is.EqualTo(guid));
+        Assert.That(result.NewAssetRef, Is.EqualTo(guid));
+        Assert.That(newRefSetByCallback, Is.EqualTo(guid));
         Assert.That(result.ErrorMessage, Is.Null);
     }
 
@@ -96,16 +96,16 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
         {
             MayBeGuid = false,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -120,15 +120,15 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
         {
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -141,16 +141,16 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
         {
             MustBeTexture = true,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -163,16 +163,16 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
         {
             MustBeTexture = true,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
         Assert.That(result.Status, Is.EqualTo(OK));
         Assert.That(result.AssetInfo, Is.Null);
-        Assert.That(result.NewKey, Is.EqualTo(guid));
-        Assert.That(newKeySetByCallback, Is.EqualTo(guid));
+        Assert.That(result.NewAssetRef, Is.EqualTo(guid));
+        Assert.That(newRefSetByCallback, Is.EqualTo(guid));
     }
 
     [Test]
@@ -198,19 +198,19 @@ public class AssetReferenceValidationTests : GameServerTest
             dataContext.DataStore.WriteToStore(hash, data);
         }
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeInDataStoreIfHash = mustBeInDataStore,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         if (expectDataStoreFailure)
         {
             Assert.That(result.Status, Is.EqualTo(NotFound));
             Assert.That(result.AssetInfo, Is.Null);
-            Assert.That(result.NewKey, Is.EqualTo("0"));
-            Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+            Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+            Assert.That(newRefSetByCallback, Is.EqualTo("0"));
         }
         else if (addToDataStore)
         {
@@ -218,15 +218,15 @@ public class AssetReferenceValidationTests : GameServerTest
             Assert.That(result.AssetInfo, Is.Not.Null); // ensure it was auto-imported
             Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
             Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Level));
-            Assert.That(result.NewKey, Is.EqualTo(hash));
-            Assert.That(newKeySetByCallback, Is.EqualTo(hash));
+            Assert.That(result.NewAssetRef, Is.EqualTo(hash));
+            Assert.That(newRefSetByCallback, Is.EqualTo(hash));
         }
         else
         {
             Assert.That(result.Status, Is.EqualTo(OK));
             Assert.That(result.AssetInfo, Is.Null); // not auto-imported and also not in DB before
-            Assert.That(result.NewKey, Is.EqualTo(hash));
-            Assert.That(newKeySetByCallback, Is.EqualTo(hash));
+            Assert.That(result.NewAssetRef, Is.EqualTo(hash));
+            Assert.That(newRefSetByCallback, Is.EqualTo(hash));
         }
 
         Assert.That(result.DisallowanceInfo, Is.Null);
@@ -247,19 +247,19 @@ public class AssetReferenceValidationTests : GameServerTest
         ReadOnlySpan<byte> data = "LVLb"u8;
         string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeInDataStoreIfHash = true,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(InternalServerError));
         Assert.That(result.AssetInfo, Is.Null);
         Assert.That(result.DisallowanceInfo, Is.Null);
         Assert.That(result.ExistsInDataStore, Is.True);
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -276,11 +276,11 @@ public class AssetReferenceValidationTests : GameServerTest
         string fakeHash = BitConverter.ToString(SHA1.HashData("veryreallevel"u8)).Replace("-", "").ToLower();
         dataContext.DataStore.WriteToStore(fakeHash, data);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(fakeHash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(fakeHash, dataContext, importer)
         {
             MustBeInDataStoreIfHash = true,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
@@ -288,8 +288,8 @@ public class AssetReferenceValidationTests : GameServerTest
         Assert.That(result.DisallowanceInfo, Is.Null);
         Assert.That(result.ExistsInDataStore, Is.True);
         Assert.That(result.ErrorMessage, Is.Not.Null);
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -301,19 +301,19 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new("lololol", dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new("lololol", dataContext, importer)
         {
             MustBeInDataStoreIfHash = true,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.AssetInfo, Is.Null);
         Assert.That(result.DisallowanceInfo, Is.Null);
         Assert.That(result.ExistsInDataStore, Is.False); // Cancelled before actually wasting time looking it up
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -331,19 +331,19 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeInDataStoreIfHash = true, // Ensure disallowance is checked before the data store check
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(Unauthorized));
         Assert.That(result.ErrorMessage, Is.Null);
         Assert.That(result.AssetInfo, Is.Null);
         Assert.That(result.DisallowanceInfo, Is.Not.Null);
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -358,19 +358,19 @@ public class AssetReferenceValidationTests : GameServerTest
         ReadOnlySpan<byte> data = "LVLb"u8;
         string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MayBeHash = false,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
         Assert.That(result.AssetInfo, Is.Null);
         Assert.That(result.DisallowanceInfo, Is.Null);
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -396,17 +396,17 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeTexture = true,
             MustBeInDataStoreIfHash = false, // not tested in this one
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(OK));
-        Assert.That(result.NewKey, Is.EqualTo(hash));
-        Assert.That(newKeySetByCallback, Is.EqualTo(hash));
+        Assert.That(result.NewAssetRef, Is.EqualTo(hash));
+        Assert.That(newRefSetByCallback, Is.EqualTo(hash));
         Assert.That(result.AssetInfo, Is.Not.Null);
         Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
         Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Texture));
@@ -437,17 +437,17 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeTexture = true,
             MustBeInDataStoreIfHash = false, // not tested in this one
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
         Assert.That(result.AssetInfo, Is.Not.Null);
         Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
         Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Level));
@@ -472,17 +472,17 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeTexture = true,
             MustBeInDataStoreIfHash = true,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(OK));
-        Assert.That(result.NewKey, Is.EqualTo(hash));
-        Assert.That(newKeySetByCallback, Is.EqualTo(hash));
+        Assert.That(result.NewAssetRef, Is.EqualTo(hash));
+        Assert.That(newRefSetByCallback, Is.EqualTo(hash));
         Assert.That(result.AssetInfo, Is.Not.Null);
         Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
         Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Unknown));
@@ -506,17 +506,17 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newKeySetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        string newRefSetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeTexture = true,
             MustBeInDataStoreIfHash = true,
-            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
-        Assert.That(result.NewKey, Is.EqualTo("0"));
-        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.NewAssetRef, Is.EqualTo("0"));
+        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
         Assert.That(result.AssetInfo, Is.Not.Null);
         Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
         Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Unknown));

--- a/RefreshTests.GameServer/Tests/Assets/AssetReferenceValidationTests.cs
+++ b/RefreshTests.GameServer/Tests/Assets/AssetReferenceValidationTests.cs
@@ -1,0 +1,527 @@
+using System.Security.Cryptography;
+using Refresh.Core.Helpers;
+using Refresh.Core.Importing;
+using Refresh.Core.Types.Assets.Validation;
+using Refresh.Core.Types.Data;
+using Refresh.Database.Models.Assets;
+using Refresh.Database.Models.Authentication;
+using Refresh.Database.Models.Users;
+
+namespace RefreshTests.GameServer.Tests.Assets;
+
+public class AssetReferenceValidationTests : GameServerTest
+{
+    private const string ValidImageGuid = "g18451"; // star sticker texture
+    private const string InvalidImageGuid = "g1087"; // sackboy model
+
+    [Test]
+    [TestCase("")]
+    [TestCase(" ")]
+    [TestCase("  ")]
+    [TestCase("0")]
+    public void AcceptBlankHash(string blankHashVariation)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(blankHashVariation, dataContext, importer)
+        {
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+        Assert.That(result.Status, Is.EqualTo(OK));
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.AssetInfo, Is.Null);
+    }
+
+    [Test]
+    [TestCase("")]
+    [TestCase(" ")]
+    [TestCase("  ")]
+    [TestCase("0")]
+    public void RejectBlankHashIfDisallowed(string blankHashVariation)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(blankHashVariation, dataContext, importer)
+        {
+            MayBeBlank = false,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.ErrorMessage, Is.Not.Null);
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    [TestCase(ValidImageGuid)]
+    [TestCase(InvalidImageGuid)]
+    public void AcceptGuidsIfNotRestricted(string guid)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        {
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+        Assert.That(result.Status, Is.EqualTo(OK));
+        Assert.That(result.NewKey, Is.EqualTo(guid));
+        Assert.That(newKeySetByCallback, Is.EqualTo(guid));
+        Assert.That(result.ErrorMessage, Is.Null);
+    }
+
+    [Test]
+    [TestCase(InvalidImageGuid)]
+    [TestCase(ValidImageGuid)]
+    public void RejectGuidIfDisallowed(string guid)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        {
+            MayBeGuid = false,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.ErrorMessage, Is.Not.Null);
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    [TestCase("g")]
+    [TestCase("greg")]
+    [TestCase("g67676767676767676767676767676776767676767")]
+    public void RejectGuidIfBadlyFormatted(string guid)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        {
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.ErrorMessage, Is.Not.Null);
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void RejectNonTextureGuidIfOnlyTexturesAllowed()
+    {
+        string guid = InvalidImageGuid;
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        {
+            MustBeTexture = true,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.ErrorMessage, Is.Not.Null);
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void AcceptTextureGuidIfOnlyTexturesAllowed()
+    {
+        string guid = ValidImageGuid;
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(guid, dataContext, importer)
+        {
+            MustBeTexture = true,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+        Assert.That(result.Status, Is.EqualTo(OK));
+        Assert.That(result.AssetInfo, Is.Null);
+        Assert.That(result.NewKey, Is.EqualTo(guid));
+        Assert.That(newKeySetByCallback, Is.EqualTo(guid));
+    }
+
+    [Test]
+    [TestCase(true, false)]
+    [TestCase(false, false)]
+    [TestCase(true, true)]
+    [TestCase(false, true)]
+    public void AcceptOrRejectHashDependingOnExistenceInDataStore(bool addToDataStore, bool mustBeInDataStore)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+        bool expectDataStoreFailure = !addToDataStore && mustBeInDataStore;
+
+        ReadOnlySpan<byte> data = "LVLb"u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+
+        // add to store but not database, this way we can also test auto-import
+        if (addToDataStore)
+        {
+            dataContext.DataStore.WriteToStore(hash, data);
+        }
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        {
+            MustBeInDataStoreIfHash = mustBeInDataStore,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        if (expectDataStoreFailure)
+        {
+            Assert.That(result.Status, Is.EqualTo(NotFound));
+            Assert.That(result.AssetInfo, Is.Null);
+            Assert.That(result.NewKey, Is.EqualTo("0"));
+            Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        }
+        else if (addToDataStore)
+        {
+            Assert.That(result.Status, Is.EqualTo(OK));
+            Assert.That(result.AssetInfo, Is.Not.Null); // ensure it was auto-imported
+            Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
+            Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Level));
+            Assert.That(result.NewKey, Is.EqualTo(hash));
+            Assert.That(newKeySetByCallback, Is.EqualTo(hash));
+        }
+        else
+        {
+            Assert.That(result.Status, Is.EqualTo(OK));
+            Assert.That(result.AssetInfo, Is.Null); // not auto-imported and also not in DB before
+            Assert.That(result.NewKey, Is.EqualTo(hash));
+            Assert.That(newKeySetByCallback, Is.EqualTo(hash));
+        }
+
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.ExistsInDataStore, Is.EqualTo(addToDataStore));
+    }
+
+    [Test]
+    public void RejectHashIfReadingFromDataStoreFails()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+
+        // read-failing will unconditionally return true on key lookup, but will fail trying to read (null bytes/false return), which is what we want
+        DataContext dataContext = context.GetDataContext(token, new ReadFailingDataStore());
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        ReadOnlySpan<byte> data = "LVLb"u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        {
+            MustBeInDataStoreIfHash = true,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(InternalServerError));
+        Assert.That(result.AssetInfo, Is.Null);
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.ExistsInDataStore, Is.True);
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void RejectHashIfImportingFromDataStoreFails()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        ReadOnlySpan<byte> data = "totallyalevel"u8;
+        // importing, for now, only really fails if the given hash doesn't match the actual hash
+        string fakeHash = BitConverter.ToString(SHA1.HashData("veryreallevel"u8)).Replace("-", "").ToLower();
+        dataContext.DataStore.WriteToStore(fakeHash, data);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(fakeHash, dataContext, importer)
+        {
+            MustBeInDataStoreIfHash = true,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.AssetInfo, Is.Null);
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.ExistsInDataStore, Is.True);
+        Assert.That(result.ErrorMessage, Is.Not.Null);
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void RejectHashIfInvalidHash()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new("lololol", dataContext, importer)
+        {
+            MustBeInDataStoreIfHash = true,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.AssetInfo, Is.Null);
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.ExistsInDataStore, Is.False); // Cancelled before actually wasting time looking it up
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void RejectHashIfAssetDisallowed()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        ReadOnlySpan<byte> data = "LVLb"u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+        context.Database.DisallowAsset(hash, GameAssetType.Level, "youre evel was so shit that we had to ban it");
+
+        context.Database.Refresh();
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        {
+            MustBeInDataStoreIfHash = true, // Ensure disallowance is checked before the data store check
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(Unauthorized));
+        Assert.That(result.ErrorMessage, Is.Null);
+        Assert.That(result.AssetInfo, Is.Null);
+        Assert.That(result.DisallowanceInfo, Is.Not.Null);
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    public void RejectHashIfHashesDisallowed()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        ReadOnlySpan<byte> data = "LVLb"u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        {
+            MayBeHash = false,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.ErrorMessage, Is.Not.Null);
+        Assert.That(result.AssetInfo, Is.Null);
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AcceptTextureHashIfOnlyTexturesAllowed(bool addToDataStore)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        ReadOnlySpan<byte> data = "TEX "u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+
+        if (addToDataStore) dataContext.DataStore.WriteToStore(hash, data);
+        else context.Database.AddAssetToDatabase(new() // not adding to store: test getting from just DB instead
+        {
+            AssetHash = hash,
+            AssetType = GameAssetType.Texture,
+        });
+
+        context.Database.Refresh();
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        {
+            MustBeTexture = true,
+            MustBeInDataStoreIfHash = false, // not tested in this one
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(OK));
+        Assert.That(result.NewKey, Is.EqualTo(hash));
+        Assert.That(newKeySetByCallback, Is.EqualTo(hash));
+        Assert.That(result.AssetInfo, Is.Not.Null);
+        Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
+        Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Texture));
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.ExistsInDataStore, Is.EqualTo(addToDataStore));
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void RejectNonTextureHashIfOnlyTexturesAllowed(bool addToDataStore)
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        ReadOnlySpan<byte> data = "LVLb"u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+
+        if (addToDataStore) dataContext.DataStore.WriteToStore(hash, data);
+        else context.Database.AddAssetToDatabase(new() // not adding to store: test getting from just DB instead
+        {
+            AssetHash = hash,
+            AssetType = GameAssetType.Level,
+        });
+
+        context.Database.Refresh();
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        {
+            MustBeTexture = true,
+            MustBeInDataStoreIfHash = false, // not tested in this one
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.AssetInfo, Is.Not.Null);
+        Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
+        Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Level));
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.ExistsInDataStore, Is.EqualTo(addToDataStore));
+    }
+
+    // TODO: test AIPI using a fake test server
+
+    [Test]
+    public void AcceptsIfMustBeTextureButUnreadablePSPAsset()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanetPSP, TokenPlatform.PSP, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        ReadOnlySpan<byte> data = "bbbbbbbbbbb"u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+        dataContext.DataStore.WriteToStore($"psp/{hash}", data);
+
+        context.Database.Refresh();
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        {
+            MustBeTexture = true,
+            MustBeInDataStoreIfHash = true,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(OK));
+        Assert.That(result.NewKey, Is.EqualTo(hash));
+        Assert.That(newKeySetByCallback, Is.EqualTo(hash));
+        Assert.That(result.AssetInfo, Is.Not.Null);
+        Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
+        Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Unknown));
+        Assert.That(result.AssetInfo!.IsPSP, Is.True);
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.ExistsInDataStore, Is.True);
+    }
+
+    [Test]
+    public void RejectsIfMustBeTextureAndUnreadableNonPSPAsset()
+    {
+        using TestContext context = this.GetServer();
+        GameUser user = context.CreateUser();
+        HttpClient client = context.GetAuthenticatedClient(TokenType.Game, TokenGame.LittleBigPlanet1, TokenPlatform.PS3, out Token token, user);
+        DataContext dataContext = context.GetDataContext(token);
+        AssetImporter importer = new(dataContext.Logger, context.Time);
+
+        ReadOnlySpan<byte> data = "bbbbbbbbbbb"u8;
+        string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
+        dataContext.DataStore.WriteToStore(hash, data);
+
+        context.Database.Refresh();
+
+        string newKeySetByCallback = "unset lol";
+        ValidatedAssetResult result = ResourceValidationHelper.Validate(new(hash, dataContext, importer)
+        {
+            MustBeTexture = true,
+            MustBeInDataStoreIfHash = true,
+            OnNewAssetKeyCallback = delegate(string newKey) { newKeySetByCallback = newKey; },
+        }, dataContext.Logger);
+
+        Assert.That(result.Status, Is.EqualTo(BadRequest));
+        Assert.That(result.NewKey, Is.EqualTo("0"));
+        Assert.That(newKeySetByCallback, Is.EqualTo("0"));
+        Assert.That(result.AssetInfo, Is.Not.Null);
+        Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
+        Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Unknown));
+        Assert.That(result.AssetInfo!.IsPSP, Is.False);
+        Assert.That(result.DisallowanceInfo, Is.Null);
+        Assert.That(result.ExistsInDataStore, Is.True);
+    }
+}


### PR DESCRIPTION
This PR implements a helper method which applies various common validations to a given asset reference (common as in these kinds of validations are needed by various endpoints, like e.g. multiple endpoints needing to ensure a referenced asset is an image, or not a GUID, or not disallowed etc). The idea is that, instead of every endpoint implementing its own validation, they'd just call this method and handle its return value.

This would deduplicate a relatively high amount of code, and it would potentially also prevent edge cases where some endpoints forget to validate some things (e.g. only root level hashes are ensured to be valid hashes right now, some API endpoints only ensure an asset is in the database and not the data store, the photo upload endpoint only ensures a photo's dependencies are in the data store and not the database etc).

Since a complete refactor would've made this PR way larger than it already is (~850 lines just to implement and test the method), this PR only implements and tests the method. Modifying endpoint methods to actually use this method would have to be done in future PRs.