### PR TITLE
Remove unnecessary asset validation callback

### DIFF
--- a/Refresh.Core/Helpers/ResourceValidationHelper.cs
+++ b/Refresh.Core/Helpers/ResourceValidationHelper.cs
@@ -20,38 +20,37 @@ public abstract class ResourceValidationHelper
         GameAsset? asset = null;
         bool existsInDataStore = false;
         bool isPSP = parameters.GameToUseIn == TokenGame.LittleBigPlanetPSP;
-        Action<string>? onNewAssetRefCallback = parameters.OnNewAssetRefCallback;
 
         if (parameters.AssetRef.IsBlankHash())
         {
-            if (!parameters.MayBeBlank) return new(BadRequest, "0", $"The {assetTypeStr} must be set.", onNewAssetRefCallback);
-            else return new(OK, "0", null, onNewAssetRefCallback);
+            if (!parameters.MayBeBlank) return new(BadRequest, "0", $"The {assetTypeStr} must be set.");
+            else return new(OK, "0", null);
         }
 
         else if (parameters.AssetRef.StartsWith('g'))
         {
-            if (!parameters.MayBeGuid) return new(BadRequest, null, $"The {assetTypeStr} may not be an in-game asset.", onNewAssetRefCallback);
-            if (parameters.AssetRef.Length < 2) return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (empty GUID).", onNewAssetRefCallback);
+            if (!parameters.MayBeGuid) return new(BadRequest, null, $"The {assetTypeStr} may not be an in-game asset.");
+            if (parameters.AssetRef.Length < 2) return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (empty GUID).");
 
             // This should only happen if the user is messing with mods/the API/beta builds, so give them a more detailed response
             bool canParseGuid = long.TryParse(parameters.AssetRef[1..], out long guid);
             if (!canParseGuid)
-                return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (badly formatted GUID).", onNewAssetRefCallback);
+                return new(BadRequest, null, $"The used in-game {assetTypeStr} is invalid (badly formatted GUID).");
 
             if (parameters.MustBeTexture && !parameters.GuidChecker.IsTextureGuid(parameters.GameToUseIn, guid))
-                return new(BadRequest, null, $"The used in-game {assetTypeStr} was not a valid image (unknown GUID).", onNewAssetRefCallback);
+                return new(BadRequest, null, $"The used in-game {assetTypeStr} was not a valid image (unknown GUID).");
         }
 
         // At this point the reference is a hash
         else if (!parameters.MayBeHash)
         {
-            return new(BadRequest, null, $"The {assetTypeStr} may not be a custom asset.", onNewAssetRefCallback);
+            return new(BadRequest, null, $"The {assetTypeStr} may not be a custom asset.");
         }
 
         else if (!CommonPatterns.Sha1Regex().IsMatch(parameters.AssetRef))
         {
             // This should only happen if a player is messing with mods/the API, so give them a more detailed response
-            return new(BadRequest, null, $"The used {assetTypeStr} had an invalid hash.", onNewAssetRefCallback);
+            return new(BadRequest, null, $"The used {assetTypeStr} had an invalid hash.");
         }
 
         else
@@ -60,7 +59,7 @@ public abstract class ResourceValidationHelper
             if (disallowed != null)
             {
                 logger.LogWarning(BunkumCategory.UserContent, $"{parameters.User} tried to use a manually disallowed {assetTypeStr}.");
-                return new(Unauthorized, disallowanceInfo: disallowed, onNewAssetRefCallback: onNewAssetRefCallback);
+                return new(Unauthorized, disallowanceInfo: disallowed);
             }
 
             string filename = isPSP ? $"psp/{parameters.AssetRef}" : parameters.AssetRef;
@@ -71,7 +70,7 @@ public abstract class ResourceValidationHelper
                 logger.LogDebug(BunkumCategory.UserContent, $"Referenced asset '{filename}' could not be found in data store.");
 
                 if (parameters.MustBeInDataStoreIfHash)
-                    return new(NotFound, null, $"The used {assetTypeStr} did not exist on the server.", onNewAssetRefCallback);
+                    return new(NotFound, null, $"The used {assetTypeStr} did not exist on the server.");
             }
 
             asset = parameters.Cache.GetAssetInfo(parameters.AssetRef, parameters.Database);
@@ -88,7 +87,7 @@ public abstract class ResourceValidationHelper
                     sw.Stop();
                     logger.LogError(BunkumCategory.UserContent, $"Failed to read '{filename}' from data store!");
                     logger.LogDebug(BunkumCategory.UserContent, $"Failed to get '{filename}' after {sw.ElapsedMilliseconds}ms.");
-                    return new(InternalServerError, null, $"Failed to read {assetTypeStr} internally. Please report this to the server owner.", onNewAssetRefCallback, existsInDataStore: existsInDataStore);
+                    return new(InternalServerError, null, $"Failed to read {assetTypeStr} internally. Please report this to the server owner.", existsInDataStore: existsInDataStore);
                 }
 
                 asset = parameters.AssetImporter.ReadAndVerifyAsset(parameters.AssetRef, assetData, parameters.PlatformToUseIn, parameters.Database);
@@ -96,7 +95,7 @@ public abstract class ResourceValidationHelper
                 {
                     sw.Stop();
                     logger.LogDebug(BunkumCategory.UserContent, $"Failed to get '{filename}' after {sw.ElapsedMilliseconds}ms.");
-                    return new(BadRequest, null, $"The used {assetTypeStr} was invalid or corrupt.", onNewAssetRefCallback, existsInDataStore: existsInDataStore);
+                    return new(BadRequest, null, $"The used {assetTypeStr} was invalid or corrupt.", existsInDataStore: existsInDataStore);
                 }
 
                 sw.Stop();
@@ -109,12 +108,12 @@ public abstract class ResourceValidationHelper
                 bool isHashedTexture = (asset.AssetFlags & AssetFlags.Imagery) != 0;
 
                 if (parameters.MustBeTexture && !isHashedTexture)
-                    return new(BadRequest, null, $"The used {assetTypeStr} was not a valid custom image.", onNewAssetRefCallback, assetInfo: asset, existsInDataStore: existsInDataStore);
+                    return new(BadRequest, null, $"The used {assetTypeStr} was not a valid custom image.", assetInfo: asset, existsInDataStore: existsInDataStore);
                 
                 // TODO: actually use AIPI to scan image if not null
             }
         }
 
-        return new(OK, parameters.AssetRef, null, onNewAssetRefCallback, assetInfo: asset, existsInDataStore: existsInDataStore);
+        return new(OK, parameters.AssetRef, assetInfo: asset, existsInDataStore: existsInDataStore);
     }
 }

--- a/Refresh.Core/Types/Assets/Validation/AssetValidationParameters.cs
+++ b/Refresh.Core/Types/Assets/Validation/AssetValidationParameters.cs
@@ -34,19 +34,11 @@ public struct AssetValidationParameters
     /// What the asset should be referred as in user-faced error messages and in logs, e.g. "planet asset" or "icon".
     /// If null, we will default to calling it "asset" or "image" depending on MustBeTexture.
     /// </summary>
-    public string? AssetContextTypeStr { get; set; }
+    public string? AssetContextTypeStr { get; set; } // TODO think of a better name
 
-    /// <summary>
-    /// Callback which is called with the new asset reference as parameter when constructing <see cref="ValidatedAssetResult"/>;
-    /// useful to update asset references of entities during validation without requiring the caller to manually reassign them after validation;
-    /// this way similar attributes like photo images or face icons can simply be iterated.
-    /// If null, this will be skipped.
-    /// </summary>
-    public Action<string>? OnNewAssetRefCallback { get; set; }
-
-    public AssetValidationParameters(string assetKey, DataContext dataContext, AssetImporter assetImporter, AipiService? aipi = null)
+    public AssetValidationParameters(string assetRef, DataContext dataContext, AssetImporter assetImporter, AipiService? aipi = null)
     {
-        this.AssetRef = assetKey;
+        this.AssetRef = assetRef;
         this.User = dataContext.User;
         this.GameToUseIn = dataContext.Game;
         this.PlatformToUseIn = dataContext.Platform;

--- a/Refresh.Core/Types/Assets/Validation/ValidatedAssetResult.cs
+++ b/Refresh.Core/Types/Assets/Validation/ValidatedAssetResult.cs
@@ -26,7 +26,7 @@ public struct ValidatedAssetResult
     public DisallowedAsset? DisallowanceInfo { get; set; }
     public bool ExistsInDataStore { get; set; }
 
-    public ValidatedAssetResult(HttpStatusCode status, string? newAssetRef = null, string? errorMessage = null, Action<string>? onNewAssetRefCallback = null,
+    public ValidatedAssetResult(HttpStatusCode status, string? newAssetRef = null, string? errorMessage = null,
         GameAsset? assetInfo = null, DisallowedAsset? disallowanceInfo = null, bool existsInDataStore = false)
     {
         this.Status = status;
@@ -35,7 +35,5 @@ public struct ValidatedAssetResult
         this.AssetInfo = assetInfo;
         this.DisallowanceInfo = disallowanceInfo;
         this.ExistsInDataStore = existsInDataStore;
-
-        onNewAssetRefCallback?.Invoke(this.NewAssetRef);
     }
 }

--- a/RefreshTests.GameServer/Tests/Assets/AssetReferenceValidationTests.cs
+++ b/RefreshTests.GameServer/Tests/Assets/AssetReferenceValidationTests.cs
@@ -27,14 +27,10 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newRefSetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(blankHashVariation, dataContext, importer)
-        {
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
-        }, dataContext.Logger);
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(blankHashVariation, dataContext, importer), dataContext.Logger);
+        
         Assert.That(result.Status, Is.EqualTo(OK));
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
         Assert.That(result.AssetInfo, Is.Null);
     }
 
@@ -51,16 +47,14 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(blankHashVariation, dataContext, importer)
         {
             MayBeBlank = false,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
+        
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -74,14 +68,10 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newRefSetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
-        {
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
-        }, dataContext.Logger);
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer), dataContext.Logger);
+        
         Assert.That(result.Status, Is.EqualTo(OK));
         Assert.That(result.NewAssetRef, Is.EqualTo(guid));
-        Assert.That(newRefSetByCallback, Is.EqualTo(guid));
         Assert.That(result.ErrorMessage, Is.Null);
     }
 
@@ -96,16 +86,14 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
         {
             MayBeGuid = false,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
+        
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -120,15 +108,11 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newRefSetByCallback = "unset lol";
-        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
-        {
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
-        }, dataContext.Logger);
+        ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer), dataContext.Logger);
+        
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -141,16 +125,14 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
         {
             MustBeTexture = true,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
+        
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.ErrorMessage, Is.Not.Null);
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -163,16 +145,14 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(guid, dataContext, importer)
         {
             MustBeTexture = true,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
+        
         Assert.That(result.Status, Is.EqualTo(OK));
         Assert.That(result.AssetInfo, Is.Null);
         Assert.That(result.NewAssetRef, Is.EqualTo(guid));
-        Assert.That(newRefSetByCallback, Is.EqualTo(guid));
     }
 
     [Test]
@@ -198,11 +178,9 @@ public class AssetReferenceValidationTests : GameServerTest
             dataContext.DataStore.WriteToStore(hash, data);
         }
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeInDataStoreIfHash = mustBeInDataStore,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         if (expectDataStoreFailure)
@@ -210,7 +188,6 @@ public class AssetReferenceValidationTests : GameServerTest
             Assert.That(result.Status, Is.EqualTo(NotFound));
             Assert.That(result.AssetInfo, Is.Null);
             Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-            Assert.That(newRefSetByCallback, Is.EqualTo("0"));
         }
         else if (addToDataStore)
         {
@@ -219,14 +196,12 @@ public class AssetReferenceValidationTests : GameServerTest
             Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
             Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Level));
             Assert.That(result.NewAssetRef, Is.EqualTo(hash));
-            Assert.That(newRefSetByCallback, Is.EqualTo(hash));
         }
         else
         {
             Assert.That(result.Status, Is.EqualTo(OK));
             Assert.That(result.AssetInfo, Is.Null); // not auto-imported and also not in DB before
             Assert.That(result.NewAssetRef, Is.EqualTo(hash));
-            Assert.That(newRefSetByCallback, Is.EqualTo(hash));
         }
 
         Assert.That(result.DisallowanceInfo, Is.Null);
@@ -247,11 +222,9 @@ public class AssetReferenceValidationTests : GameServerTest
         ReadOnlySpan<byte> data = "LVLb"u8;
         string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeInDataStoreIfHash = true,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(InternalServerError));
@@ -259,7 +232,6 @@ public class AssetReferenceValidationTests : GameServerTest
         Assert.That(result.DisallowanceInfo, Is.Null);
         Assert.That(result.ExistsInDataStore, Is.True);
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -276,11 +248,9 @@ public class AssetReferenceValidationTests : GameServerTest
         string fakeHash = BitConverter.ToString(SHA1.HashData("veryreallevel"u8)).Replace("-", "").ToLower();
         dataContext.DataStore.WriteToStore(fakeHash, data);
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(fakeHash, dataContext, importer)
         {
             MustBeInDataStoreIfHash = true,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
@@ -289,7 +259,6 @@ public class AssetReferenceValidationTests : GameServerTest
         Assert.That(result.ExistsInDataStore, Is.True);
         Assert.That(result.ErrorMessage, Is.Not.Null);
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -301,11 +270,9 @@ public class AssetReferenceValidationTests : GameServerTest
         DataContext dataContext = context.GetDataContext(token);
         AssetImporter importer = new(dataContext.Logger, context.Time);
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new("lololol", dataContext, importer)
         {
             MustBeInDataStoreIfHash = true,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
@@ -313,7 +280,6 @@ public class AssetReferenceValidationTests : GameServerTest
         Assert.That(result.DisallowanceInfo, Is.Null);
         Assert.That(result.ExistsInDataStore, Is.False); // Cancelled before actually wasting time looking it up
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -331,11 +297,9 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeInDataStoreIfHash = true, // Ensure disallowance is checked before the data store check
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(Unauthorized));
@@ -343,7 +307,6 @@ public class AssetReferenceValidationTests : GameServerTest
         Assert.That(result.AssetInfo, Is.Null);
         Assert.That(result.DisallowanceInfo, Is.Not.Null);
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -358,11 +321,9 @@ public class AssetReferenceValidationTests : GameServerTest
         ReadOnlySpan<byte> data = "LVLb"u8;
         string hash = BitConverter.ToString(SHA1.HashData(data)).Replace("-", "").ToLower();
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MayBeHash = false,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
@@ -370,7 +331,6 @@ public class AssetReferenceValidationTests : GameServerTest
         Assert.That(result.AssetInfo, Is.Null);
         Assert.That(result.DisallowanceInfo, Is.Null);
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
     }
 
     [Test]
@@ -396,17 +356,14 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeTexture = true,
             MustBeInDataStoreIfHash = false, // not tested in this one
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(OK));
         Assert.That(result.NewAssetRef, Is.EqualTo(hash));
-        Assert.That(newRefSetByCallback, Is.EqualTo(hash));
         Assert.That(result.AssetInfo, Is.Not.Null);
         Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
         Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Texture));
@@ -437,17 +394,14 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeTexture = true,
             MustBeInDataStoreIfHash = false, // not tested in this one
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
         Assert.That(result.AssetInfo, Is.Not.Null);
         Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
         Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Level));
@@ -472,17 +426,14 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeTexture = true,
             MustBeInDataStoreIfHash = true,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(OK));
         Assert.That(result.NewAssetRef, Is.EqualTo(hash));
-        Assert.That(newRefSetByCallback, Is.EqualTo(hash));
         Assert.That(result.AssetInfo, Is.Not.Null);
         Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
         Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Unknown));
@@ -506,17 +457,14 @@ public class AssetReferenceValidationTests : GameServerTest
 
         context.Database.Refresh();
 
-        string newRefSetByCallback = "unset lol";
         ValidatedAssetResult result = ResourceValidationHelper.ValidateReference(new(hash, dataContext, importer)
         {
             MustBeTexture = true,
             MustBeInDataStoreIfHash = true,
-            OnNewAssetRefCallback = delegate(string NewAssetRef) { newRefSetByCallback = NewAssetRef; },
         }, dataContext.Logger);
 
         Assert.That(result.Status, Is.EqualTo(BadRequest));
         Assert.That(result.NewAssetRef, Is.EqualTo("0"));
-        Assert.That(newRefSetByCallback, Is.EqualTo("0"));
         Assert.That(result.AssetInfo, Is.Not.Null);
         Assert.That(result.AssetInfo!.AssetHash, Is.EqualTo(hash));
         Assert.That(result.AssetInfo!.AssetType, Is.EqualTo(GameAssetType.Unknown));


### PR DESCRIPTION
Removes the `AssetValidationParameters.OnNewAssetRefCallback` callback passed to `ResourceValidationHelper.ValidateReference()`, because after more thinking, I've determined it to be unnecessary. Any function calling `ValidateResource()` can just simply set its asset reference to `ValidatedAssetResult.NewAssetRef` after calling the function without much effort. The only reason I initially implemented the callback was so we could iterate asset references using loops, but there won't really be any places where that will be useful. We won't iterate photo images after all if we want to actually implement #977, since the mainline games use TEX for small/medium images and JPEG for large images. Only place where iterating could be useful is when validating face icons, but generally, the idea of iterating the asset references (with additional data like asset type, depending on where the function is used) instead of just duplicating a few lines for simplicity is a little overcomplicated imo, and probably not worth it just for one usecase.